### PR TITLE
3 small fixes, tweaks to recent changes

### DIFF
--- a/cuppa/dependencies/boost/version_and_location.py
+++ b/cuppa/dependencies/boost/version_and_location.py
@@ -143,8 +143,8 @@ def get_boost_version( location ):
             match = re.search( r'BOOST_VERSION\s+(?P<version>\d+)', line )
             if match:
                 int_version = int(match.group('version'))
-                major = int_version/100000
-                minor = int_version/100%1000
+                major = int_version//100000
+                minor = int_version//100%1000
                 patch = int_version%100
                 full_version = "{}.{}.{}".format( major, minor, patch )
                 short_version = "{}_{}".format( major, minor )

--- a/cuppa/location.py
+++ b/cuppa/location.py
@@ -42,12 +42,14 @@ from .scms import subversion, git, mercurial, bazaar
 from cuppa.colourise import as_notice, as_info, as_warning, as_error
 from cuppa.log import logger, register_secret
 from cuppa.path import split_common
+from cuppa.utility.python2to3 import as_str
 
 try:
     import pip.vcs as pip_vcs
     import pip.download as pip_download
     import pip.exceptions as pip_exceptions
     from pip.download import is_url as pip_is_url
+    from pip.download import is_archive_file as pip_is_archive_file
 
     def get_url_rev( vcs_backend ):
         return vcs_backend.get_url_rev()
@@ -491,7 +493,7 @@ class Location(object):
 
         vcs_info = cls.detect_vcs_info( local_directory, expected_vc_type )
         if vcs_info:
-            return vcs_info
+            return tuple( as_str(t) for t in vcs_info )
 
         return info
 

--- a/cuppa/utility/python2to3.py
+++ b/cuppa/utility/python2to3.py
@@ -38,6 +38,6 @@ except ImportError:
 from .types import is_string
 
 def as_str( bytes_or_string, encoding='utf-8' ):
-    if is_string( bytes_or_string ):
+    if None == bytes_or_string or is_string( bytes_or_string ):
         return bytes_or_string
     return bytes_or_string.decode(encoding)


### PR DESCRIPTION
Ensure _revision is a normal string (caused bug when creating version failed
update integer division when working out boost version (caused bug with applying boost patches)
import pip_is_archive_file explicitly for earlier versions of pip (caused issue with pre 18 versions of pip)