### PR TITLE
Report and update the local working copies used by --develop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,8 @@ cuppa -D --rel
 cuppa -D --cov --test
 cuppa -D --toolchains=gcc,clang
 cuppa -D --scripts=path/to/sconscript
+cuppa -D --list-develop
+cuppa -D --update-develop
 ```
 
 `cuppa` wraps `scons`, appends `--cuppa-mode`, masks `*TOKEN*` env values in output, and may restrict CPU affinity with `--parallel`.
@@ -285,8 +287,12 @@ In a project that *uses* cuppa (not this repo):
 
 ```sh
 cuppa -D --dbg --develop --offline --test
+cuppa -D --list-develop
+cuppa -D --update-develop
 cuppa -D --cov --test --toolchains=gcc
 ```
+
+`--list-develop` reports the branch and cleanliness of each configured develop working copy; `--update-develop` fast-forwards the clean ones that are behind. See `dependencies.adoc` § Checking your develop copies.
 
 Package registry dependencies need matching toolchain archives in the registry (or cache); `--develop` does not invent them.
 GitLab auth: `GITLAB_REGISTRY_TOKEN` or `CI_JOB_TOKEN`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,25 @@ pasted build output. Instead:
 whenever you introduce a new anonymised reference — but never copy a name out of it into a
 tracked file.
 
+## Commit messages
+
+**No trailers.** A commit message ends with its last paragraph — no `Co-authored-by`, no
+`Signed-off-by`, no generated-by or tool attribution lines, and nothing appended by a client.
+The history records what changed and why; who or what typed it is the author field's job, and
+trailers naming tools date the history and add a line of noise to every `git log`.
+
+That means `git commit` is never invoked with `--trailer`, and a `Co-authored-by:` line is
+never written into the message body either. An agent committing here passes the message with
+`-m` or `-F` and nothing else.
+
+Otherwise, follow the shape already in the log:
+
+- A subject line that names the change, in the imperative, without a full stop.
+- A blank line, then prose explaining **why** the change was needed and what it now does. Wrap
+  at roughly 72 characters, and use bullets for a change with several distinct parts.
+- Reference issues in prose (`Groundwork for #132`), not as a trailer.
+- One coherent change per commit; split unrelated work rather than describing two things at once.
+
 ## GitHub access
 
 Cuppa is a public repository, so anything that only reads it — issue lists, issue bodies, pull

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `--list-develop` reports the state of every configured develop working copy — branch, upstream,
+  ahead / behind as of your last fetch, and whether the tree is modified — and exits without
+  building. It warns when a copy is on the wrong branch, behind, diverged, or carrying local work
+  on the default branch that no other build will see, and exits non-zero when a develop path does
+  not exist (#132).
+- `--update-develop` fetches each git develop working copy and fast-forwards only those that are
+  clean and strictly behind their upstream. Modified, ahead, diverged, and detached copies are
+  left alone and reported. It refuses under `--offline`, and `-n` shows the plan without changing
+  anything (#132).
+
 ### Changed
 
 - `cuppa/VERSION` carries a `.dev` suffix while a release is being assembled, so a build from a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ahead / behind as of your last fetch, and whether the tree is modified — and exits without
   building. It warns when a copy is on the wrong branch, behind, diverged, or carrying local work
   on the default branch that no other build will see, and exits non-zero when a develop path does
-  not exist (#132).
+  not exist. The report is written to standard output rather than logged, so `--verbosity` and
+  `-Q` cannot take pieces out of it and `cuppa -Q -D --list-develop` prints the report on its own.
+  Severity appears in a `STATUS` column as well as in colour, so it survives `--raw-output`.
+  Below the table the reasons hang from the summary line as one tree, grouped by severity with the
+  worst first and counted in each heading, so reading down it is reading a work list. Long reasons
+  are wrapped to the table's right edge with the stem carried down the wrapped lines. The report
+  closes by naming the copies `--update-develop` would fast-forward, when there are any (#132).
+- `CUPPA_CONSOLE_BACKGROUND=light` (or `dark`) tells cuppa which way to make text recede: reduced
+  intensity on a dark console, grey on a light one, where dimming black text can look untouched.
+  `COLORFGBG` is used where a terminal sets it, and this setting overrides it.
 - `--update-develop` fetches each git develop working copy and fast-forwards only those that are
   clean and strictly behind their upstream. Modified, ahead, diverged, and detached copies are
   left alone and reported. It refuses under `--offline`, and `-n` shows the plan without changing

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -245,15 +245,14 @@ mechanics: [`design/plans/removal-options.md`](design/plans/removal-options.md).
 | Capability | Status |
 |------------|--------|
 | `--clean` removes the current variant's build outputs | Yes |
+| `--list-develop` / `--update-develop` for the working copies `--develop` builds against | Yes — [#132](https://github.com/ja11sop/cuppa/issues/132) |
 | Remove a whole build tree, a dependency, or a stale download | No — manual deletion |
 | See what is stored, where, and how large it is | No |
-| See which branch each `--develop` working copy is on | No |
 
 ### Planned / potential
 
 | ID | Work | Priority | Notes |
 |----|------|----------|-------|
-| `develop-report` | `--list-develop` and a fast-forward-only `--update-develop` | High | Independent of the storage rename; no migration risk. GitHub [#132](https://github.com/ja11sop/cuppa/issues/132) |
 | `storage-roots` | Rename to `--dependencies-root` / `--downloads-root`, add `--storage-root`, default to `~/.cuppa` | High | Old options kept as deprecated aliases; existing trees still used. GitHub [#133](https://github.com/ja11sop/cuppa/issues/133) |
 | `storage-listing-removal` | `--list-*`, `--remove-*`, `--purge-*` for builds, dependencies, and downloads | Medium | Depends on the rename so one vocabulary is used throughout. GitHub [#134](https://github.com/ja11sop/cuppa/issues/134) |
 | `artefact-removal` | Decide how to remove artefacts written outside the build root | Low | Design pass first; `--remove-build` deliberately stops at `_build`. GitHub [#135](https://github.com/ja11sop/cuppa/issues/135) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -255,6 +255,7 @@ mechanics: [`design/plans/removal-options.md`](design/plans/removal-options.md).
 |----|------|----------|-------|
 | `storage-roots` | Rename to `--dependencies-root` / `--downloads-root`, add `--storage-root`, default to `~/.cuppa` | High | Old options kept as deprecated aliases; existing trees still used. GitHub [#133](https://github.com/ja11sop/cuppa/issues/133) |
 | `storage-listing-removal` | `--list-*`, `--remove-*`, `--purge-*` for builds, dependencies, and downloads | Medium | Depends on the rename so one vocabulary is used throughout. GitHub [#134](https://github.com/ja11sop/cuppa/issues/134) |
+| `develop-clone` | `--clone-develop` for a develop working copy that is configured but not yet on disk, for a new machine or a dependency added since you last looked | Medium | Surface settled, remaining design to finalise first: pinned locations, submodules, whether retrieval machinery is reused. [`design/plans/removal-options.md`](design/plans/removal-options.md) §3.7. GitHub [#138](https://github.com/ja11sop/cuppa/issues/138) |
 | `artefact-removal` | Decide how to remove artefacts written outside the build root | Low | Design pass first; `--remove-build` deliberately stops at `_build`. GitHub [#135](https://github.com/ja11sop/cuppa/issues/135) |
 
 ### Out of scope (storage)

--- a/cuppa/colourise.py
+++ b/cuppa/colourise.py
@@ -9,7 +9,42 @@
 #   Colouriser
 #-------------------------------------------------------------------------------
 
+import os
 import re
+
+
+# Reduced intensity moves text towards the background, which only works when the background is
+# the darker end. On a light console the default foreground is already black and dimming it can
+# leave it looking untouched, so a grey foreground is used there instead.
+GREY_256 = "\x1b[38;5;244m"
+BRIGHT_BLACK = "\x1b[90m"
+
+# The convention COLORFGBG reports: the last field is the background colour index, and 7 or 15
+# means a light background. Anything else is treated as dark, which is the safe assumption.
+LIGHT_BACKGROUNDS = ( 7, 15 )
+
+
+def console_background():
+    """`light`, `dark`, or `unknown` where the terminal does not say.
+
+    `CUPPA_CONSOLE_BACKGROUND` settles it for terminals that report nothing, which is most of
+    them; `COLORFGBG` is used where a terminal does set it.
+    """
+    declared = os.environ.get( 'CUPPA_CONSOLE_BACKGROUND', '' ).strip().lower()
+    if declared in ( 'light', 'dark' ):
+        return declared
+
+    fields = os.environ.get( 'COLORFGBG', '' ).split( ';' )
+    background = fields[-1].strip()
+    if background.isdigit():
+        return int( background ) in LIGHT_BACKGROUNDS and 'light' or 'dark'
+
+    return 'unknown'
+
+
+def supports_256_colours():
+    term = os.environ.get( 'TERM', '' )
+    return '256color' in term or bool( os.environ.get( 'COLORTERM', '' ) )
 
 
 try:
@@ -49,6 +84,25 @@ class Colouriser(object):
             return text
         else:
             return colorama.Style.BRIGHT + text + colorama.Style.RESET_ALL
+
+
+    def subdue( self, text ):
+        """Text that recedes: reduced intensity on a dark console, grey on a light one.
+
+        Both move the text towards the background rather than towards a colour, so the meaning
+        survives either console, and a terminal that ignores the sequence shows ordinary text.
+        """
+        if not self.use_colour:
+            return text
+        return self.start_subdued() + text + colorama.Style.RESET_ALL
+
+
+    def start_subdued( self ):
+        if not self.use_colour:
+            return ''
+        if console_background() == 'light':
+            return supports_256_colours() and GREY_256 or BRIGHT_BLACK
+        return colorama.Style.DIM
 
 
     def emphasise_time_by_group( self, time_text ):
@@ -200,6 +254,12 @@ def as_highlighted( meaning, text ):
 
 def as_emphasised( text ):
     return colouriser.emphasise( text )
+
+def as_subdued( text ):
+    return colouriser.subdue( text )
+
+def start_subdued():
+    return colouriser.start_subdued()
 
 def as_error( text ):
     return colouriser.colour( 'error', text )

--- a/cuppa/construct.py
+++ b/cuppa/construct.py
@@ -33,6 +33,7 @@ import cuppa.recursive_glob
 import cuppa.configure
 import cuppa.version
 import cuppa.scms
+import cuppa.develop
 #import cuppa.progress
 #import cuppa.tree
 #import cuppa.cpp.stdcpp
@@ -544,6 +545,18 @@ class Construct(object):
             if cuppa_env['dump']:
                 logger.info( as_info_label( "Running in DUMP mode, no building will be attempted" ) )
                 cuppa_env.dump()
+
+            # Both report on dependencies, so they run once those are registered, and neither
+            # builds anything.
+            if cuppa_env['update_develop']:
+                logger.info( as_info_label(
+                        "Running in UPDATE DEVELOP mode, no building will be attempted" ) )
+                SCons.Script.Exit( cuppa.develop.update_develop( cuppa_env ) )
+
+            if cuppa_env['list_develop']:
+                logger.info( as_info_label(
+                        "Running in LIST DEVELOP mode, no building will be attempted" ) )
+                SCons.Script.Exit( cuppa.develop.list_develop( cuppa_env ) )
 
             job_count = cuppa_env.get_option( 'num_jobs' )
             parallel  = cuppa_env.get_option( 'parallel' )

--- a/cuppa/core/location_options.py
+++ b/cuppa/core/location_options.py
@@ -45,10 +45,25 @@ def add_location_options( add_option ):
                      " attempt to check those locations out on the same tag as specified, if it exists"
                      " or the default branch otherwise." )
 
+    add_option( '--list-develop', dest='list_develop', action='store_true',
+                help="Report the state of the local working copies that --develop builds against,"
+                     " and exit. Shows the branch each copy is on, whether it is behind its"
+                     " upstream as of your last fetch, and whether it has uncommitted or unpushed"
+                     " work, warning where that will not be visible to a build that does not use"
+                     " --develop. No remote is contacted." )
+
+    add_option( '--update-develop', dest='update_develop', action='store_true',
+                help="Fetch each local working copy used by --develop and fast-forward the ones"
+                     " that are clean and behind their upstream, then exit. Copies that are"
+                     " modified, ahead, diverged or detached are left alone and reported."
+                     " Nothing is stashed, reset or switched. Not available with --offline." )
+
 
 def process_location_options( cuppa_env ):
 
     cuppa_env['develop']                          = cuppa_env.get_option( 'develop' )
+    cuppa_env['list_develop']                     = cuppa_env.get_option( 'list_develop' )
+    cuppa_env['update_develop']                   = cuppa_env.get_option( 'update_develop' )
     cuppa_env['location_default_branch']          = cuppa_env.get_option( 'location_default_branch' )
     cuppa_env['location_match_current_branch']    = cuppa_env.get_option( 'location_match_current_branch' )
     cuppa_env['location_explicit_default_branch'] = cuppa_env.get_option( 'location_explicit_default_branch' )

--- a/cuppa/develop.py
+++ b/cuppa/develop.py
@@ -19,11 +19,15 @@ Observation, reporting, and the git commands are kept out of them so the rules c
 without a repository, and so the two options can never judge the same copy differently.
 """
 
+import locale
 import os
+import re
+import sys
+import textwrap
 
 from collections import namedtuple
 
-from cuppa.colourise import as_error, as_info, as_info_label, as_notice, as_warning
+from cuppa.colourise import as_error, as_info, as_info_label, as_notice, as_subdued, as_warning
 from cuppa.location import develop_location
 from cuppa.log import logger
 from cuppa.scms import scms
@@ -63,12 +67,31 @@ def plural( count, noun, plural_noun=None ):
     return "{} {}".format( count, plural_noun or noun + "s" )
 
 
+def display_path( path ):
+    """A develop path as somewhere you can recognise.
+
+    Most develop paths are written relative to the sconstruct, so the resolved path carries the
+    `..` segments that got it there. Those are noise in a report, and the same path has to read
+    the same way in the table and in the judgement about it.
+    """
+    if not path:
+        return path
+    path = os.path.normpath( path )
+    home = os.path.expanduser( "~" )
+    if path.startswith( home ):
+        return "~" + path[len(home):]
+    return path
+
+
 #-------------------------------------------------------------------------------
 #   The rules
 #-------------------------------------------------------------------------------
 
 def classify( copy, current_branch, default_branch ):
     """How much of a problem this copy is, and why. A pure function of observed state.
+
+    Each note continues the sentence its dependency's name begins, because the report groups
+    notes under that name rather than repeating it on every line.
 
     Local work is benign only where the rest of the world will find it. On the branch being built
     it is the intended workflow, because pushing that branch makes every other build see the same
@@ -77,14 +100,14 @@ def classify( copy, current_branch, default_branch ):
     """
     if not copy.exists:
         return Classification( ERROR, [
-            "[{}] develop path [{}] does not exist, so this build cannot succeed".format(
-                    copy.name, copy.path )
+            "has a develop path [{}] that does not exist, so this build cannot succeed".format(
+                    display_path( copy.path ) )
         ] )
 
     if not copy.is_working_copy:
         return Classification( WARNING, [
-            "[{}] at [{}] is not a working copy, so its state cannot be reasoned about".format(
-                    copy.name, copy.path )
+            "at [{}] is not a working copy, so its state cannot be reasoned about".format(
+                    display_path( copy.path ) )
         ] )
 
     severities = [ OK ]
@@ -95,35 +118,32 @@ def classify( copy, current_branch, default_branch ):
 
     if copy.detached:
         severities.append( WARNING )
-        notes.append( "[{}] is on a detached HEAD; it works today and is forgotten"
-                      " tomorrow".format( copy.name ) )
+        notes.append( "is on a detached HEAD; it works today and is forgotten tomorrow" )
     elif not on_built_branch and not on_default_branch:
         severities.append( WARNING )
         if current_branch:
-            notes.append( "[{}] is on [{}], which is neither [{}] nor the default branch"
-                          " [{}]".format( copy.name, copy.branch, current_branch,
-                                          default_branch ) )
+            notes.append( "is on [{}], which is neither [{}] nor the default branch [{}]".format(
+                    copy.branch, current_branch, default_branch ) )
         else:
-            notes.append( "[{}] is on [{}], which is not the default branch [{}]".format(
-                    copy.name, copy.branch, default_branch ) )
+            notes.append( "is on [{}], which is not the default branch [{}]".format(
+                    copy.branch, default_branch ) )
 
     if copy.scm != 'git':
         severities.append( NOTE )
-        notes.append( "[{}] is a {} working copy; ahead, behind and modified are not"
-                      " reported for it".format( copy.name, copy.scm or "non-git" ) )
+        notes.append( "is a {} working copy; ahead, behind and modified are not reported"
+                      " for it".format( copy.scm or "non-git" ) )
     elif not copy.detached and not copy.upstream:
         severities.append( NOTE )
-        notes.append( "[{}] has no upstream branch, so ahead and behind cannot be"
-                      " answered".format( copy.name ) )
+        notes.append( "has no upstream branch, so ahead and behind cannot be answered" )
 
     if copy.behind and copy.ahead:
         severities.append( WARNING )
-        notes.append( "[{}] has diverged from [{}]: {} ahead, {} behind as of your last"
-                      " fetch".format( copy.name, copy.upstream, copy.ahead, copy.behind ) )
+        notes.append( "has diverged from [{}]: {} ahead, {} behind as of your last fetch".format(
+                copy.upstream, copy.ahead, copy.behind ) )
     elif copy.behind:
         severities.append( WARNING )
-        notes.append( "[{}] is {} behind [{}] as of your last fetch".format(
-                copy.name, plural( copy.behind, "commit" ), copy.upstream ) )
+        notes.append( "is {} behind [{}] as of your last fetch".format(
+                plural( copy.behind, "commit" ), copy.upstream ) )
     elif copy.ahead:
         severities.append( _local_work_severity( on_default_branch ) )
         notes.append( _local_work_note( copy, on_default_branch,
@@ -142,11 +162,11 @@ def _local_work_severity( on_default_branch ):
 
 def _local_work_note( copy, on_default_branch, work ):
     if on_default_branch:
-        return ( "[{name}] has {work} on the default branch [{branch}]; a build without"
-                 " --develop resolves [{name}] to the published [{branch}] and will not see"
-                 " them. Put the work on a branch named for the branch you are building, commit"
-                 " it, and push it".format( name=copy.name, work=work, branch=copy.branch ) )
-    return "[{}] has {} on [{}]".format( copy.name, work, copy.branch )
+        return ( "has {work} on the default branch [{branch}]; a build without --develop resolves"
+                 " it to the published [{branch}] and will not see them. Put the work on a branch"
+                 " named for the branch you are building, commit it, and push it".format(
+                        work=work, branch=copy.branch ) )
+    return "has {} on [{}]".format( work, copy.branch )
 
 
 def update_action( copy ):
@@ -282,30 +302,74 @@ def survey( cuppa_env ):
 
 #-------------------------------------------------------------------------------
 #   Reporting
+#
+#   A report is what was asked for, not commentary on producing it, so it is written to standard
+#   output rather than logged. Logging it would mean `--verbosity=warn` printing the warning rows
+#   of a table without its header, and `-Q` printing nothing at all. The logger keeps the
+#   diagnostics.
 #-------------------------------------------------------------------------------
 
-COLUMNS = ( "DEPENDENCY", "BRANCH", "UPSTREAM", "STATE", "PATH" )
-
-COLOUR_FOR = { OK: as_info, NOTE: as_info, WARNING: as_warning, ERROR: as_error }
+COLUMNS = ( "STATUS", "DEPENDENCY", "BRANCH", "UPSTREAM", "STATE", "PATH" )
 
 
-def log_at( severity, message ):
-    { OK: logger.info, NOTE: logger.info, WARNING: logger.warn, ERROR: logger.error }[severity](
-            COLOUR_FOR[severity]( message ) )
+def uncoloured( text ):
+    return text
 
 
-def display_path( path ):
-    if not path:
-        return path
-    path = os.path.normpath( path )
-    home = os.path.expanduser( "~" )
-    if path.startswith( home ):
-        return "~" + path[len(home):]
-    return path
+# A copy with nothing to be done about it is left in the console's own colour, so the rows that
+# want attention are the only coloured ones in the table.
+COLOUR_FOR = { OK: uncoloured, NOTE: as_info, WARNING: as_warning, ERROR: as_error }
+
+# Severity has to survive --raw-output, so it is a column rather than a colour or a log prefix.
+STATUS_FOR = { OK: "ok", NOTE: "note", WARNING: "warn", ERROR: "error" }
+
+# The column abbreviates to keep the table narrow; a heading has the room to say it in full.
+HEADING_FOR = { OK: "ok", NOTE: "note", WARNING: "warning", ERROR: "error" }
+
+INDENT = "  "
+RULE = "-"
+
+# Prose is wrapped to the table's right edge so the report has one, but a wide table comes from a
+# long path rather than from anything worth reading across, so the text stops at a readable width.
+WIDEST_PROSE = 110
+NARROWEST_PROSE = 40
+
+# The values a note is about. Colouring these and leaving the prose plain is what lets a name be
+# found in a page of text; colouring both leaves nothing to find.
+VALUES = re.compile( r'\[([^\[\]]+)\]' )
+
+# tee, elbow, and the two continuations that sit under them, each the same width.
+GLYPHS = ( "\u251c\u2500\u2500 ", "\u2514\u2500\u2500 ", "\u2502   ", "    " )
+ASCII_GLYPHS = ( "+-- ", "`-- ", "|   ", "    " )
 
 
-def row_for( copy ):
+Entry = namedtuple( 'Entry', [ 'copy', 'severity', 'notes' ] )
+
+
+def write( text="" ):
+    print( text )
+
+
+def highlight_values( text, colour ):
+    return VALUES.sub( lambda match: "[" + colour( match.group(1) ) + "]", text )
+
+
+def action_line( text, colour=as_info ):
+    """An action, indented under the table, with only the values it names picked out."""
+    return INDENT + highlight_values( text, colour )
+
+
+def entries( copies, current_branch, default_branch ):
+    """The report as data, so a renderer decides only how to present it."""
+    return [
+        Entry( copy, *classify( copy, current_branch, default_branch ) ) for copy in copies
+    ]
+
+
+def row_for( entry ):
+    copy = entry.copy
     return (
+        STATUS_FOR[entry.severity],
         copy.name,
         copy.detached and "(detached)" or ( copy.branch or "-" ),
         copy.upstream or "-",
@@ -314,62 +378,182 @@ def row_for( copy ):
     )
 
 
-def table( copies ):
-    """The rows, padded to the widest value in each column including the header."""
-    rows = [ COLUMNS ] + [ row_for( copy ) for copy in copies ]
+def table( entries ):
+    """Header and rows as plain text, padded to the widest value in each column."""
+    rows = [ COLUMNS ] + [ row_for( entry ) for entry in entries ]
     widths = [ max( len( row[column] ) for row in rows ) for column in range( len( COLUMNS ) ) ]
     return [
-        "  " + "  ".join( value.ljust( width )
-                          for value, width in zip( row, widths ) ).rstrip()
+        INDENT + "  ".join( value.ljust( width )
+                            for value, width in zip( row, widths ) ).rstrip()
         for row in rows
     ]
 
 
-def report( copies, without_develop, current_branch, default_branch, develop_active ):
-    """Print the table, then the judgements in full, so a reason needs no column decoding."""
+def table_width( entries ):
+    return max( len( row ) for row in table( entries ) )
+
+
+def emphasis( severity, text ):
+    """A row asking for attention is shown at full strength, and everything else recedes.
+
+    Reduced intensity is what makes a copy with nothing to be done about it quiet without hiding
+    it, and it behaves the same way on a light console as on a dark one.
+    """
+    coloured = COLOUR_FOR[severity]( text )
+    return as_subdued( coloured ) if severity in ( OK, NOTE ) else coloured
+
+
+def render_table( entries ):
+    """The table, ruled around the header and under the last row."""
+    rows = table( entries )
+    rule = as_subdued( INDENT + RULE * ( table_width( entries ) - len( INDENT ) ) )
+
+    lines = [ rule, rows[0], rule ]
+    for entry, row in zip( entries, rows[1:] ):
+        lines.append( emphasis( entry.severity, row ) )
+    lines.append( rule )
+    return lines
+
+
+def glyphs( encoding=None ):
+    """Box drawing where the console can encode it, ASCII where it cannot."""
+    encoding = ( encoding
+                 or getattr( sys.stdout, 'encoding', None )
+                 or locale.getpreferredencoding()
+                 or 'ascii' )
+    try:
+        "".join( GLYPHS ).encode( encoding )
+    except ( UnicodeError, LookupError ):
+        return ASCII_GLYPHS
+    return GLYPHS
+
+
+def wrapped( text, width ):
+    """The text as lines that fit, keeping bracketed values whole so they can still be coloured."""
+    if not width:
+        return [ text ]
+    return textwrap.wrap( text, max( width, NARROWEST_PROSE ),
+                          break_long_words=False, break_on_hyphens=False ) or [ text ]
+
+
+def render_judgements( entries, width=None, encoding=None ):
+    """Every judgement in one tree that hangs from the summary line: severity, then dependency,
+    then reason, worst first.
+
+    Reading down the tree is reading a work list. What must be fixed for the build to succeed is
+    at the top, and what is only worth knowing is at the bottom, each dependency named once.
+
+    A reason long enough to run past `width` is wrapped and the stem is carried down through the
+    wrapped lines, so the tree stays a tree and the report keeps one right edge.
+    """
+    tee, elbow, pipe, gap = glyphs( encoding )
+    stub = pipe.rstrip()
+    lines = []
+
+    groups = [ ( severity, [ entry for entry in entries
+                             if entry.severity == severity and entry.notes ] )
+               for severity in ( ERROR, WARNING, NOTE ) ]
+    groups = [ group for group in groups if group[1] ]
+
+    for index, ( severity, group ) in enumerate( groups ):
+        last_group = index == len( groups ) - 1
+        colour = COLOUR_FOR[severity]
+        # A gap on the stem above each name, so a dependency and its reasons read as one block
+        # rather than as a wall of branches.
+        lines.append( as_subdued( stub ) )
+        lines.append( as_subdued( last_group and elbow or tee )
+                      + colour( plural( len( group ), HEADING_FOR[severity] ) ) )
+
+        under_severity = last_group and gap or pipe
+        for position, entry in enumerate( group ):
+            last_entry = position == len( group ) - 1
+            lines.append( as_subdued( under_severity + stub ) )
+            lines.append( as_subdued( under_severity + ( last_entry and elbow or tee ) )
+                          + colour( entry.copy.name ) )
+
+            under_entry = under_severity + ( last_entry and gap or pipe )
+            for note_index, note in enumerate( entry.notes ):
+                last_note = note_index == len( entry.notes ) - 1
+                branch = under_entry + ( last_note and elbow or tee )
+                carried = under_entry + ( last_note and gap or pipe )
+                for piece in wrapped( note, width and width - len( branch ) ):
+                    lines.append( as_subdued( branch ) + highlight_values( piece, colour ) )
+                    branch = carried
+
+    return lines
+
+
+def summary( entries, without_develop ):
+    counts = { OK: 0, NOTE: 0, WARNING: 0, ERROR: 0 }
+    for entry in entries:
+        counts[entry.severity] += 1
+    return "{}: {} ok, {}, {}, {}; {} not using develop".format(
+            plural( len( entries ), "develop location" ),
+            counts[OK],
+            plural( counts[NOTE], "note" ),
+            plural( counts[WARNING], "warning" ),
+            plural( counts[ERROR], "error" ),
+            plural( len( without_develop ), "dependency", "dependencies" ) )
+
+
+def suggestion( copies ):
+    """What `--update-develop` would make of what has just been observed, or nothing when it
+    would leave every copy alone.
+
+    The decision comes from `update_action()`, the same function `--update-develop` uses, so the
+    suggestion cannot promise something the option will then decline to do. It can understate,
+    because `--update-develop` fetches before deciding and a fetch can find more, and the line
+    says so rather than leaving the reader to discover it.
+    """
+    ready = [ copy.name for copy in copies if update_action( copy ).act ]
+    if not ready:
+        return None
+    return ( "Of these, --update-develop would fast-forward {} ({}) as of your last fetch;"
+             " it fetches first, so it may find more".format(
+                    len( ready ), ", ".join( "[{}]".format( name ) for name in ready ) ) )
+
+
+def report( copies, without_develop, current_branch, default_branch, develop_active, out=write,
+            suggest_update=False ):
+    """Write the table, then the judgements in full, so a reason needs no column decoding."""
     if not copies:
-        logger.info( "No dependencies have a develop location configured; {} dependencies"
-                     " in total".format( len( without_develop ) ) )
+        out()
+        out( "No dependencies have a develop location configured; {} in total".format(
+                plural( len( without_develop ), "dependency", "dependencies" ) ) )
         return OK
 
-    classifications = [
-        ( copy, classify( copy, current_branch, default_branch ) ) for copy in copies
-    ]
+    found = entries( copies, current_branch, default_branch )
+    width = min( table_width( found ), WIDEST_PROSE )
 
-    logger.info( "Building on branch [{}] with default branch [{}]; --develop is {}".format(
+    out()
+    out( "Building on branch [{}] with default branch [{}]; --develop is {}".format(
             as_info( current_branch or "unknown" ),
             as_info( default_branch ),
             develop_active and as_info_label( "active" ) or as_notice( "not active" )
     ) )
+    out()
 
-    lines = table( copies )
-    logger.info( lines[0] )
-    for ( copy, classification ), line in zip( classifications, lines[1:] ):
-        log_at( classification.severity, line )
+    for line in render_table( found ):
+        out( line )
 
-    counts = { OK: 0, NOTE: 0, WARNING: 0, ERROR: 0 }
-    for copy, classification in classifications:
-        counts[classification.severity] += 1
+    out()
+    out( summary( found, without_develop ) )
 
-    logger.info( "{}: {} ok, {}, {}, {};"
-                 " {} not using develop".format(
-                        plural( len( copies ), "develop location" ),
-                        counts[OK],
-                        plural( counts[NOTE], "note" ),
-                        plural( counts[WARNING], "warning" ),
-                        plural( counts[ERROR], "error" ),
-                        plural( len( without_develop ), "dependency", "dependencies" ) ) )
+    for line in render_judgements( found, width ):
+        out( line )
 
-    for copy, classification in classifications:
-        for note in classification.notes:
-            log_at( classification.severity, note )
+    out()
+    out( "Ahead and behind are relative to your last fetch; no remote was contacted" )
 
-    logger.info( "Ahead and behind are relative to your last fetch; no remote was contacted" )
+    advice = suggest_update and suggestion( copies ) or None
+    if advice:
+        for piece in wrapped( advice, width ):
+            out( highlight_values( piece, as_info ) )
 
-    return worst( [ classification.severity for copy, classification in classifications ] )
+    return worst( [ entry.severity for entry in found ] )
 
 
-def list_develop( cuppa_env ):
+def list_develop( cuppa_env, out=write ):
     """`--list-develop`. Non-zero only when a develop path does not exist, because that build
     cannot succeed and a CI job should hear about it."""
     copies, without_develop = survey( cuppa_env )
@@ -378,12 +562,14 @@ def list_develop( cuppa_env ):
             without_develop,
             cuppa_env['current_branch'],
             cuppa_env['location_default_branch'],
-            cuppa_env['develop']
+            cuppa_env['develop'],
+            out,
+            suggest_update=True
     )
     return severity == ERROR and 1 or 0
 
 
-def update_develop( cuppa_env ):
+def update_develop( cuppa_env, out=write ):
     """`--update-develop`. Fetch, then fast-forward only where nothing can be lost."""
     if cuppa_env['offline']:
         logger.error( "--update-develop needs the network, but --offline was specified" )
@@ -395,51 +581,55 @@ def update_develop( cuppa_env ):
     dry_run = cuppa_env.get_option( 'no_exec' ) and True or False
 
     copies, without_develop = survey( cuppa_env )
-    report( copies, without_develop, current_branch, default_branch, develop_active )
+    report( copies, without_develop, current_branch, default_branch, develop_active, out )
 
+    out()
     if dry_run:
-        logger.info( as_info_label( "Dry run: showing what --update-develop would do" ) )
+        # No fetch happens, so the decisions shown are the ones the last fetch supports.
+        out( "{} {}".format(
+                as_info_label( "Dry run" ),
+                "showing what --update-develop would do, judged as of your last fetch" ) )
 
     failures = 0
     updated = []
 
     for copy in copies:
-        observed, failed = _fetch( copy, dry_run )
+        observed, failed = _fetch( copy, dry_run, out )
         failures += failed
 
         action = update_action( observed )
         if not action.act:
-            logger.info( "Leaving [{}] alone: {}".format(
-                    as_info( observed.name ), as_notice( action.reason ) ) )
+            out( action_line( "Leaving [{}] alone: {}".format(
+                    observed.name, action.reason ) ) )
             continue
 
         if dry_run:
-            logger.info( "Would fast-forward [{}], {}".format(
-                    as_info( observed.name ), as_notice( action.reason ) ) )
+            out( action_line( "Would fast-forward [{}], {}".format(
+                    observed.name, action.reason ) ) )
             continue
 
         try:
             Git.fast_forward( observed.path )
             updated.append( observed.name )
-            logger.info( "Fast-forwarded [{}], which was {}".format(
-                    as_info( observed.name ), as_notice( action.reason ) ) )
+            out( action_line( "Fast-forwarded [{}], which was {}".format(
+                    observed.name, action.reason ) ) )
         except Git.Error as error:
             failures += 1
-            logger.error( "Could not fast-forward [{}]: {}".format(
-                    as_error( observed.name ), as_error( str(error) ) ) )
+            out( action_line( "Could not fast-forward [{}]: {}".format(
+                    observed.name, str(error) ), as_error ) )
 
     if dry_run:
         return 0
 
-    severity = OK
     if updated:
-        logger.info( "Updated {} of {} develop locations. The state is now:".format(
-                len( updated ), len( copies ) ) )
+        out()
+        out( "Updated {} of {}. The state is now:".format(
+                len( updated ), plural( len( copies ), "develop location" ) ) )
         copies, without_develop = survey( cuppa_env )
         severity = report( copies, without_develop, current_branch, default_branch,
-                           develop_active )
+                           develop_active, out )
     else:
-        logger.info( "Nothing could be fast-forwarded; no working copy was changed" )
+        out( INDENT + "Nothing could be fast-forwarded; no working copy was changed" )
         severity = worst( [ OK ] + [
             classify( copy, current_branch, default_branch ).severity for copy in copies
         ] )
@@ -449,21 +639,21 @@ def update_develop( cuppa_env ):
     return severity == ERROR and 1 or 0
 
 
-def _fetch( copy, dry_run ):
+def _fetch( copy, dry_run, out ):
     """Fetch, then observe again: the decision must be taken on what is true after the fetch."""
     if not copy.exists or copy.scm != 'git':
         return copy, 0
 
     if dry_run:
-        logger.info( "Would fetch [{}] in [{}]".format(
-                as_info( copy.name ), as_notice( display_path( copy.path ) ) ) )
+        out( action_line( "Would fetch [{}] in [{}]".format(
+                copy.name, display_path( copy.path ) ) ) )
         return copy, 0
 
     try:
         Git.fetch( copy.path )
     except Git.Error as error:
-        logger.error( "Could not fetch [{}]: {}".format(
-                as_error( copy.name ), as_error( str(error) ) ) )
+        out( action_line( "Could not fetch [{}]: {}".format(
+                copy.name, str(error) ), as_error ) )
         return copy, 1
 
     return inspect( copy.name, copy.path ), 0

--- a/cuppa/develop.py
+++ b/cuppa/develop.py
@@ -1,0 +1,469 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   Develop
+#-------------------------------------------------------------------------------
+
+"""Reporting on, and updating, the local working copies that `--develop` builds against.
+
+`--develop` substitutes a working copy on disk for a retrieved dependency and says nothing about
+the state of that copy, so a build can be reading someone else's spike branch, or a checkout that
+has not been pulled for months. `--list-develop` answers what you are actually building against,
+and `--update-develop` fast-forwards the copies where doing so cannot lose work.
+
+The decisions are `classify()` and `update_action()`, pure functions of observed state.
+Observation, reporting, and the git commands are kept out of them so the rules can be tested
+without a repository, and so the two options can never judge the same copy differently.
+"""
+
+import os
+
+from collections import namedtuple
+
+from cuppa.colourise import as_error, as_info, as_info_label, as_notice, as_warning
+from cuppa.location import develop_location
+from cuppa.log import logger
+from cuppa.scms import scms
+from cuppa.scms.git import Git
+
+
+OK      = 'ok'
+NOTE    = 'note'
+WARNING = 'warning'
+ERROR   = 'error'
+
+SEVERITY_ORDER = { OK: 0, NOTE: 1, WARNING: 2, ERROR: 3 }
+
+
+# One develop location and everything observed about it. `ahead`, `behind` and `modified` are
+# None when the question could not be answered, which is not the same as zero or clean.
+Copy = namedtuple(
+        'Copy',
+        [ 'name', 'path', 'exists', 'is_working_copy', 'scm',
+          'branch', 'detached', 'upstream', 'ahead', 'behind', 'modified' ]
+)
+
+Copy.__new__.__defaults__ = ( False, False, None, None, False, None, None, None, None )
+
+Classification = namedtuple( 'Classification', [ 'severity', 'notes' ] )
+
+Action = namedtuple( 'Action', [ 'act', 'reason' ] )
+
+
+def worst( severities ):
+    return max( severities, key=lambda severity: SEVERITY_ORDER[severity] )
+
+
+def plural( count, noun, plural_noun=None ):
+    if count == 1:
+        return "{} {}".format( count, noun )
+    return "{} {}".format( count, plural_noun or noun + "s" )
+
+
+#-------------------------------------------------------------------------------
+#   The rules
+#-------------------------------------------------------------------------------
+
+def classify( copy, current_branch, default_branch ):
+    """How much of a problem this copy is, and why. A pure function of observed state.
+
+    Local work is benign only where the rest of the world will find it. On the branch being built
+    it is the intended workflow, because pushing that branch makes every other build see the same
+    code. The same work on the default branch is a trap: your build reads the working copy, while
+    every build without `--develop` resolves the dependency to the published default branch.
+    """
+    if not copy.exists:
+        return Classification( ERROR, [
+            "[{}] develop path [{}] does not exist, so this build cannot succeed".format(
+                    copy.name, copy.path )
+        ] )
+
+    if not copy.is_working_copy:
+        return Classification( WARNING, [
+            "[{}] at [{}] is not a working copy, so its state cannot be reasoned about".format(
+                    copy.name, copy.path )
+        ] )
+
+    severities = [ OK ]
+    notes = []
+
+    on_built_branch = bool( current_branch ) and copy.branch == current_branch
+    on_default_branch = copy.branch == default_branch
+
+    if copy.detached:
+        severities.append( WARNING )
+        notes.append( "[{}] is on a detached HEAD; it works today and is forgotten"
+                      " tomorrow".format( copy.name ) )
+    elif not on_built_branch and not on_default_branch:
+        severities.append( WARNING )
+        if current_branch:
+            notes.append( "[{}] is on [{}], which is neither [{}] nor the default branch"
+                          " [{}]".format( copy.name, copy.branch, current_branch,
+                                          default_branch ) )
+        else:
+            notes.append( "[{}] is on [{}], which is not the default branch [{}]".format(
+                    copy.name, copy.branch, default_branch ) )
+
+    if copy.scm != 'git':
+        severities.append( NOTE )
+        notes.append( "[{}] is a {} working copy; ahead, behind and modified are not"
+                      " reported for it".format( copy.name, copy.scm or "non-git" ) )
+    elif not copy.detached and not copy.upstream:
+        severities.append( NOTE )
+        notes.append( "[{}] has no upstream branch, so ahead and behind cannot be"
+                      " answered".format( copy.name ) )
+
+    if copy.behind and copy.ahead:
+        severities.append( WARNING )
+        notes.append( "[{}] has diverged from [{}]: {} ahead, {} behind as of your last"
+                      " fetch".format( copy.name, copy.upstream, copy.ahead, copy.behind ) )
+    elif copy.behind:
+        severities.append( WARNING )
+        notes.append( "[{}] is {} behind [{}] as of your last fetch".format(
+                copy.name, plural( copy.behind, "commit" ), copy.upstream ) )
+    elif copy.ahead:
+        severities.append( _local_work_severity( on_default_branch ) )
+        notes.append( _local_work_note( copy, on_default_branch,
+                                        plural( copy.ahead, "unpushed commit" ) ) )
+
+    if copy.modified:
+        severities.append( _local_work_severity( on_default_branch ) )
+        notes.append( _local_work_note( copy, on_default_branch, "uncommitted changes" ) )
+
+    return Classification( worst( severities ), notes )
+
+
+def _local_work_severity( on_default_branch ):
+    return on_default_branch and WARNING or NOTE
+
+
+def _local_work_note( copy, on_default_branch, work ):
+    if on_default_branch:
+        return ( "[{name}] has {work} on the default branch [{branch}]; a build without"
+                 " --develop resolves [{name}] to the published [{branch}] and will not see"
+                 " them. Put the work on a branch named for the branch you are building, commit"
+                 " it, and push it".format( name=copy.name, work=work, branch=copy.branch ) )
+    return "[{}] has {} on [{}]".format( copy.name, work, copy.branch )
+
+
+def update_action( copy ):
+    """Whether this copy can be fast-forwarded, or why it is being left alone.
+
+    Fast-forwarding a clean copy discards nothing and invents no commits. Everything else is a
+    judgement about someone's unpublished work, so it is reported rather than resolved.
+    """
+    if not copy.exists:
+        return Action( False, "path does not exist" )
+    if not copy.is_working_copy:
+        return Action( False, "not a working copy" )
+    if copy.scm != 'git':
+        return Action( False, "only git working copies can be updated" )
+    if copy.detached:
+        return Action( False, "detached HEAD" )
+    if not copy.upstream:
+        return Action( False, "no upstream branch" )
+    if copy.modified:
+        return Action( False, "uncommitted changes" )
+    if copy.ahead and copy.behind:
+        return Action( False, "diverged from [{}]".format( copy.upstream ) )
+    if copy.ahead:
+        return Action( False, "ahead of [{}]".format( copy.upstream ) )
+    if not copy.behind:
+        return Action( False, "already up to date" )
+    return Action( True, "{} behind [{}]".format(
+            plural( copy.behind, "commit" ), copy.upstream ) )
+
+
+def state_summary( copy ):
+    """The STATE column: what was observed, in the order that reads naturally."""
+    if not copy.exists:
+        return "path does not exist"
+    if not copy.is_working_copy:
+        return "not a working copy"
+
+    parts = [ copy.modified is None and "unknown" or ( copy.modified and "modified" or "clean" ) ]
+    if copy.ahead:
+        parts.append( "{} ahead".format( copy.ahead ) )
+    if copy.behind:
+        parts.append( "{} behind".format( copy.behind ) )
+    if copy.scm == 'git' and not copy.detached and not copy.upstream:
+        parts.append( "no upstream" )
+    return ", ".join( parts )
+
+
+#-------------------------------------------------------------------------------
+#   Observation
+#-------------------------------------------------------------------------------
+
+def inspect( name, path ):
+    """Observe one develop location. Reads the working copy only; never the network."""
+    if not path or not os.path.exists( path ):
+        return Copy( name, path )
+
+    try:
+        state = Git.get_working_copy_state( path )
+        return Copy(
+                name            = name,
+                path            = path,
+                exists          = True,
+                is_working_copy = True,
+                scm             = 'git',
+                branch          = state.branch,
+                detached        = state.detached,
+                upstream        = state.upstream,
+                ahead           = state.ahead,
+                behind          = state.behind,
+                modified        = state.modified
+        )
+    except Git.Error:
+        pass
+
+    # Subversion, Mercurial and Bazaar report branch and revision. The rest stays unknown rather
+    # than being guessed from a backend that cannot answer it.
+    url, repository, branch, remote, revision = scms.get_current_rev_info( path )
+    if branch or revision:
+        return Copy( name, path, exists=True, is_working_copy=True, scm='other',
+                     branch=branch, upstream=remote )
+
+    return Copy( name, path, exists=True )
+
+
+def configured_develop( dependency, cuppa_env ):
+    """The develop location a dependency is configured with, and how it is resolved to a path.
+
+    Location dependencies carry theirs in `location_id()`, which also applies the command line
+    overrides, and resolve through `develop_location` — the same helper the develop swap uses.
+    Package dependencies keep their own and only expand `~`, matching what
+    `GitlabPackageDependency` does when it swaps.
+    """
+    location_id = getattr( dependency, 'location_id', None )
+    if location_id:
+        try:
+            identity = location_id( cuppa_env )
+        except Exception as error:
+            logger.trace( "Could not resolve the location of [{}]: {}".format(
+                    getattr( dependency, '_name', dependency ), str(error) ) )
+            identity = None
+        if identity and identity[1]:
+            return develop_location( cuppa_env['sconstruct_dir'], identity[1] )
+
+    manager = getattr( dependency, '_package_manager', None )
+    name = getattr( dependency, '_name', None )
+    if manager and name:
+        override = cuppa_env.get_option( "-".join( [ name, manager, "develop" ] ) )
+        if override:
+            return os.path.expanduser( override )
+
+    develop = getattr( dependency, '_develop', None )
+    if develop:
+        return os.path.expanduser( develop )
+    return None
+
+
+def survey( cuppa_env ):
+    """Every dependency with a develop location, observed, whether or not --develop is active."""
+    copies = []
+    without_develop = []
+
+    for name in sorted( cuppa_env['dependencies'] ):
+        factory = cuppa_env['dependencies'][name]
+        dependency = getattr( factory, '__self__', factory )
+        path = configured_develop( dependency, cuppa_env )
+        if path:
+            copies.append( inspect( name, path ) )
+        else:
+            without_develop.append( name )
+
+    return copies, without_develop
+
+
+#-------------------------------------------------------------------------------
+#   Reporting
+#-------------------------------------------------------------------------------
+
+COLUMNS = ( "DEPENDENCY", "BRANCH", "UPSTREAM", "STATE", "PATH" )
+
+COLOUR_FOR = { OK: as_info, NOTE: as_info, WARNING: as_warning, ERROR: as_error }
+
+
+def log_at( severity, message ):
+    { OK: logger.info, NOTE: logger.info, WARNING: logger.warn, ERROR: logger.error }[severity](
+            COLOUR_FOR[severity]( message ) )
+
+
+def display_path( path ):
+    if not path:
+        return path
+    path = os.path.normpath( path )
+    home = os.path.expanduser( "~" )
+    if path.startswith( home ):
+        return "~" + path[len(home):]
+    return path
+
+
+def row_for( copy ):
+    return (
+        copy.name,
+        copy.detached and "(detached)" or ( copy.branch or "-" ),
+        copy.upstream or "-",
+        state_summary( copy ),
+        display_path( copy.path )
+    )
+
+
+def table( copies ):
+    """The rows, padded to the widest value in each column including the header."""
+    rows = [ COLUMNS ] + [ row_for( copy ) for copy in copies ]
+    widths = [ max( len( row[column] ) for row in rows ) for column in range( len( COLUMNS ) ) ]
+    return [
+        "  " + "  ".join( value.ljust( width )
+                          for value, width in zip( row, widths ) ).rstrip()
+        for row in rows
+    ]
+
+
+def report( copies, without_develop, current_branch, default_branch, develop_active ):
+    """Print the table, then the judgements in full, so a reason needs no column decoding."""
+    if not copies:
+        logger.info( "No dependencies have a develop location configured; {} dependencies"
+                     " in total".format( len( without_develop ) ) )
+        return OK
+
+    classifications = [
+        ( copy, classify( copy, current_branch, default_branch ) ) for copy in copies
+    ]
+
+    logger.info( "Building on branch [{}] with default branch [{}]; --develop is {}".format(
+            as_info( current_branch or "unknown" ),
+            as_info( default_branch ),
+            develop_active and as_info_label( "active" ) or as_notice( "not active" )
+    ) )
+
+    lines = table( copies )
+    logger.info( lines[0] )
+    for ( copy, classification ), line in zip( classifications, lines[1:] ):
+        log_at( classification.severity, line )
+
+    counts = { OK: 0, NOTE: 0, WARNING: 0, ERROR: 0 }
+    for copy, classification in classifications:
+        counts[classification.severity] += 1
+
+    logger.info( "{}: {} ok, {}, {}, {};"
+                 " {} not using develop".format(
+                        plural( len( copies ), "develop location" ),
+                        counts[OK],
+                        plural( counts[NOTE], "note" ),
+                        plural( counts[WARNING], "warning" ),
+                        plural( counts[ERROR], "error" ),
+                        plural( len( without_develop ), "dependency", "dependencies" ) ) )
+
+    for copy, classification in classifications:
+        for note in classification.notes:
+            log_at( classification.severity, note )
+
+    logger.info( "Ahead and behind are relative to your last fetch; no remote was contacted" )
+
+    return worst( [ classification.severity for copy, classification in classifications ] )
+
+
+def list_develop( cuppa_env ):
+    """`--list-develop`. Non-zero only when a develop path does not exist, because that build
+    cannot succeed and a CI job should hear about it."""
+    copies, without_develop = survey( cuppa_env )
+    severity = report(
+            copies,
+            without_develop,
+            cuppa_env['current_branch'],
+            cuppa_env['location_default_branch'],
+            cuppa_env['develop']
+    )
+    return severity == ERROR and 1 or 0
+
+
+def update_develop( cuppa_env ):
+    """`--update-develop`. Fetch, then fast-forward only where nothing can be lost."""
+    if cuppa_env['offline']:
+        logger.error( "--update-develop needs the network, but --offline was specified" )
+        return 1
+
+    current_branch = cuppa_env['current_branch']
+    default_branch = cuppa_env['location_default_branch']
+    develop_active = cuppa_env['develop']
+    dry_run = cuppa_env.get_option( 'no_exec' ) and True or False
+
+    copies, without_develop = survey( cuppa_env )
+    report( copies, without_develop, current_branch, default_branch, develop_active )
+
+    if dry_run:
+        logger.info( as_info_label( "Dry run: showing what --update-develop would do" ) )
+
+    failures = 0
+    updated = []
+
+    for copy in copies:
+        observed, failed = _fetch( copy, dry_run )
+        failures += failed
+
+        action = update_action( observed )
+        if not action.act:
+            logger.info( "Leaving [{}] alone: {}".format(
+                    as_info( observed.name ), as_notice( action.reason ) ) )
+            continue
+
+        if dry_run:
+            logger.info( "Would fast-forward [{}], {}".format(
+                    as_info( observed.name ), as_notice( action.reason ) ) )
+            continue
+
+        try:
+            Git.fast_forward( observed.path )
+            updated.append( observed.name )
+            logger.info( "Fast-forwarded [{}], which was {}".format(
+                    as_info( observed.name ), as_notice( action.reason ) ) )
+        except Git.Error as error:
+            failures += 1
+            logger.error( "Could not fast-forward [{}]: {}".format(
+                    as_error( observed.name ), as_error( str(error) ) ) )
+
+    if dry_run:
+        return 0
+
+    severity = OK
+    if updated:
+        logger.info( "Updated {} of {} develop locations. The state is now:".format(
+                len( updated ), len( copies ) ) )
+        copies, without_develop = survey( cuppa_env )
+        severity = report( copies, without_develop, current_branch, default_branch,
+                           develop_active )
+    else:
+        logger.info( "Nothing could be fast-forwarded; no working copy was changed" )
+        severity = worst( [ OK ] + [
+            classify( copy, current_branch, default_branch ).severity for copy in copies
+        ] )
+
+    if failures:
+        return 1
+    return severity == ERROR and 1 or 0
+
+
+def _fetch( copy, dry_run ):
+    """Fetch, then observe again: the decision must be taken on what is true after the fetch."""
+    if not copy.exists or copy.scm != 'git':
+        return copy, 0
+
+    if dry_run:
+        logger.info( "Would fetch [{}] in [{}]".format(
+                as_info( copy.name ), as_notice( display_path( copy.path ) ) ) )
+        return copy, 0
+
+    try:
+        Git.fetch( copy.path )
+    except Git.Error as error:
+        logger.error( "Could not fetch [{}]: {}".format(
+                as_error( copy.name ), as_error( str(error) ) ) )
+        return copy, 1
+
+    return inspect( copy.name, copy.path ), 0

--- a/cuppa/location.py
+++ b/cuppa/location.py
@@ -65,6 +65,31 @@ def get_common_top_directory_under( path ):
         return dirs[0]
     return None
 
+
+def replace_sconstruct_anchor( sconstruct_dir, path ):
+    if path.startswith( "#" ):
+        path = os.path.join( sconstruct_dir, path[1:] )
+    return path
+
+
+def develop_location( sconstruct_dir, develop ):
+    """Where a develop location actually lives on disk.
+
+    A relative develop path is anchored to the sconstruct directory rather than to the working
+    directory, so it means the same thing wherever cuppa is invoked from. Anything reporting on
+    develop copies must resolve them through here, or it describes a different path from the one
+    the build substitutes.
+
+    Home-relative and explicitly anchored paths are recognised before that, since neither is
+    relative to the sconstruct directory in the sense that needs anchoring.
+    """
+    if not develop:
+        return None
+    develop = os.path.expanduser( develop )
+    if not os.path.isabs( develop ) and not develop.startswith( "#" ):
+        develop = '#' + develop
+    return replace_sconstruct_anchor( sconstruct_dir, develop )
+
 class ReportDownloadProgress(object):
 
     def __init__( self ):
@@ -629,9 +654,7 @@ class Location(object):
 
 
     def replace_sconstruct_anchor( self, path ):
-        if path.startswith( "#" ):
-            path = os.path.join( self._cuppa_env['sconstruct_dir'], path[1:] )
-        return path
+        return replace_sconstruct_anchor( self._cuppa_env['sconstruct_dir'], path )
 
 
     @classmethod
@@ -670,9 +693,7 @@ class Location(object):
         location = self.replace_sconstruct_anchor( location )
 
         if develop:
-            if not os.path.isabs( develop ):
-                develop = '#' + develop
-            develop = self.replace_sconstruct_anchor( develop )
+            develop = develop_location( self._cuppa_env['sconstruct_dir'], develop )
             logger.debug( "Develop location specified [{}]".format( as_info( develop ) ) )
 
         if self.option_set('develop') and develop:

--- a/cuppa/output.py
+++ b/cuppa/output.py
@@ -23,6 +23,11 @@ class AutoFlushWriter(object):
         self.f.write(x)
         self.f.flush()
 
+    def __getattr__( self, name ):
+        # Anything else the stream is asked for -- encoding, isatty, fileno -- is answered by the
+        # stream being wrapped, rather than looking like a stream that cannot answer.
+        return getattr( self.f, name )
+
 
 try:
     import colorama

--- a/cuppa/scms/git.py
+++ b/cuppa/scms/git.py
@@ -13,9 +13,19 @@ import shlex
 import os
 import re
 
+from collections import namedtuple
+
 from cuppa.log import logger
 from cuppa.colourise import as_notice, as_info, colour_items, as_warning
 from cuppa.utility.python2to3 import as_str, Exception
+
+
+# What a working copy looks like without asking the network. Counts are relative to the last
+# fetch; None means the question could not be answered rather than zero.
+WorkingCopyState = namedtuple(
+        'WorkingCopyState',
+        [ 'branch', 'detached', 'upstream', 'ahead', 'behind', 'modified' ]
+)
 
 
 class Git:
@@ -245,6 +255,81 @@ class Git:
         if revision.strip() != "undefined":
             guessed_revision = revision
         return guessed_revision
+
+
+    @classmethod
+    def get_working_copy_state( cls, path ):
+        """Branch, upstream, ahead, behind and modified, without touching the network.
+
+        The counts describe the working copy against the upstream ref as it stood after the last
+        fetch. `modified` ignores untracked files: they are not what stops a fast-forward.
+        """
+        if not path or not os.path.exists( os.path.join( path, ".git" ) ):
+            raise cls.Error("Not a Git working copy")
+
+        branch = None
+        detached = False
+        try:
+            branch = cls.execute_command(
+                    "{git} symbolic-ref --short -q HEAD".format( git=cls.binary() ), path
+            )
+        except cls.Error:
+            detached = True
+
+        upstream = None
+        if branch:
+            try:
+                upstream = cls.execute_command(
+                        "{git} rev-parse --abbrev-ref --symbolic-full-name @{{upstream}}".format(
+                                git=cls.binary()
+                        ),
+                        path
+                )
+            except cls.Error:
+                logger.trace( "No upstream branch for [{}] in [{}]".format(
+                        as_notice(branch), as_notice(path)
+                ) )
+
+        ahead = None
+        behind = None
+        if upstream:
+            counts = cls.execute_command(
+                    "{git} rev-list --left-right --count @{{upstream}}...HEAD".format(
+                            git=cls.binary()
+                    ),
+                    path
+            )
+            fields = counts.split()
+            if len(fields) == 2:
+                behind, ahead = int(fields[0]), int(fields[1])
+
+        status = cls.execute_command(
+                "{git} status --porcelain --untracked-files=no".format( git=cls.binary() ), path
+        )
+
+        return WorkingCopyState(
+                branch   = branch,
+                detached = detached,
+                upstream = upstream,
+                ahead    = ahead,
+                behind   = behind,
+                modified = bool( status.strip() )
+        )
+
+
+    @classmethod
+    def fetch( cls, path ):
+        """Update the remote-tracking refs. The one command in this family that uses the network."""
+        return cls.execute_command( "{git} fetch".format( git=cls.binary() ), path )
+
+
+    @classmethod
+    def fast_forward( cls, path ):
+        """Advance the checked-out branch to its upstream, refusing anything that is not a
+        fast-forward. Git enforces that, so a copy that has moved on is never rewritten here."""
+        return cls.execute_command( "{git} merge --ff-only @{{upstream}}".format(
+                git=cls.binary()
+        ), path )
 
 
     @classmethod

--- a/design/README.md
+++ b/design/README.md
@@ -20,7 +20,7 @@ alternatives behind one of those roadmap entries.
 |----------|--------|---------|
 | [`plans/coverage-performance.md`](plans/coverage-performance.md) | proposal | Where `--cov --test` time actually goes, what the A/B measurement ruled out, and the remaining suspects |
 | [`plans/modules-activation.md`](plans/modules-activation.md) | proposal | Whether C++ modules should stay opt-in behind `--modules` or become opt-out, and what must land first |
-| [`plans/removal-options.md`](plans/removal-options.md) | in progress | `--remove-build` / `--remove-dependencies` / `--purge-*`, listing with sizes, renaming the storage roots, and the `--develop` copy report |
+| [`plans/removal-options.md`](plans/removal-options.md) | in progress | `--remove-build` / `--remove-dependencies` / `--purge-*`, listing with sizes, renaming the storage roots; `--list-develop` / `--update-develop` are done ([#132](https://github.com/ja11sop/cuppa/issues/132)) |
 | [`plans/scons-tool-wrapper.md`](plans/scons-tool-wrapper.md) | proposal | Wrapping an SCons Tool as a cuppa dependency instead of hand-writing a dependency class |
 | [`archive/conan-consumer-plan.md`](archive/conan-consumer-plan.md) | shipped | Design of `conan_deps` / `conan_dependency` consumer support |
 | [`archive/conan-publish-plan.md`](archive/conan-publish-plan.md) | shipped | Design of `ConanPackagePublisher` and `--publish-package` |

--- a/design/plans/removal-options.md
+++ b/design/plans/removal-options.md
@@ -4,11 +4,12 @@
 - **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Storage roots, listing, and removal; GitHub [#132](https://github.com/ja11sop/cuppa/issues/132), [#133](https://github.com/ja11sop/cuppa/issues/133), [#134](https://github.com/ja11sop/cuppa/issues/134), [#135](https://github.com/ja11sop/cuppa/issues/135)
 - **Updated:** 2026-08-01
 
-Nothing here is implemented. Follow-on from the `--clean` work in `cuppa/location.py` and `cuppa/package_managers/gitlab.py`,
-where a clean could not complete because a dependency was missing, and where the advice for
-leftover artefacts was "remove the folder by hand". Telling people to run `rm -rf` is
-unsatisfying: it is platform-specific, it is easy to aim at the wrong path, and cuppa already
-knows exactly which folders belong to which variant and which dependency.
+`--list-develop` and `--update-develop` (§3.5, §3.6) are implemented; the storage rename and the
+removal options are not. Follow-on from the `--clean` work in `cuppa/location.py` and
+`cuppa/package_managers/gitlab.py`, where a clean could not complete because a dependency was
+missing, and where the advice for leftover artefacts was "remove the folder by hand". Telling
+people to run `rm -rf` is unsatisfying: it is platform-specific, it is easy to aim at the wrong
+path, and cuppa already knows exactly which folders belong to which variant and which dependency.
 
 This plan proposes renaming the storage roots, a way to list what is in them, a family of
 explicit removal options, a report on the state of the local working copies `--develop`

--- a/design/plans/removal-options.md
+++ b/design/plans/removal-options.md
@@ -1,11 +1,12 @@
 # Plan: removal options for build folders and dependencies
 
 - **Status:** in progress
-- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Storage roots, listing, and removal; GitHub [#132](https://github.com/ja11sop/cuppa/issues/132), [#133](https://github.com/ja11sop/cuppa/issues/133), [#134](https://github.com/ja11sop/cuppa/issues/134), [#135](https://github.com/ja11sop/cuppa/issues/135)
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Storage roots, listing, and removal; GitHub [#132](https://github.com/ja11sop/cuppa/issues/132), [#133](https://github.com/ja11sop/cuppa/issues/133), [#134](https://github.com/ja11sop/cuppa/issues/134), [#135](https://github.com/ja11sop/cuppa/issues/135), [#138](https://github.com/ja11sop/cuppa/issues/138)
 - **Updated:** 2026-08-01
 
-`--list-develop` and `--update-develop` (§3.5, §3.6) are implemented; the storage rename and the
-removal options are not. Follow-on from the `--clean` work in `cuppa/location.py` and
+`--list-develop` and `--update-develop` (§3.5, §3.6) are implemented; cloning a missing develop
+copy (§3.7) came out of using them and is a proposal, as are the storage rename and the removal
+options. Follow-on from the `--clean` work in `cuppa/location.py` and
 `cuppa/package_managers/gitlab.py`, where a clean could not complete because a dependency was
 missing, and where the advice for leftover artefacts was "remove the folder by hand". Telling
 people to run `rm -rf` is unsatisfying: it is platform-specific, it is easy to aim at the wrong
@@ -13,8 +14,8 @@ path, and cuppa already knows exactly which folders belong to which variant and 
 
 This plan proposes renaming the storage roots, a way to list what is in them, a family of
 explicit removal options, a report on the state of the local working copies `--develop`
-substitutes together with a conservative way to bring them up to date, and the safety model that
-governs all of it.
+substitutes together with conservative ways to bring them up to date and to create the ones that
+are missing, and the safety model that governs all of it.
 
 The storage rename comes **first** (§6, Phase 1). Every later phase talks about paths, so doing
 the rename up front means each subsequent discussion and changeset uses one vocabulary, instead
@@ -36,6 +37,8 @@ new names are used: `dependencies_root` for what is currently `download_root`, a
 - Let people see the state of the local working copies `--develop` substitutes, relative to the
   branch being built, so a mismatched or stale copy is found before it confuses a build (§3.5),
   and bring the out-of-date ones forward where that cannot lose work (§3.6).
+- Create a develop working copy that is configured but not yet on disk, so a new machine, or a
+  dependency added since you last looked, does not need a clone worked out by hand (§3.7).
 - Remove the build output for the *currently selected* variant / toolchain combination.
 - Remove the whole build root.
 - Remove the on-disk copies of dependencies cuppa manages, either all of them or by name.
@@ -456,6 +459,117 @@ it. And because the value slot is spoken for, per-dependency scoping would need 
 (`--update-develop-only=dep1,dep2`), which is a further reason to wait until there is evidence
 that scoping is wanted at all.
 
+### 3.7 Cloning a develop copy that is not there yet
+
+Tracked as GitHub [#138](https://github.com/ja11sop/cuppa/issues/138). The surface is settled —
+a first-class `--clone-develop` — and the remaining design questions are gathered at the end of
+this section and in §9; they should be answered before implementation starts.
+
+Using `--list-develop` on real projects surfaced a case the two options above only report on: a
+dependency has a develop path configured, and there is nothing at that path. Today that is the
+one row `--list-develop` calls an `error`, because a build with `--develop` active cannot
+succeed, and the remedy is entirely manual — find the remote, clone it into exactly the right
+directory, and check out a branch that will not immediately be flagged as wrong.
+
+Three situations produce that row, and all three are ordinary:
+
+- **A new machine.** Someone joins, or rebuilds their laptop, has their SSH key working, and
+  wants the set of repositories the project develops against.
+- **A dependency added since you last looked.** The project grew a new component; everyone
+  else's tree has it, yours does not, and the first sign is a failed build.
+- **A dependency you have never needed to edit until now.** It was being retrieved into the
+  dependencies root and that was fine, until the change you are making spans it.
+
+**Cuppa already knows all three of the things a person has to work out by hand.** The location
+dependency carries the remote and, often, the branch (`git+ssh://…/widget.git@master`); the
+develop clause carries the destination, resolved by the same `develop_location()` helper the
+report and the swap both use; and §3.5's classification already produces the row that says the
+destination is empty. So this is a new *action* over observation that exists, in the same shape
+as §3.6: one decision per copy, taken from state already gathered.
+
+**Surface.** Three candidates, and the choice matters because it decides what `--update-develop`
+promises:
+
+| Form | For | Against |
+|------|-----|---------|
+| Fold into `--update-develop` | One command makes the environment right, which is what a newcomer wants | Changes the option's character. Fast-forwarding is seconds and reversible; cloning is minutes, megabytes, and network. A missing path is also what a **typo** in a develop clause looks like, and answering a typo by cloning a repository into it is the wrong reflex |
+| `--update-develop=clone-missing` | Fits the additive-modes idea already set out in §3.6 | The modes slot was reserved for *how much of someone's unpublished work you are willing to disturb*. Creating a copy is a different axis, and overloading the slot makes both harder to explain |
+| A first-class `--clone-develop` (**recommended**) | Keeps `--update-develop`'s promise intact; composes — `cuppa -D --clone-develop --update-develop` is the onboarding command, and either half is useful alone; leaves the mode slot for tolerance levels; says plainly what it does | One more option in the family, and people have to learn that update does not clone |
+
+The third is the one taken. The family then reads as three verbs over one observation:
+`--list-develop` looks, `--clone-develop` creates what is missing, `--update-develop` moves
+forward what is behind.
+
+**Which branch a fresh copy lands on.** A clone that is born a warning is a poor introduction, so
+the checkout has to satisfy §3.5's rules rather than merely succeed. The order should be: the
+branch being built, when the remote has it and the project is using branch matching; otherwise
+the branch the location names; otherwise the remote's default branch. What it must **never** do
+is leave a detached HEAD, which is what checking out a tag or a revision produces. That is a real
+difference from managed retrieval, where a detached checkout at a pinned revision is exactly
+right: a copy in the dependencies root is read, and a develop copy is worked in. Where the
+location pins a tag or a revision, the honest outcome is to clone and check out the branch that
+contains it, or to refuse and say why, rather than to hand back a copy nobody can commit to.
+
+**Credentials must not end up in the clone.** `Location.expand_secret` puts tokens into HTTPS
+URLs so retrieval can authenticate. A develop copy lives in someone's home directory for months,
+so writing `https://oauth2:<token>@host/…` into its `.git/config` would persist a credential
+where nobody thinks to look for one, keep working after the token should have been rotated, and
+travel into the first support paste that includes `git remote -v`. The clone must therefore use
+the **unexpanded** URL and let SSH or the user's git credential helper answer, and refuse with a
+clear message rather than quietly embedding a secret. This also argues against cuppa growing a
+protocol option: git already rewrites remotes through `url.<base>.insteadOf`, so a developer who
+wants SSH where the project names HTTPS can say so once in their own git configuration, and both
+cuppa and every other tool honour it.
+
+**Where it must refuse.** Cloning is the one write in this family with no destructive potential,
+but only because it never touches anything that already exists:
+
+| Situation | Response |
+|-----------|----------|
+| Destination is a working copy already | Nothing to do; that is `--update-develop`'s job |
+| Destination exists and is not empty | Refuse and report. Emptying it is a person's decision |
+| Destination exists and is empty | Clone into it |
+| Parent directories are missing | Create them, and say which were created |
+| Dependency has no develop clause | Skip. Nothing says where the copy should go (see the follow-on below) |
+| Location is an archive, a plain path, or an unsupported VCS | Skip with the reason; there is nothing to clone |
+| `--offline` | An error, exactly as for `--update-develop` — this option is nothing but network |
+| Authentication or remote failure | Report per dependency, continue with the rest, exit non-zero |
+
+Nothing is ever removed, moved, or overwritten, which is what makes the option safe enough to
+run without a dry run first — though `-n` still prints the plan: what would be cloned, from
+where, to where, and on which branch.
+
+**Submodules and depth.** A dependency that uses submodules and is cloned without them produces
+a tree that fails to build in a way that looks like a code error, so recursing is the kinder
+default; the cost is size, and the alternative is a confusing failure. Shallow clones should not
+be offered: a develop copy has to support branching, pushing, and the ahead / behind counts
+`--list-develop` reports, all of which a shallow history complicates for no benefit to someone
+who is going to work in the tree.
+
+**Reporting.** The same shape as §3.6 — the table before, a line per copy saying what was cloned
+and where, and the table afterwards. A successful clone turns an `error` row into an `ok` row,
+which is the proof the reader wants, and the closing suggestion that names what
+`--update-develop` would do next follows naturally from it.
+
+**Follow-on: the one-command fresh machine.** Everything above assumes the develop paths are
+already configured, which in practice means a shared `configure.conf` or the clauses being in the
+`sconstruct`. That covers the second and third situations completely and the first one as soon as
+the newcomer has the project's configuration. It does not cover the truly bare machine, where
+nothing yet says where copies should live. A `--develop-root=<path>` that clones every dependency
+to `<root>/<name>` and treats those as the develop locations would close that gap, but it turns
+cuppa from something that reads your configuration into something that writes it, so it deserves
+its own design pass rather than being smuggled in here.
+
+**Follow-on: name the option in the failure.** When a `--develop` build fails because a develop
+path does not exist, the message should say which option creates it. That is a one-line change
+once the option exists, and it is how most people will discover it.
+
+**Testing sketch.** The decision is a third pure function over the state §3.5 already observes —
+`clone_action(copy, location)` returning create-or-skip and a reason — so every row of the
+refusal table above is a unit test with no network. Integration tests clone from a local origin:
+one landing on the branch being built, one falling back to the remote default, one refusing on a
+non-empty directory, and one asserting that no token appears in the resulting `.git/config`.
+
 ---
 
 ## 4. Scope resolution
@@ -821,6 +935,12 @@ working.
 - The `--update-develop` decision is a second pure function over the same state: fast-forward
   only when clean and strictly behind, skip with a reason in every other case, and refuse
   outright under `--offline`.
+- The `--clone-develop` decision is a third pure function over the same state plus the location:
+  clone only into a missing or empty destination, skip with a reason for a working copy, a
+  non-empty directory, a missing develop clause, or a location with nothing to clone, and refuse
+  outright under `--offline` (§3.7). The branch a fresh copy would land on is chosen by the same
+  rules `--list-develop` judges by, so a clone cannot be born a warning, and the remote recorded
+  in the clone never carries an expanded secret.
 
 **Integration tests** (`tests/integration/`):
 
@@ -835,6 +955,9 @@ working.
 - `-n` reports paths and removes nothing.
 - Dependency removal against a location dependency backed by a local archive, then a rebuild to
   prove re-fetch works.
+- `--clone-develop` against a local origin: a missing develop path becomes a working copy on the
+  expected branch and the following `--list-develop` reports it as `ok`; a non-empty destination
+  is refused and left untouched.
 
 **Documentation:**
 
@@ -1046,6 +1169,7 @@ Settled while reviewing this plan, and folded into the sections above:
 | An inventory under the dependencies root | Yes — per-entry JSON, updated on resolve, advisory only (§4.5) |
 | Exact or sampled sizing | Sampled, cached in the inventory, refreshed lazily, `~` marks an estimate, `--exact-sizes` measures (§4.5) |
 | Shared or project-relative default | Shared, with a documentation obligation rather than a footnote, and one option to make a project self-contained (§8.3) |
+| Whether cloning a missing develop copy is its own option or a mode of `--update-develop` | Its own option, `--clone-develop`, so that updating keeps its narrow promise and the mode slot stays reserved for tolerance levels (§3.7, [#138](https://github.com/ja11sop/cuppa/issues/138)) |
 
 Still open, and none of them block Phase 1:
 
@@ -1064,6 +1188,12 @@ Still open, and none of them block Phase 1:
 - **Which `--update-develop` modes are worth adding** beyond the fast-forward default, and
   whether per-dependency scoping is wanted once the value slot is spoken for (§3.6). Both should
   be answered by using `--list-develop` and `--update-develop`, not by guessing now.
+- **What a pinned develop location should clone to** (§3.7). Where a location names a tag or a
+  revision there is no branch to land on, and the choice is between checking out the branch that
+  contains it and refusing with an explanation. Refusing is the safer first answer.
+- **Whether `--develop-root` should exist** (§3.7), letting a bare machine clone every dependency
+  into one root without develop clauses being configured first. It would make onboarding a single
+  command, at the cost of cuppa writing configuration rather than reading it.
 - **What happens to the inventory when the roots move.** A `--migrate-storage` action (§8.5)
   would need to rewrite recorded paths, or simply discard the inventory and let it rebuild —
   which is cheap, and probably the right answer.

--- a/docs/modules/ROOT/pages/cli-reference.adoc
+++ b/docs/modules/ROOT/pages/cli-reference.adoc
@@ -63,13 +63,17 @@ See xref:configuration.adoc[Configuration] for `--show-conf`, `--save-conf`, `--
 | Option | Description
 
 | `--develop` | Use develop locations for location/package dependencies that define them
-| `--location-default-branch` | Default branch name (default `master`) used in offline / relative location logic
+| `--list-develop` | Report the state of each configured develop working copy and exit (no network access)
+| `--update-develop` | Fetch each git develop working copy and fast-forward those that are clean and behind; refuse under `--offline`
+| `--location-default-branch` | Default branch name (default `master`) used in offline / relative location logic and by `--list-develop`
 | `--location-match-current-branch` | For relative locations (`path@`), try the current branch
 | `--location-explicit-default-branch` | Record the default branch explicitly in local checkouts
 | `--location-match-branch` / `--location-match-tag` | Pin relative locations to a branch or tag
 |===
 
 Per-dependency location options follow the pattern `--<name>-location`, `--<name>-develop`, `--<name>-include`, `--<name>-sys-include`, `--<name>-branch-path`, and related flags.
+
+See xref:dependencies.adoc#checking-your-develop-copies[Checking your develop copies] for what each state means and what `--update-develop` changes.
 
 == Environment propagation
 

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -58,6 +58,7 @@ cuppa.run(
 | `CI_JOB_TOKEN` | GitLab CI job token for registry access
 | Per-package custom token | Via `--<name>-gitlab-custom-token` (option names a token-bearing setting)
 | `PATH` / `PKG_CONFIG_PATH` | How much of your shell environment reaches build/test/run subprocesses depends on `--propagate-env`, `--propagate-path`, and `--merge-path` (see xref:cli-reference.adoc#environment-propagation[Environment propagation]). Host `PKG_CONFIG_PATH` is forwarded even when those flags are off.
+| `CUPPA_CONSOLE_BACKGROUND` | `light` or `dark`. Tells cuppa which way to make text recede: reduced intensity on a dark console, grey on a light one. Set it when your console is light, because most terminals report nothing and reduced intensity applied to black text on white can look untouched. Where a terminal does set `COLORFGBG`, cuppa reads it, and this variable overrides it.
 |===
 
 The `cuppa` wrapper masks environment values whose names match `*TOKEN*` in build output.

--- a/docs/modules/ROOT/pages/dependencies.adoc
+++ b/docs/modules/ROOT/pages/dependencies.adoc
@@ -87,6 +87,64 @@ With `--develop`, location dependencies that define a develop path use the local
 
 Relative locations ending in `@` participate in `--location-match-*` branch/tag behaviour (see xref:cli-reference.adoc[CLI reference]).
 
+== Checking your develop copies
+
+`--develop` substitutes a working copy on disk for a retrieved dependency and says nothing about the state of that copy.
+You can be building your feature branch against a dependency parked on someone else's spike branch, or against a copy that has not been pulled for months, and the only symptom is a compile error that makes no sense, a test that fails only on your machine, or one that passes only on your machine.
+A develop path that does not exist is not checked at all today: the swap happens regardless and the failure surfaces much later as a missing include.
+
+`--list-develop` reports what you are actually building against.
+It runs after dependency registration and exits without building.
+One row appears for every dependency that has a develop location configured, whether or not `--develop` is active, plus a count of those that have none:
+
+[source,shell]
+----
+cuppa -D --list-develop
+----
+
+The columns are dependency, branch, upstream, state, and path.
+Ahead and behind are relative to your last fetch, and the report says so; no remote is contacted, so the option remains available with `--offline`.
+
+Severity is the value of the option:
+
+|===
+| Situation | Severity
+
+| Branch equals the branch being built, or the default branch | ok
+| Any other branch, or detached HEAD | warning
+| Behind upstream, or diverged | warning
+| Ahead or modified, on the branch being built | note — this is the intended workflow
+| Ahead or modified, on the default branch | warning — local work that no other build will see
+| No upstream tracking branch | note — ahead and behind cannot be answered
+| Not a working copy | warning
+| Path does not exist | error
+|===
+
+Local work is only benign where the rest of the world will find it.
+Uncommitted or unpushed changes on a branch that matches the branch being built are the intended workflow: when that branch is pushed, `--location-match-current-branch` selects it and everyone else's build sees the same code.
+The same changes sitting on the default branch are a trap.
+Your build works, because `--develop` reads the working copy; every build that does not use `--develop` resolves the dependency to the published default branch and compiles something else.
+The warning names the remedy: put the work on a branch named for the branch you are building, commit it, and push it.
+
+The exit status is zero for a report, and non-zero when a develop path does not exist, because that build cannot succeed and a CI job should hear about it.
+
+`--update-develop` answers the next question after `--list-develop` tells you a copy is behind.
+It fetches each git working copy, then fast-forwards only those that are clean and strictly behind their upstream.
+Everything else is skipped and reported with the reason: ahead, diverged, modified, detached, no upstream, not a working copy, or path missing.
+
+[source,shell]
+----
+cuppa -D --update-develop
+cuppa -D --update-develop -n
+----
+
+It never stashes, resets, rewrites history, or switches branches.
+A fast-forward of a clean tree discards nothing and leaves nothing to recover from.
+`--offline` makes `--update-develop` an error rather than a silent no-op, because this is the one option in the family that needs the network.
+`-n` / `--no-exec` shows the plan and changes nothing.
+
+Subversion, Mercurial, and Bazaar copies appear in the `--list-develop` table with branch and revision from the existing SCM support; ahead, behind, and modified are reported as unknown, and `--update-develop` leaves them alone.
+
 == Conan 2 consumer (optional)
 
 Cuppa can consume Conan 2 packages through `cuppa.conan_deps` / `cuppa.conan_dependency` and apply them with `env.BuildWith`, using Conan's **SConsDeps** generator (`SConscript_conandeps` + `env.MergeFlags`).

--- a/docs/modules/ROOT/pages/dependencies.adoc
+++ b/docs/modules/ROOT/pages/dependencies.adoc
@@ -102,10 +102,72 @@ One row appears for every dependency that has a develop location configured, whe
 cuppa -D --list-develop
 ----
 
-The columns are dependency, branch, upstream, state, and path.
-Ahead and behind are relative to your last fetch, and the report says so; no remote is contacted, so the option remains available with `--offline`.
+....
+Building on branch [feature_orders] with default branch [master]; --develop is active
 
-Severity is the value of the option:
+  ---------------------------------------------------------------------------------------------
+  STATUS  DEPENDENCY  BRANCH          UPSTREAM               STATE                PATH
+  ---------------------------------------------------------------------------------------------
+  note    widget      feature_orders  origin/feature_orders  modified, 2 ahead    ~/coding/widget
+  ok      gadget      master          origin/master          clean                ~/coding/gadget
+  warn    flange      spike_cache     origin/spike_cache     clean, 12 behind     ~/coding/flange
+  error   gizmo       -               -                      path does not exist  ~/coding/gizmo
+  ---------------------------------------------------------------------------------------------
+
+4 develop locations: 1 ok, 1 note, 1 warning, 1 error; 6 dependencies not using develop
+│
+├── 1 error
+│   │
+│   └── gizmo
+│       └── has a develop path [~/coding/gizmo] that does not exist, so this build cannot
+│           succeed
+│
+├── 1 warning
+│   │
+│   └── flange
+│       ├── is on [spike_cache], which is neither [feature_orders] nor the default branch
+│       │   [master]
+│       └── is 12 commits behind [origin/spike_cache] as of your last fetch
+│
+└── 1 note
+    │
+    └── widget
+        └── has 2 unpushed commits on [feature_orders]
+
+Ahead and behind are relative to your last fetch; no remote was contacted
+Of these, --update-develop would fast-forward 1 ([flange]) as of your last fetch; it fetches
+first, so it may find more
+....
+
+The table is the inventory of what you are building against.
+Every judgement then hangs from the summary line as one tree, grouped by severity with the worst first, so reading down the tree is reading a work list: what stops the build, then what needs a decision, then what is only worth knowing.
+Each severity heading counts the dependencies beneath it, and each dependency is named once, with a gap on the stem above each name so that a dependency and its reasons read as one block.
+A reason too long for the line is wrapped to the table's right edge and the stem is carried down through the wrapped lines, so the report keeps one right edge and the tree stays a tree.
+Paths are shown the way the table shows them, with `..` segments resolved and your home directory written as `~`, because a develop location written relative to the `sconstruct` resolves to a path that is hard to recognise.
+Where the console cannot encode box drawing characters the tree falls back to ASCII.
+No remote is contacted, so the option remains available with `--offline`.
+
+The last line appears when `--update-develop` would do something with what has just been observed, and names the copies it would fast-forward.
+The decision behind it is the one `--update-develop` uses, so the line cannot offer an update that the option then declines to make.
+It can understate, because `--update-develop` fetches before deciding and a fetch can find copies that are behind without your knowing yet, which is why the line says so.
+Nothing is printed when every copy would be left alone.
+
+On a colour console the `ok` and `note` rows recede, so the rows at full strength are exactly the ones wanting attention.
+Receding is done by reduced intensity rather than by a background colour, so it works on either console, and a terminal that ignores it simply shows a plain table.
+On a light console reduced intensity applied to black text can look untouched, so grey is used there instead; set `CUPPA_CONSOLE_BACKGROUND=light` to say which console you have, since most terminals do not report it (see xref:configuration.adoc#_environment_variables[Environment variables]).
+In the judgement tree the severity, the dependency name, and the values are coloured and the prose is left plain, so a dependency or branch name can be found without reading every line.
+
+The report is written to standard output rather than to the log, because it is the result you asked for rather than commentary on producing it.
+That means a quieter build does not take pieces out of it, and `-Q` gives you the report on its own:
+
+[source,shell]
+----
+cuppa -Q -D --list-develop
+cuppa -Q -D --list-develop --raw-output > develop.txt
+----
+
+Severity appears in the `STATUS` column as well as in colour, so it survives `--raw-output` and can be searched for.
+It is the value of the option:
 
 |===
 | Situation | Severity
@@ -138,10 +200,12 @@ cuppa -D --update-develop
 cuppa -D --update-develop -n
 ----
 
+It prints the table before acting, then what it did to each copy, then the table again if anything moved, so the effect is visible rather than inferred.
 It never stashes, resets, rewrites history, or switches branches.
 A fast-forward of a clean tree discards nothing and leaves nothing to recover from.
 `--offline` makes `--update-develop` an error rather than a silent no-op, because this is the one option in the family that needs the network.
-`-n` / `--no-exec` shows the plan and changes nothing.
+`-n` / `--no-exec` shows the plan and changes nothing; because no fetch happens, the plan is judged as of your last fetch, and the report says so.
+Updating several repositories is not atomic: a failure in one is reported, the rest continue, and the exit status is non-zero.
 
 Subversion, Mercurial, and Bazaar copies appear in the `--list-develop` table with branch and revision from the existing SCM support; ahead, behind, and modified are reported as unknown, and `--update-develop` leaves them alone.
 

--- a/tests/unit/test_colourise.py
+++ b/tests/unit/test_colourise.py
@@ -1,9 +1,31 @@
 import pytest
 
-from cuppa.colourise import colour_items
+from cuppa.colourise import (
+    BRIGHT_BLACK,
+    GREY_256,
+    colour_items,
+    colouriser,
+    console_background,
+    start_subdued,
+)
 
 
 pytestmark = pytest.mark.unit
+
+
+DIM = "\x1b[2m"
+
+
+@pytest.fixture
+def plain_environment( monkeypatch ):
+    """A console that says nothing about itself, so each test states only what it is about."""
+    for variable in ( 'CUPPA_CONSOLE_BACKGROUND', 'COLORFGBG', 'TERM', 'COLORTERM' ):
+        monkeypatch.delenv( variable, raising=False )
+
+    was = colouriser.use_colour
+    colouriser.enable()
+    yield monkeypatch
+    colouriser.use_colour = was
 
 
 def test_colour_items_joins_values():
@@ -11,3 +33,46 @@ def test_colour_items_joins_values():
     assert "a" in text
     assert "b" in text
     assert "c" in text
+
+
+def test_a_console_that_says_nothing_is_not_assumed_to_be_light( plain_environment ):
+    """Dimming a dark console is safe; treating a dark console as light is not."""
+    assert console_background() == 'unknown'
+    assert start_subdued() == DIM
+
+
+@pytest.mark.parametrize( "reported,background", [
+    ( "15;0", 'dark' ),
+    ( "0;15", 'light' ),
+    ( "0;default;15", 'light' ),
+    ( "default;7", 'light' ),
+    ( "7;8", 'dark' ),
+] )
+def test_the_background_is_read_from_colorfgbg_where_a_terminal_sets_it(
+        plain_environment, reported, background ):
+    plain_environment.setenv( 'COLORFGBG', reported )
+    assert console_background() == background
+
+
+def test_the_background_can_be_declared_when_the_terminal_will_not_say( plain_environment ):
+    """Most terminals report nothing, so the setting has to be available to say it outright."""
+    plain_environment.setenv( 'COLORFGBG', "0;15" )
+    plain_environment.setenv( 'CUPPA_CONSOLE_BACKGROUND', "dark" )
+    assert console_background() == 'dark'
+
+
+def test_a_light_console_recedes_by_going_grey_rather_than_by_dimming( plain_environment ):
+    """Reduced intensity applied to black text on white can look untouched, so grey is used."""
+    plain_environment.setenv( 'CUPPA_CONSOLE_BACKGROUND', "light" )
+
+    plain_environment.setenv( 'TERM', "xterm-256color" )
+    assert start_subdued() == GREY_256
+
+    plain_environment.setenv( 'TERM', "xterm" )
+    assert start_subdued() == BRIGHT_BLACK
+
+
+def test_nothing_is_emitted_when_colour_is_off( plain_environment ):
+    plain_environment.setenv( 'CUPPA_CONSOLE_BACKGROUND', "light" )
+    colouriser.use_colour = False
+    assert start_subdued() == ''

--- a/tests/unit/test_develop.py
+++ b/tests/unit/test_develop.py
@@ -1,0 +1,433 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+"""The rules behind --list-develop and --update-develop, which are pure functions of state."""
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from cuppa.develop import (
+    ERROR,
+    NOTE,
+    OK,
+    WARNING,
+    Copy,
+    classify,
+    inspect,
+    list_develop,
+    state_summary,
+    survey,
+    table,
+    update_action,
+    update_develop,
+)
+from cuppa.location import Location, develop_location
+from cuppa.scms.git import Git
+
+
+pytestmark = pytest.mark.unit
+
+
+BUILT = "feature_orders"
+DEFAULT = "master"
+
+
+def copy( **observed ):
+    """A clean git copy on the branch being built, unless the test says otherwise."""
+    state = dict(
+        name            = "widget",
+        path            = "/home/user/coding/widget",
+        exists          = True,
+        is_working_copy = True,
+        scm             = 'git',
+        branch          = BUILT,
+        detached        = False,
+        upstream        = "origin/" + BUILT,
+        ahead           = 0,
+        behind          = 0,
+        modified        = False,
+    )
+    state.update( observed )
+    return Copy( **state )
+
+
+def severity( **observed ):
+    return classify( copy( **observed ), BUILT, DEFAULT ).severity
+
+
+def notes( **observed ):
+    return " ".join( classify( copy( **observed ), BUILT, DEFAULT ).notes )
+
+
+#-------------------------------------------------------------------------------
+#   One case per row of the classification table
+#-------------------------------------------------------------------------------
+
+def test_the_branch_being_built_is_ok():
+    assert severity( branch=BUILT ) == OK
+
+
+def test_the_default_branch_is_ok():
+    assert severity( branch=DEFAULT, upstream="origin/" + DEFAULT ) == OK
+
+
+def test_any_other_branch_warns():
+    assert severity( branch="spike_cache" ) == WARNING
+    assert "neither" in notes( branch="spike_cache" )
+
+
+def test_a_detached_head_warns():
+    assert severity( detached=True, branch=None ) == WARNING
+
+
+def test_behind_upstream_warns():
+    assert severity( behind=12 ) == WARNING
+    assert "12 commits behind" in notes( behind=12 )
+
+
+def test_diverged_warns():
+    assert severity( ahead=2, behind=3 ) == WARNING
+    assert "diverged" in notes( ahead=2, behind=3 )
+
+
+def test_ahead_on_the_branch_being_built_is_a_note():
+    assert severity( ahead=2 ) == NOTE
+
+
+def test_modified_on_the_branch_being_built_is_a_note():
+    assert severity( modified=True ) == NOTE
+
+
+def test_ahead_on_the_default_branch_warns():
+    assert severity( branch=DEFAULT, upstream="origin/" + DEFAULT, ahead=2 ) == WARNING
+
+
+def test_modified_on_the_default_branch_warns():
+    assert severity( branch=DEFAULT, upstream="origin/" + DEFAULT, modified=True ) == WARNING
+
+
+def test_no_upstream_is_a_note():
+    assert severity( upstream=None, ahead=None, behind=None ) == NOTE
+    assert "no upstream" in notes( upstream=None, ahead=None, behind=None )
+
+
+def test_a_directory_that_is_not_a_working_copy_warns():
+    assert severity( is_working_copy=False, scm=None ) == WARNING
+
+
+def test_a_missing_path_is_an_error():
+    assert severity( exists=False ) == ERROR
+
+
+def test_a_non_git_working_copy_reports_what_it_cannot_answer():
+    classification = classify(
+            copy( scm='other', upstream=None, ahead=None, behind=None, modified=None ),
+            BUILT, DEFAULT
+    )
+    assert classification.severity == NOTE
+    assert "not reported" in " ".join( classification.notes )
+
+
+#-------------------------------------------------------------------------------
+#   The pair that differ only by branch
+#-------------------------------------------------------------------------------
+
+def test_local_work_is_judged_by_the_branch_it_sits_on():
+    """Identical state, different branch: on the default branch nobody else will see the work."""
+    on_built = copy( branch=BUILT, upstream="origin/" + BUILT, modified=True, ahead=1 )
+    on_default = on_built._replace( branch=DEFAULT, upstream="origin/" + DEFAULT )
+
+    assert classify( on_built, BUILT, DEFAULT ).severity == NOTE
+    assert classify( on_default, BUILT, DEFAULT ).severity == WARNING
+
+    remedy = " ".join( classify( on_default, BUILT, DEFAULT ).notes )
+    assert "will not see them" in remedy
+    assert "push it" in remedy
+
+
+def test_the_branch_being_built_is_unknown_outside_a_working_copy():
+    """With no branch to match, only the default branch is unremarkable."""
+    assert classify( copy( branch=DEFAULT, upstream="origin/" + DEFAULT ), "", DEFAULT ).severity == OK
+    other = classify( copy( branch="anything" ), "", DEFAULT )
+    assert other.severity == WARNING
+    assert "not the default branch" in " ".join( other.notes )
+
+
+#-------------------------------------------------------------------------------
+#   What the table says
+#-------------------------------------------------------------------------------
+
+@pytest.mark.parametrize( "observed,expected", [
+    ( {}, "clean" ),
+    ( { "modified": True }, "modified" ),
+    ( { "modified": True, "ahead": 2 }, "modified, 2 ahead" ),
+    ( { "behind": 12 }, "clean, 12 behind" ),
+    ( { "ahead": 3, "behind": 2 }, "clean, 3 ahead, 2 behind" ),
+    ( { "upstream": None, "ahead": None, "behind": None }, "clean, no upstream" ),
+    ( { "is_working_copy": False }, "not a working copy" ),
+    ( { "exists": False }, "path does not exist" ),
+    ( { "scm": 'other', "modified": None, "upstream": None }, "unknown" ),
+] )
+def test_state_summary( observed, expected ):
+    assert state_summary( copy( **observed ) ) == expected
+
+
+def test_the_table_has_a_header_row_and_aligned_columns():
+    lines = table( [ copy( name="widget" ), copy( name="a_much_longer_name" ) ] )
+
+    assert lines[0].split() == [ "DEPENDENCY", "BRANCH", "UPSTREAM", "STATE", "PATH" ]
+    assert lines[0].index( "BRANCH" ) == lines[1].index( BUILT )
+    assert lines[1].index( BUILT ) == lines[2].index( BUILT )
+
+
+#-------------------------------------------------------------------------------
+#   The update decision, over the same state
+#-------------------------------------------------------------------------------
+
+def test_only_a_clean_copy_that_is_behind_is_fast_forwarded():
+    action = update_action( copy( behind=4 ) )
+    assert action.act
+    assert "4 commits behind" in action.reason
+
+
+@pytest.mark.parametrize( "observed,reason", [
+    ( { "exists": False }, "path does not exist" ),
+    ( { "is_working_copy": False }, "not a working copy" ),
+    ( { "scm": 'other' }, "only git working copies can be updated" ),
+    ( { "detached": True }, "detached HEAD" ),
+    ( { "upstream": None }, "no upstream branch" ),
+    ( { "behind": 4, "modified": True }, "uncommitted changes" ),
+    ( { "behind": 4, "ahead": 2 }, "diverged" ),
+    ( { "ahead": 2 }, "ahead of" ),
+    ( {}, "already up to date" ),
+] )
+def test_everything_else_is_skipped_with_a_reason( observed, reason ):
+    action = update_action( copy( **observed ) )
+    assert not action.act
+    assert reason in action.reason
+
+
+#-------------------------------------------------------------------------------
+#   Develop path resolution, shared with the swap it describes
+#-------------------------------------------------------------------------------
+
+def test_a_relative_develop_path_is_anchored_to_the_sconstruct_directory():
+    assert develop_location( "/project", "../widget" ) == os.path.join( "/project", "../widget" )
+
+
+def test_an_anchored_develop_path_is_resolved_against_the_sconstruct_directory():
+    assert develop_location( "/project", "#sub/widget" ) == os.path.join( "/project", "sub/widget" )
+
+
+def test_an_absolute_develop_path_is_left_alone():
+    assert develop_location( "/project", "/elsewhere/widget" ) == "/elsewhere/widget"
+
+
+def test_a_home_relative_develop_path_is_expanded_not_anchored():
+    assert develop_location( "/project", "~/coding/widget" ) == os.path.join(
+            os.path.expanduser( "~" ), "coding/widget" )
+
+
+def test_no_develop_location_resolves_to_nothing():
+    assert develop_location( "/project", None ) is None
+
+
+def test_the_swap_resolves_paths_through_the_same_helper():
+    """Location must not grow its own copy of the rule, or a report can describe another path."""
+    location = Location.__new__( Location )
+    location._cuppa_env = { 'sconstruct_dir': "/project" }
+    assert location.replace_sconstruct_anchor( "#sub/widget" ) == os.path.join(
+            "/project", "sub/widget" )
+
+
+#-------------------------------------------------------------------------------
+#   Enumeration and exit status
+#-------------------------------------------------------------------------------
+
+class FakeEnv( dict ):
+
+    def get_option( self, option, default=None ):
+        return self.get( option, default )
+
+
+def fake_env( dependencies, **overrides ):
+    env = FakeEnv( {
+        'dependencies': dependencies,
+        'sconstruct_dir': "/project",
+        'current_branch': BUILT,
+        'location_default_branch': DEFAULT,
+        'develop': True,
+        'offline': False,
+        'no_exec': False,
+    } )
+    env.update( overrides )
+    return env
+
+
+def dependency_with_develop( name, develop ):
+    return type( name, (object,), { '_name': name, '_develop': develop } )
+
+
+def test_dependencies_without_a_develop_location_are_counted_not_listed( tmp_path ):
+    env = fake_env( {
+        'widget': dependency_with_develop( 'widget', str(tmp_path) ),
+        'gadget': type( 'gadget', (object,), { '_name': 'gadget' } ),
+    } )
+
+    copies, without_develop = survey( env )
+
+    assert [ copy.name for copy in copies ] == [ 'widget' ]
+    assert without_develop == [ 'gadget' ]
+
+
+def test_a_report_exits_zero_even_when_it_warns( tmp_path ):
+    """A directory that is not a working copy is worth a warning, not a failed build."""
+    env = fake_env( { 'widget': dependency_with_develop( 'widget', str(tmp_path) ) } )
+    assert list_develop( env ) == 0
+
+
+def test_a_missing_develop_path_exits_non_zero( tmp_path ):
+    missing = str( tmp_path / "not_here" )
+    env = fake_env( { 'widget': dependency_with_develop( 'widget', missing ) } )
+    assert list_develop( env ) == 1
+
+
+def test_update_refuses_to_run_offline( tmp_path ):
+    env = fake_env( { 'widget': dependency_with_develop( 'widget', str(tmp_path) ) },
+                    offline=True )
+    assert update_develop( env ) == 1
+
+
+def test_a_dry_run_changes_nothing_and_exits_zero( tmp_path, monkeypatch ):
+    def refuse( *args, **kwargs ):
+        raise AssertionError( "a dry run must not touch the working copy" )
+
+    monkeypatch.setattr( Git, 'fetch', refuse )
+    monkeypatch.setattr( Git, 'fast_forward', refuse )
+
+    env = fake_env( { 'widget': dependency_with_develop( 'widget', str(tmp_path) ) },
+                    no_exec=True )
+    assert update_develop( env ) == 0
+
+
+#-------------------------------------------------------------------------------
+#   Observation against a real working copy
+#-------------------------------------------------------------------------------
+
+git_available = pytest.mark.skipif(
+    shutil.which( "git" ) is None, reason="git is not installed"
+)
+
+
+def git( path, *arguments ):
+    subprocess.check_output(
+        [ "git", "-c", "user.email=test@example.com", "-c", "user.name=test",
+          "-c", "commit.gpgsign=false" ] + list( arguments ),
+        cwd = str(path),
+        stderr = subprocess.STDOUT
+    )
+
+
+def commit( path, name ):
+    ( path / name ).write_text( name )
+    git( path, "add", name )
+    git( path, "commit", "-m", name )
+
+
+@pytest.fixture
+def working_copy( tmp_path ):
+    """A clone of a local origin, so ahead and behind are real without touching a network."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    git( origin, "init", "--initial-branch=master", "." )
+    commit( origin, "first" )
+
+    clone = tmp_path / "clone"
+    subprocess.check_output(
+        [ "git", "clone", str(origin), str(clone) ], stderr=subprocess.STDOUT
+    )
+    return origin, clone
+
+
+@git_available
+def test_a_clean_clone_is_observed_as_clean( working_copy ):
+    origin, clone = working_copy
+    observed = inspect( "widget", str(clone) )
+
+    assert observed.exists and observed.is_working_copy
+    assert observed.scm == 'git'
+    assert observed.branch == "master"
+    assert observed.upstream == "origin/master"
+    assert ( observed.ahead, observed.behind, observed.modified ) == ( 0, 0, False )
+
+
+@git_available
+def test_local_commits_are_observed_as_ahead( working_copy ):
+    origin, clone = working_copy
+    commit( clone, "local" )
+
+    observed = inspect( "widget", str(clone) )
+    assert ( observed.ahead, observed.behind ) == ( 1, 0 )
+    assert update_action( observed ).reason.startswith( "ahead of" )
+
+
+@git_available
+def test_upstream_commits_are_observed_as_behind_after_a_fetch( working_copy ):
+    origin, clone = working_copy
+    commit( origin, "second" )
+
+    assert inspect( "widget", str(clone) ).behind == 0, "behind is relative to the last fetch"
+
+    Git.fetch( str(clone) )
+    observed = inspect( "widget", str(clone) )
+
+    assert ( observed.ahead, observed.behind ) == ( 0, 1 )
+    assert update_action( observed ).act
+
+    Git.fast_forward( str(clone) )
+    assert inspect( "widget", str(clone) ).behind == 0
+
+
+@git_available
+def test_uncommitted_changes_are_observed_but_untracked_files_are_not( working_copy ):
+    origin, clone = working_copy
+
+    ( clone / "untracked" ).write_text( "untracked" )
+    assert inspect( "widget", str(clone) ).modified is False
+
+    ( clone / "first" ).write_text( "changed" )
+    assert inspect( "widget", str(clone) ).modified is True
+
+
+@git_available
+def test_a_detached_head_is_observed_as_detached( working_copy ):
+    origin, clone = working_copy
+    git( clone, "checkout", "--detach", "HEAD" )
+
+    observed = inspect( "widget", str(clone) )
+    assert observed.detached
+    assert observed.branch is None
+    assert not update_action( observed ).act
+
+
+@git_available
+def test_a_branch_with_no_upstream_is_observed_as_such( working_copy ):
+    origin, clone = working_copy
+    git( clone, "checkout", "-b", "spike" )
+
+    observed = inspect( "widget", str(clone) )
+    assert observed.branch == "spike"
+    assert observed.upstream is None
+    assert ( observed.ahead, observed.behind ) == ( None, None )
+
+
+@git_available
+def test_a_directory_that_is_not_a_working_copy_is_observed_as_such( tmp_path ):
+    observed = inspect( "widget", str(tmp_path) )
+    assert observed.exists
+    assert not observed.is_working_copy

--- a/tests/unit/test_develop.py
+++ b/tests/unit/test_develop.py
@@ -5,12 +5,16 @@
 
 """The rules behind --list-develop and --update-develop, which are pure functions of state."""
 
+import logging
 import os
 import shutil
 import subprocess
 
+from contextlib import contextmanager
+
 import pytest
 
+from cuppa.colourise import colouriser, start_subdued
 from cuppa.develop import (
     ERROR,
     NOTE,
@@ -18,15 +22,22 @@ from cuppa.develop import (
     WARNING,
     Copy,
     classify,
+    entries,
+    highlight_values,
     inspect,
     list_develop,
+    render_judgements,
+    render_table,
+    row_for,
     state_summary,
+    suggestion,
     survey,
     table,
     update_action,
     update_develop,
 )
 from cuppa.location import Location, develop_location
+from cuppa.log import logger
 from cuppa.scms.git import Git
 
 
@@ -35,6 +46,25 @@ pytestmark = pytest.mark.unit
 
 BUILT = "feature_orders"
 DEFAULT = "master"
+
+RESET = "\x1b[0m"
+
+STUB  = "\u2502"
+TEE   = "\u251c\u2500\u2500 "
+ELBOW = "\u2514\u2500\u2500 "
+PIPE  = "\u2502   "
+GAP   = "    "
+
+
+@contextmanager
+def colour():
+    """Colour is off by default in a test run, so a test that is about colour turns it on."""
+    was = colouriser.use_colour
+    colouriser.enable()
+    try:
+        yield start_subdued()
+    finally:
+        colouriser.use_colour = was
 
 
 def copy( **observed ):
@@ -178,11 +208,161 @@ def test_state_summary( observed, expected ):
 
 
 def test_the_table_has_a_header_row_and_aligned_columns():
-    lines = table( [ copy( name="widget" ), copy( name="a_much_longer_name" ) ] )
+    lines = table( entries( [ copy( name="widget" ), copy( name="a_much_longer_name" ) ],
+                            BUILT, DEFAULT ) )
 
-    assert lines[0].split() == [ "DEPENDENCY", "BRANCH", "UPSTREAM", "STATE", "PATH" ]
+    assert lines[0].split() == [ "STATUS", "DEPENDENCY", "BRANCH", "UPSTREAM", "STATE", "PATH" ]
     assert lines[0].index( "BRANCH" ) == lines[1].index( BUILT )
     assert lines[1].index( BUILT ) == lines[2].index( BUILT )
+
+
+def test_the_table_is_ruled_above_and_below_the_header_and_at_the_foot():
+    found = entries( [ copy( name="widget" ), copy( name="gadget" ) ], BUILT, DEFAULT )
+    lines = render_table( found )
+
+    assert lines[0] == lines[2] == lines[-1]
+    assert set( lines[0].strip() ) == { "-" }
+    assert len( lines[0] ) == max( len( row ) for row in table( found ) )
+    assert lines[1].split()[0] == "STATUS"
+    assert len( lines ) == 4 + len( found )
+
+
+def test_rows_that_need_nothing_recede_and_rows_that_need_attention_do_not():
+    """Receding, rather than a background colour, reads the same way on a light console as on a
+    dark one, and a terminal that ignores it just shows a plain table."""
+    found = entries( [ copy( name="widget" ),
+                       copy( name="flange", ahead=2 ),
+                       copy( name="gadget", behind=2 ),
+                       copy( name="gizmo", exists=False ) ], BUILT, DEFAULT )
+
+    with colour() as subdued:
+        rows = render_table( found )[3:-1]
+
+    assert [ row.startswith( subdued ) for row in rows ] == [ True, True, False, False ]
+
+
+def test_a_note_colours_the_values_and_leaves_the_prose_plain():
+    coloured = highlight_values( "[flange] is behind [origin/master] as of your last fetch",
+                                 lambda value: "<" + value + ">" )
+    assert coloured == "[<flange>] is behind [<origin/master>] as of your last fetch"
+
+
+def test_judgements_hang_from_the_summary_as_one_tree_worst_first():
+    """Reading down the tree is reading a work list: what stops the build, then what needs a
+    decision, then what is only worth knowing, all of it one tree rooted on the summary."""
+    found = entries( [ copy( name="widget" ),
+                       copy( name="flange", ahead=2 ),
+                       copy( name="doodad", detached=True, branch=None ),
+                       copy( name="gizmo", exists=False ) ], BUILT, DEFAULT )
+    lines = render_judgements( found )
+
+    assert lines[0] == STUB
+    assert lines[1] == TEE + "1 error"
+    assert lines[2] == PIPE + STUB
+    assert lines[3] == PIPE + ELBOW + "gizmo"
+    assert lines[4].startswith( PIPE + GAP + ELBOW + "has a develop path" )
+    assert lines[5] == STUB
+    assert lines[6] == TEE + "1 warning"
+    assert lines[10] == STUB
+    assert lines[11] == ELBOW + "1 note"
+    assert lines[12] == GAP + STUB
+    assert lines[13] == GAP + ELBOW + "flange"
+    assert lines[14] == GAP + GAP + ELBOW + "has 2 unpushed commits on [feature_orders]"
+
+
+def test_a_severity_heading_counts_the_dependencies_under_it():
+    """The heading answers how much of this there is before you read any of it."""
+    found = entries( [ copy( name="doodad", detached=True, branch=None ),
+                       copy( name="gadget", detached=True, branch=None ),
+                       copy( name="flange", ahead=2 ) ], BUILT, DEFAULT )
+    lines = render_judgements( found )
+
+    assert lines[1] == TEE + "2 warnings"
+    assert ELBOW + "1 note" in lines
+
+
+def test_a_severity_with_two_dependencies_keeps_the_stem_under_the_first():
+    found = entries( [ copy( name="doodad", detached=True, branch=None ),
+                       copy( name="gadget", branch="spike", upstream="origin/spike",
+                             modified=True ) ], BUILT, DEFAULT )
+    lines = render_judgements( found )
+
+    assert lines == [
+        STUB,
+        ELBOW + "2 warnings",
+        GAP + STUB,
+        GAP + TEE + "doodad",
+        GAP + PIPE + ELBOW + "is on a detached HEAD; it works today and is forgotten tomorrow",
+        GAP + STUB,
+        GAP + ELBOW + "gadget",
+        GAP + GAP + TEE + "is on [spike], which is neither [feature_orders] nor the default"
+        " branch [master]",
+        GAP + GAP + ELBOW + "has uncommitted changes on [spike]",
+    ]
+
+
+def test_the_tree_falls_back_to_ascii_when_the_console_cannot_encode_it():
+    found = entries( [ copy( name="doodad", detached=True, branch=None ) ], BUILT, DEFAULT )
+
+    assert render_judgements( found, encoding='ascii' )[:4] == [
+        "|", "`-- 1 warning", "    |", "    `-- doodad"
+    ]
+    assert render_judgements( found, encoding='utf-8' )[3] == GAP + ELBOW + "doodad"
+
+
+def test_a_long_reason_wraps_and_the_stem_is_carried_down_the_wrapped_lines():
+    """A reason that runs past the table's right edge is wrapped rather than left to wrap itself
+    at the console edge, which would break the tree."""
+    found = entries( [ copy( name="widget", branch=DEFAULT, upstream="origin/" + DEFAULT,
+                             modified=True ) ], BUILT, DEFAULT )
+    lines = render_judgements( found, width=72 )
+    reasons = lines[4:]
+
+    assert len( reasons ) > 1
+    assert reasons[0].startswith( GAP + GAP + ELBOW )
+    assert all( line.startswith( GAP + GAP + GAP ) for line in reasons[1:] )
+    assert all( len( line ) <= 72 for line in lines )
+    assert " ".join( line.lstrip( "\u2502\u251c\u2514\u2500 " ) for line in reasons ) \
+        == found[0].notes[0]
+
+
+def test_a_reason_is_not_wrapped_when_no_width_is_given():
+    found = entries( [ copy( name="widget", branch=DEFAULT, upstream="origin/" + DEFAULT,
+                             modified=True ) ], BUILT, DEFAULT )
+
+    assert render_judgements( found )[4:] == [ GAP + GAP + ELBOW + found[0].notes[0] ]
+
+
+def test_an_ok_copy_recedes_and_says_nothing_more():
+    """Nothing to be done, so nothing to draw the eye: no colour of its own, and no note."""
+    entry = entries( [ copy( name="widget" ) ], BUILT, DEFAULT )[0]
+
+    with colour() as subdued:
+        row = render_table( [ entry ] )[3]
+
+    assert row == subdued + table( [ entry ] )[1] + RESET
+    assert render_judgements( [ entry ] ) == []
+
+
+def test_a_judgement_names_a_path_the_way_the_table_does():
+    """Develop paths are usually written relative to the sconstruct, so the resolved path is full
+    of `..`. The table tidies it and the judgement about it has to agree."""
+    relative = os.path.join( os.path.expanduser( "~" ), "coding", "project", "..", "gizmo" )
+    entry = entries( [ copy( name="gizmo", path=relative, exists=False ) ], BUILT, DEFAULT )[0]
+
+    assert entry.notes[0].startswith( "has a develop path [~/coding/gizmo]" )
+    assert row_for( entry )[-1] == "~/coding/gizmo"
+
+
+def test_severity_is_a_column_so_it_survives_colourless_output():
+    """With no log prefix and no colour, the status must still be readable and greppable."""
+    rows = table( entries( [ copy( name="widget" ),
+                             copy( name="flange", behind=2 ),
+                             copy( name="gizmo", exists=False ) ], BUILT, DEFAULT ) )
+
+    assert rows[1].split()[0] == "ok"
+    assert rows[2].split()[0] == "warn"
+    assert rows[3].split()[0] == "error"
 
 
 #-------------------------------------------------------------------------------
@@ -210,6 +390,22 @@ def test_everything_else_is_skipped_with_a_reason( observed, reason ):
     action = update_action( copy( **observed ) )
     assert not action.act
     assert reason in action.reason
+
+
+def test_the_report_says_what_updating_would_do_when_it_would_do_something():
+    """The suggestion comes from update_action(), so it cannot offer what --update-develop then
+    declines to do, and it says that a fetch may find more rather than reading as a promise."""
+    advice = suggestion( [ copy( name="widget", behind=3 ),
+                           copy( name="flange", behind=1 ),
+                           copy( name="gadget", modified=True ) ] )
+
+    assert "fast-forward 2 ([widget], [flange])" in advice
+    assert "as of your last fetch" in advice
+    assert "may find more" in advice
+
+
+def test_nothing_is_suggested_when_every_copy_would_be_left_alone():
+    assert suggestion( [ copy( name="widget" ), copy( name="gadget", modified=True ) ] ) is None
 
 
 #-------------------------------------------------------------------------------
@@ -289,6 +485,33 @@ def test_a_report_exits_zero_even_when_it_warns( tmp_path ):
     """A directory that is not a working copy is worth a warning, not a failed build."""
     env = fake_env( { 'widget': dependency_with_develop( 'widget', str(tmp_path) ) } )
     assert list_develop( env ) == 0
+
+
+def test_the_report_is_written_to_standard_output( tmp_path, capsys ):
+    env = fake_env( { 'widget': dependency_with_develop( 'widget', str(tmp_path) ) } )
+    list_develop( env )
+
+    written = capsys.readouterr().out
+    assert "DEPENDENCY" in written
+    assert "widget" in written
+    assert "develop location" in written
+
+
+def test_the_report_survives_a_quiet_log_level( tmp_path, capsys ):
+    """The report is what was asked for, so a quieter log must not take pieces out of it."""
+    env = fake_env( { 'widget': dependency_with_develop( 'widget', str(tmp_path) ) } )
+
+    was = logger.level
+    logger.setLevel( logging.CRITICAL )
+    try:
+        list_develop( env )
+    finally:
+        logger.setLevel( was )
+
+    written = capsys.readouterr().out
+    assert "DEPENDENCY" in written
+    assert "not a working copy" in written
+    assert "develop location" in written
 
 
 def test_a_missing_develop_path_exits_non_zero( tmp_path ):
@@ -431,3 +654,24 @@ def test_a_directory_that_is_not_a_working_copy_is_observed_as_such( tmp_path ):
     observed = inspect( "widget", str(tmp_path) )
     assert observed.exists
     assert not observed.is_working_copy
+
+
+@git_available
+def test_listing_ends_by_saying_what_updating_would_do( working_copy, capsys ):
+    origin, clone = working_copy
+    commit( origin, "second" )
+    Git.fetch( str(clone) )
+
+    list_develop( fake_env( { 'widget': dependency_with_develop( 'widget', str(clone) ) } ) )
+
+    assert "--update-develop would fast-forward 1 ([widget])" in capsys.readouterr().out
+
+
+@git_available
+def test_updating_does_not_suggest_the_option_you_have_just_run( working_copy, capsys ):
+    origin, clone = working_copy
+    commit( origin, "second" )
+
+    update_develop( fake_env( { 'widget': dependency_with_develop( 'widget', str(clone) ) } ) )
+
+    assert "--update-develop would fast-forward" not in capsys.readouterr().out

--- a/tests/unit/test_location_options.py
+++ b/tests/unit/test_location_options.py
@@ -16,6 +16,8 @@ def test_process_location_options_copies_flags():
     env = FakeEnv(
         {
             "develop": True,
+            "list_develop": True,
+            "update_develop": False,
             "location_default_branch": "main",
             "location_match_current_branch": True,
             "location_explicit_default_branch": False,
@@ -25,6 +27,8 @@ def test_process_location_options_copies_flags():
     )
     location_options.process_location_options(env)
     assert env["develop"] is True
+    assert env["list_develop"] is True
+    assert env["update_develop"] is False
     assert env["location_default_branch"] == "main"
     assert env["location_match_current_branch"] is True
     assert env["location_explicit_default_branch"] is False


### PR DESCRIPTION
Closes #132.

`--develop` swaps a retrieved dependency for a local working copy and then says nothing about the
state of that copy. You can be building against someone else's spike branch, or a checkout that
has not been pulled since March, and the only symptom is a compile error that makes no sense, a
test that fails only on your machine, or one that passes only on your machine. A develop path
that did not exist was not checked at all: the swap happened regardless and the failure surfaced
much later as a missing include.

This adds two options that answer what you are building against, and bring forward the copies
where that cannot lose work.

## `--list-develop`

One row per dependency with a develop location configured, whether or not `--develop` is active,
followed by the judgements in full so a reason needs no column decoding. It reads working copies
only and contacts no remote, so it is available under `--offline`.

```
Building on branch [feature_orders] with default branch [master]; --develop is active

  ---------------------------------------------------------------------------------------------
  STATUS  DEPENDENCY  BRANCH          UPSTREAM               STATE                PATH
  ---------------------------------------------------------------------------------------------
  note    widget      feature_orders  origin/feature_orders  modified, 2 ahead    ~/coding/widget
  ok      gadget      master          origin/master          clean                ~/coding/gadget
  warn    flange      spike_cache     origin/spike_cache     clean, 12 behind     ~/coding/flange
  error   gizmo       -               -                      path does not exist  ~/coding/gizmo
  ---------------------------------------------------------------------------------------------

4 develop locations: 1 ok, 1 note, 1 warning, 1 error; 6 dependencies not using develop
|
+-- 1 error
|   |
|   `-- gizmo
|       `-- has a develop path [~/coding/gizmo] that does not exist, so this build cannot
|           succeed
|
+-- 1 warning
|   |
|   `-- flange
|       +-- is on [spike_cache], which is neither [feature_orders] nor the default branch
|       |   [master]
|       `-- is 12 commits behind [origin/spike_cache] as of your last fetch
|
`-- 1 note
    |
    `-- widget
        `-- has 2 unpushed commits on [feature_orders]

Ahead and behind are relative to your last fetch; no remote was contacted
Of these, --update-develop would fast-forward 1 ([flange]) as of your last fetch; it fetches
first, so it may find more
```

(The tree draws with box characters on a console that can encode them; the ASCII above is the
fallback, and what GitHub renders legibly here.)

Severity follows the table in the issue. The case worth calling out is the pair that differs only
by branch: uncommitted or unpushed work on the branch being built is a note, because pushing that
branch makes every other build see the same code, while the same work on the default branch is a
warning, because every build without `--develop` resolves the dependency to the published default
branch and compiles something else. That warning names the remedy rather than only the symptom.

Ahead and behind are relative to your last fetch and the report says so. Exit status is zero for
a report and non-zero only when a develop path does not exist, because that build cannot succeed
and a CI job should hear about it.

## `--update-develop`

Prints the table, fetches each git develop copy, then fast-forwards **only** those that are clean
and strictly behind their upstream. Ahead, diverged, modified, detached, no upstream, not a
working copy and path missing are each skipped and reported with the reason, and the table is
printed again when anything moved.

Nothing is stashed, reset, rewritten or switched: a fast-forward of a clean tree discards nothing
and leaves nothing to recover from. `--offline` makes it an error rather than a silent no-op, and
`-n` shows the plan and changes nothing.

## How the report presents itself

A report is the result you asked for rather than commentary on producing it, so it is written to
standard output rather than logged. Logging it meant `--verbosity=warn` printing the warning rows
of a table without its header, and `-Q` printing nothing at all; now `cuppa -Q -D --list-develop`
gives you the report on its own. Severity is a `STATUS` column as well as a colour, so it
survives `--raw-output`.

The rest follows from wanting the report to be scannable rather than merely complete:

- **Severity drives emphasis.** `ok` and `note` rows recede, so the rows at full strength are
  exactly the ones wanting attention. Receding uses reduced intensity rather than a background
  colour, which reads the same on a light console as on a dark one.
- **A light console goes grey instead.** Reduced intensity applied to black text on white can
  look untouched, so grey is used there. `COLORFGBG` is read where a terminal sets it, and the
  new `CUPPA_CONSOLE_BACKGROUND=light|dark` says so outright, since most terminals report
  nothing. This is the one new configuration surface in the pull request.
- **The judgements are one tree.** They hang from the summary line, grouped by severity with the
  worst first and counted in each heading, so reading down the tree is reading a work list. Each
  dependency is named once, and long reasons wrap to the table's right edge with the stem carried
  down the wrapped lines.
- **Paths read the way the table shows them.** A develop clause written relative to the
  `sconstruct` resolves to a path full of `..` segments; both the table and the judgement about
  it show the tidied path with `~` for home.
- **The report closes by saying what updating would do**, naming the copies `--update-develop`
  would fast-forward. The line comes from the same decision function that option uses, so the two
  cannot disagree, and it says the count is as of your last fetch because a fetch may find more.

## Structure

| Piece | Where |
|-------|-------|
| The rules | `cuppa/develop.py`: `classify()` and `update_action()`, pure functions of observed state |
| Observation | `Git.get_working_copy_state()`, plus `fetch()` and `fast_forward()`, in `cuppa/scms/git.py` |
| Path resolution | `develop_location()` in `cuppa/location.py`, now used by both the report and the develop swap |
| Presentation | `render_table()`, `render_judgements()` and `suggestion()` in `cuppa/develop.py`, over `Colouriser.subdue()` in `cuppa/colourise.py` |
| Wiring | Registered with the other location options, run after dependency registration, exits the way `--dump` does |

Keeping the decisions pure is what stops the two options judging the same copy differently, and
it is what makes a test per row of the classification table possible without a repository.
Subversion, Mercurial and Bazaar copies appear with branch and revision from the existing SCM
support and `unknown` for the rest; `--update-develop` leaves them alone.

## Fixed along the way

Extracting the develop path resolution exposed that a develop path of `~/coding/widget` or
`#sub/widget` was treated as relative to the sconstruct directory, producing
`/project/~/coding/widget`. Home-relative and explicitly anchored paths are now recognised before
anchoring. The real flow was mostly unaffected, because `location_id()` expands `~` before
`Location` sees it, but the helper is now correct for every caller — including the new report.

`AutoFlushWriter` in `cuppa/output.py` now delegates attribute lookups to the stream it wraps, so
`sys.stdout.encoding` is answerable through it. Without that, the console's encoding could not be
detected and the tree fell back to ASCII on a UTF-8 terminal.

## Testing

- `tests/unit/test_develop.py`: one case per row of the classification table, the pair that
  differs only by branch, the state column, the update decision for every skip reason, develop
  path resolution including `~`, `#`, relative and absolute forms, enumeration, exit status, the
  `--offline` refusal, and a dry run that fails if it touches a working copy. Observation is
  covered against real local clones (clean, ahead, behind after a fetch, modified versus
  untracked, detached, no upstream), so no network is needed.
- Presentation is tested as data rather than as a screenshot: the table rules and which rows
  recede, the tree shape including the stem under a non-final dependency, the counted headings,
  wrapping with the stem carried down, the ASCII fallback, path agreement between table and
  judgement, and that the closing suggestion appears for `--list-develop` and not for
  `--update-develop`.
- `tests/unit/test_colourise.py`: `COLORFGBG` parsing, the `CUPPA_CONSOLE_BACKGROUND` override,
  grey rather than dim on a light console, and nothing emitted when colour is off.
- 412 unit tests pass; `flake8 cuppa` and `pylint -E cuppa` are clean.
- Manually exercised against a project with develop copies in each interesting state, checking
  the table, the exit statuses, the dry run, the `--offline` refusal, both console backgrounds,
  and that only the clean copy that was behind moved.

## Documentation

`dependencies.adoc` gains "Checking your develop copies" covering both options, what each state
means, how the report presents itself, and the one thing `--update-develop` changes.
`configuration.adoc` documents `CUPPA_CONSOLE_BACKGROUND`. `cli-reference.adoc`, `AGENTS.md`,
`ROADMAP.md`, `design/README.md` and the plan are updated, and `CHANGELOG.md` records both
options under `[1.4.0]`.

## Follow-on, not in this pull request

Using `--list-develop` surfaced the one case it can only report on: a develop path that is
configured and not on disk. `design/plans/removal-options.md` §3.7 records the design for
`--clone-develop`, filed as #138. This pull request also adds a short `AGENTS.md` section stating
that commit messages carry no trailers.
