### PR TITLE
Updated default definition of CPPPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,19 @@ Build variants and the output from each `sconscript` is kept separate using the 
 
 If `<sconscript_name>` is "sconscript" then it is omitted from the path. The assumption is that a single `sconscript` file is being used for the given folder and therefore the folder name is sufficient to differentiate from other `sconscript`s.
 
+### New environment variables for paths
+
+**cuppa** provides several new variables in the default environment for defining search paths. These should be used in place of `CPPPATH` and `LIBPATH`.
+
+| Variable      | Usage |
+| ------------- | ----- |
+| `SYSINCPATH`  | List of system include paths. Depending on the toolchain, the compiler may intentially produce fewer diagnostic messages for includes found on this path. |
+| `INCPATH`     | List of regular include paths. |
+| `DYNAMICLIBS` | List of dynamic libraries to link against. |
+| `STATICLIBS`  | List of static libraries to link against. |
+
+> Note, don't append to `CPPPATH` or `LIBPATH` directly, instead use one of the 4 new variables.
+
 ### Using `--xxxx-conf` to show, save and udpate command-line choices
 
 **cuppa** allows you to save commonly used or local settings to a conf file so that they can be re-applied when you execute `scons` from anywhere in your Sconscript tree. The basic approach is to pass `--save-conf` along with the options you wish to save.

--- a/cuppa/methods/compile.py
+++ b/cuppa/methods/compile.py
@@ -18,8 +18,6 @@ class CompileMethod:
     def __call__( self, env, source, **kwargs ):
         sources = Flatten( [ source ] )
         objects = []
-        if 'CPPPATH' in env:
-            env.AppendUnique( INCPATH = env['CPPPATH'] )
 
         obj_suffix = env.subst('$OBJSUFFIX')
         for source in sources:
@@ -35,7 +33,6 @@ class CompileMethod:
                     env.Object(
                         source = source,
                         target = target,
-                        CPPPATH = env['SYSINCPATH'] + env['INCPATH'],
                         **kwargs ) )
 
         cuppa.progress.NotifyProgress.add( env, objects )

--- a/cuppa/toolchains/cl.py
+++ b/cuppa/toolchains/cl.py
@@ -226,6 +226,7 @@ class Cl(object):
         env['_CPPINCFLAGS'] = self.values['_CPPINCFLAGS']
         env['INCPATH']      = [ '#.', '.' ]
         env['CPPDEFINES']   = []
+        env['CPPPATH']      = '${SYSINCPATH + INCPATH}'
         env['LIBS']         = []
         env['STATICLIBS']   = []
 

--- a/cuppa/toolchains/clang.py
+++ b/cuppa/toolchains/clang.py
@@ -315,6 +315,7 @@ class Clang(object):
         env['INCPATH']      = [ '#.', '.' ]
         env['LIBPATH']      = []
         env['CPPDEFINES']   = []
+        env['CPPPATH']      = '${SYSINCPATH + INCPATH}'
         env['LIBS']         = []
         env['STATICLIBS']   = []
         env['DYNAMICLIBS']  = self.values['dynamic_libraries']

--- a/cuppa/toolchains/gcc.py
+++ b/cuppa/toolchains/gcc.py
@@ -297,6 +297,7 @@ class Gcc(object):
         env['INCPATH']      = [ '#.', '.' ]
         env['LIBPATH']      = []
         env['CPPDEFINES']   = []
+        env['CPPPATH']      = '${SYSINCPATH + INCPATH}'
         env['LIBS']         = []
         env['STATICLIBS']   = []
         env['DYNAMICLIBS']  = self.values['dynamic_libraries']


### PR DESCRIPTION
I'm using some builder tools from another project that call `SharedLibrary` (and not `BuildLibrary`/`Compile`), and was totally confused as to why the C scanner couldn't implicitly find the dependent header files.

The intention here is that `CPPPATH` should not be used directly by the user, but `INCPATH`/`SYSINCPATH` instead.