### PR TITLE
Fix for builds under windows

### DIFF
--- a/cuppa/toolchains/cl.py
+++ b/cuppa/toolchains/cl.py
@@ -224,6 +224,7 @@ class Cl(object):
         )
 
         env['_CPPINCFLAGS'] = self.values['_CPPINCFLAGS']
+        env['SYSINCPATH']   = []
         env['INCPATH']      = [ '#.', '.' ]
         env['CPPDEFINES']   = []
         env['LIBS']         = []


### PR DESCRIPTION
I know windows isn't officially supported
but when trying a simple example using Scons 2.5.1 and the latest cuppa
I noticed the build was failing due to a missing key in the toolchain setup for the cl toolchain

The attached change seems to fix it

Below is the error I had before the fix

scons: Reading SConscript files ...
cuppa: version: [info] cuppa: version 0.9.21
cuppa: core: [info] using sconstruct file [sconstruct]
cuppa: configure: [info] No settings to load, skipping configure
cuppa: core: [info] available toolchains are ['vc90', 'vc140', 'vc120', 'vc110', 'vc', 'gcc53', 'gcc']
cuppa: core: [info] Using sub-sconscripts ['.\Atk.Glue\sconscript']
KeyError: 'SYSINCPATH':
  File "D:\SourceControl\GitRepos.Appst\Gtk3-Sharp-Core\Source\Libs-Glue\SConstruct", line 1:
    execfile('SConstruct.py')
  File "SConstruct.py", line 4:
    cuppa.run()
  File "C:\Python27\lib\site-packages\cuppa\__init__.py", line 10:
    cuppa.core.run( *args, **kwargs )
  File "C:\Python27\lib\site-packages\cuppa\core.py", line 1007:
    Construct( *args, **kwargs )
  File "C:\Python27\lib\site-packages\cuppa\core.py", line 692:
    self.build( cuppa_env )
  File "C:\Python27\lib\site-packages\cuppa\core.py", line 910:
    self.call_project_sconscript_files( toolchain, build_env['variant'], build_env['target_arch'], build_env['abi'], build_env['env'], sconscript )
  File "C:\Python27\lib\site-packages\cuppa\core.py", line 994:
    exports     = sconscript_exports
  File "c:\python27\lib\site-packages\scons-2.5.1\SCons\Script\SConscript.py", line 604:
    return method(*args, **kw)
  File "c:\python27\lib\site-packages\scons-2.5.1\SCons\Script\SConscript.py", line 541:
    return _SConscript(self.fs, *files, **subst_kw)
  File "c:\python27\lib\site-packages\scons-2.5.1\SCons\Script\SConscript.py", line 250:
    exec _file_ in call_stack[-1].globals
  File "D:\SourceControl\GitRepos.Appst\Gtk3-Sharp-Core\Source\Libs-Glue\Atk.Glue\sconscript", line 6:
    env.Build('test1', 'hello1.cpp')
  File "c:\python27\lib\site-packages\scons-2.5.1\SCons\Environment.py", line 224:
    return self.method(*nargs, **kwargs)
  File "C:\Python27\lib\site-packages\cuppa\methods\build.py", line 45:
    return self.build( env, target, source, final_dir=final_dir, append_variant=append_variant, **kwargs )
  File "C:\Python27\lib\site-packages\cuppa\methods\build.py", line 33:
    env.Compile( source ),
  File "c:\python27\lib\site-packages\scons-2.5.1\SCons\Environment.py", line 224:
    return self.method(*nargs, **kwargs)
  File "C:\Python27\lib\site-packages\cuppa\methods\compile.py", line 38:
    CPPPATH = env['SYSINCPATH'] + env['INCPATH'],
  File "c:\python27\lib\site-packages\scons-2.5.1\SCons\Environment.py", line 410:
    return self._dict[key]
