### PR TITLE
Handle case when svn executable is not installed

### DIFF
--- a/cuppa/scms/subversion.py
+++ b/cuppa/scms/subversion.py
@@ -43,7 +43,7 @@ def info( path ):
     try:
         command = "svnversion -n {}".format( path )
         revision = subprocess.check_output( shlex.split( command ), stderr=subprocess.STDOUT )
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, OSError):
         pass
 
     return url, repository, branch, revision


### PR DESCRIPTION
Calling an inexistent executable raises an OSError, therefor we need to catch it