### PR TITLE
Name the storage roots for what they hold and share them by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,24 @@ from scripts.github_helpers import create_pull_request
 create_pull_request( title='…', body='…', labels=['impact:minor'] )
 ```
 
+### After pushing a pull request branch
+
+After `git push -u origin HEAD` (or any later push to an open PR), **do not stop without knowing
+how CI finished**. The person should not be the first to discover a red check. Poll until the
+checks complete, then report the outcome and be ready to decide next steps — merge discussion if
+green, diagnosis and a fix if red.
+
+```sh
+python -m scripts.github_helpers watch-pr          # current branch's open PR
+python -m scripts.github_helpers watch-pr --pr 139
+python -m scripts.github_helpers pr-status --pr 139   # one snapshot; no wait
+```
+
+Exit codes: `0` all checks succeeded (or were skipped / neutral), `1` at least one failed, `2`
+still pending (`pr-status` only), `3` timed out while still pending (`watch-pr`). Prefer
+`watch-pr` after a push; use `pr-status` when you only need a snapshot. Grow this helper if the
+same follow-up (for example fetching a failed job log) starts repeating.
+
 Be clear about what sealing buys. It makes the stored file meaningless anywhere else — in a backup,
 a synced folder, or a pasted diff. It does **not** stop a process running as you from asking the
 helper for the token, because unattended decryption means the helper answers whoever asks. That

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,16 +110,21 @@ Otherwise, follow the shape already in the log:
 
 ## GitHub access
 
+**Do not use the `gh` CLI.** It is not authenticated in this environment and is not the path these
+notes set up. For authenticated writes use `scripts.github_api` (and the helpers below). For
+anonymous reads use the public GitHub HTTP API, `curl`, or `urllib` — still not `gh`.
+
 Cuppa is a public repository, so anything that only reads it — issue lists, issue bodies, pull
 request state — needs no credential at all. Use the public API anonymously and do not ask for a
 token. A token is only for **writing**: filing or editing issues, applying labels, commenting on
-pull requests.
+pull requests. Pushing a branch is ordinary `git push -u origin HEAD`; that does not need this
+credential.
 
-Having one is optional. If you want an agent to write on your behalf, set it up as follows; tokens
-are personal, so mint your own rather than reusing anyone else's, and what an agent did stays
-attributable to you while revoking it affects nobody else. Agents: when no credential is present,
-that is not a blocker — say what needs filing, labelling, or commenting, and leave it to the
-person.
+Having a token is optional. If you want an agent to write on your behalf, set it up as follows;
+tokens are personal, so mint your own rather than reusing anyone else's, and what an agent did
+stays attributable to you while revoking it affects nobody else. Agents: when no credential is
+present, that is not a blocker — say what needs filing, labelling, or commenting, and leave it to
+the person.
 
 ### Creating the token
 
@@ -155,7 +160,8 @@ work on a machine with no TPM.
 
 ### Using it
 
-One helper reads the credential into the calling process, never into the environment:
+`scripts.github_api` is the credential and transport layer. It reads the sealed token into the
+calling process only — never into the environment — and makes authenticated API calls:
 
 ```sh
 python -m scripts.github_api GET /repos/ja11sop/cuppa/issues/132
@@ -164,6 +170,21 @@ python -m scripts.github_api GET /repos/ja11sop/cuppa/issues/132
 ```python
 from scripts.github_api import GitHub
 GitHub().request( 'POST', '/repos/ja11sop/cuppa/issues/132/labels', { 'labels': [ 'bug' ] } )
+```
+
+Repeated write workflows live in `scripts.github_helpers` so agents do not rewrite the same API
+sequence each time. Add to that module when the same sequence appears twice; do not invent helpers
+for a one-off. Opening a pull request for the current branch (and applying labels such as
+`impact:minor`) is already there:
+
+```sh
+python -m scripts.github_helpers create-pr \
+    --title "…" --body-file /tmp/pr.md --label impact:minor
+```
+
+```python
+from scripts.github_helpers import create_pull_request
+create_pull_request( title='…', body='…', labels=['impact:minor'] )
 ```
 
 Be clear about what sealing buys. It makes the stored file meaningless anywhere else — in a backup,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,8 +202,9 @@ Equivalent: `scons -D …` when the project's `sconstruct` already imports cuppa
 | Purpose | Default |
 |---------|---------|
 | Build root | `_build` |
-| Download root | `_cuppa` |
-| Cache root | `~/_cuppa/_cache` |
+| Storage root | `~/.cuppa` |
+| Dependencies root | `~/.cuppa/dependencies` (`--dependencies-root`, was `--download-root`) |
+| Downloads root | `~/.cuppa/downloads` (`--downloads-root`, was `--cache-root`) |
 | Project conf | `configure.conf` |
 | Global conf | `~/.cuppaconfig` |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,10 +115,10 @@ notes set up. For authenticated writes use `scripts.github_api` (and the helpers
 anonymous reads use the public GitHub HTTP API, `curl`, or `urllib` — still not `gh`.
 
 Cuppa is a public repository, so anything that only reads it — issue lists, issue bodies, pull
-request state — needs no credential at all. Use the public API anonymously and do not ask for a
-token. A token is only for **writing**: filing or editing issues, applying labels, commenting on
-pull requests. Pushing a branch is ordinary `git push -u origin HEAD`; that does not need this
-credential.
+request state, check runs — needs no credential at all. Use the public API anonymously
+(`GitHub.public()` / `pr-status` / `watch-pr`) and do not ask for a token. A token is only for
+**writing**: filing or editing issues, applying labels, commenting on pull requests. Pushing a
+branch is ordinary `git push -u origin HEAD`; that does not need this credential either.
 
 Having a token is optional. If you want an agent to write on your behalf, set it up as follows;
 tokens are personal, so mint your own rather than reusing anyone else's, and what an agent did
@@ -199,6 +199,10 @@ python -m scripts.github_helpers watch-pr          # current branch's open PR
 python -m scripts.github_helpers watch-pr --pr 139
 python -m scripts.github_helpers pr-status --pr 139   # one snapshot; no wait
 ```
+
+These status helpers read the public API anonymously — they do **not** unseal the token. Owner and
+repository come from the local `origin` remote. The default poll interval is three minutes; that
+matters less without a seal, but still keeps the noise down on long integration runs.
 
 Exit codes: `0` all checks succeeded (or were skipped / neutral), `1` at least one failed, `2`
 still pending (`pr-status` only), `3` timed out while still pending (`watch-pr`). Prefer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,8 +201,7 @@ python -m scripts.github_helpers pr-status --pr 139   # one snapshot; no wait
 ```
 
 These status helpers read the public API anonymously — they do **not** unseal the token. Owner and
-repository come from the local `origin` remote. The default poll interval is three minutes; that
-matters less without a seal, but still keeps the noise down on long integration runs.
+repository come from the local `origin` remote. The default poll interval is thirty seconds.
 
 Exit codes: `0` all checks succeeded (or were skipped / neutral), `1` at least one failed, `2`
 still pending (`pr-status` only), `3` timed out while still pending (`watch-pr`). Prefer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,14 +27,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clean and strictly behind their upstream. Modified, ahead, diverged, and detached copies are
   left alone and reported. It refuses under `--offline`, and `-n` shows the plan without changing
   anything (#132).
+- `--storage-root` names the parent of the dependencies and downloads roots, so one flag moves
+  cuppa's storage as a whole. `--dependencies-root` and `--downloads-root` set either root on its
+  own and leave the other derived from the storage root. `--storage-root=_cuppa` keeps everything
+  a build retrieves inside the project (#133).
+- The dependencies and downloads roots are named at info level the first time a run retrieves
+  anything, so where a build is reading from and writing to is visible in its output (#133).
 
 ### Changed
 
 - `cuppa/VERSION` carries a `.dev` suffix while a release is being assembled, so a build from a
   checkout between releases reports, for example, `cuppa: version 1.4.0.dev` rather than claiming
   to be the last release. Released versions are unchanged.
+- Retrieved dependency trees and downloaded archives now default to `~/.cuppa/dependencies` and
+  `~/.cuppa/downloads`, shared between projects. Previously dependencies went into a `_cuppa`
+  folder inside each project, so the same library was retrieved again for every project that used
+  it. Where a `_cuppa` folder beside your sconstruct, or a `~/_cuppa/_download` or `~/_cuppa/_cache`
+  from an earlier cuppa, already exists and you have not named a root yourself, cuppa keeps using
+  it and says so once, so upgrading does not trigger a re-fetch. Pass `--storage-root=_cuppa` to
+  keep the previous project-local arrangement (#133).
+- The environment keys are `storage_root`, `dependencies_root`, and `downloads_root`.
+  `download_root` and `cache_root` remain as aliases of the resolved values, so a dependency
+  plugin reading them keeps working (#133).
 
 ### Deprecated
+
+- `--download-root` and `--cache-root` are deprecated in favour of `--dependencies-root` and
+  `--downloads-root`. They still choose the same roots, and cuppa names the replacement when one
+  is used (#133).
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Full reference documentation: **[https://ja11sop.github.io/cuppa/](https://ja11s
 - Make-like CLI via `cuppa` or `scons` with cuppa loaded in the `sconstruct`
 - Multi-variant builds: debug (`--dbg`), release (`--rel`), coverage (`--cov`, GCC/Clang)
 - Multi-toolchain: GCC, Clang, and MSVC (`vc` on Windows), with wildcards (`--toolchains=gcc*,clang21`)
-- Out-of-tree builds under `_build/` (downloads under `_cuppa/`, archive cache under `~/_cuppa/_cache`)
+- Out-of-tree builds under `_build/`, with dependencies and downloads shared under `~/.cuppa/`
 - Dependencies: Boost, Qt4/Qt5, Quince, location-based libraries, GitLab package registry
 - Test runners and HTML coverage (gcovr), plus optional HTML test reports
 - Optional C++20 modules (`--modules`): named modules, partitions, header units, `import std` where supported
@@ -128,8 +128,11 @@ See the [CLI reference](https://ja11sop.github.io/cuppa/cuppa/cli-reference.html
 | Purpose | Default | Override |
 |---------|---------|----------|
 | Build output | `_build` | `--build-root` |
-| Downloads / checkouts | `_cuppa` | `--download-root` |
-| Archive cache | `~/_cuppa/_cache` | `--cache-root` |
+| Dependency trees | `~/.cuppa/dependencies` | `--dependencies-root` |
+| Downloaded archives | `~/.cuppa/downloads` | `--downloads-root` |
+
+The last two are shared between projects. `--storage-root` moves both together, so
+`--storage-root=_cuppa` keeps all storage inside the project.
 
 Layout under the build root:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -246,6 +246,7 @@ mechanics: [`design/plans/removal-options.md`](design/plans/removal-options.md).
 |------------|--------|
 | `--clean` removes the current variant's build outputs | Yes |
 | `--list-develop` / `--update-develop` for the working copies `--develop` builds against | Yes — [#132](https://github.com/ja11sop/cuppa/issues/132) |
+| Shared storage under `~/.cuppa`, named `--dependencies-root` / `--downloads-root`, with `--storage-root` to move both | Yes — [#133](https://github.com/ja11sop/cuppa/issues/133) |
 | Remove a whole build tree, a dependency, or a stale download | No — manual deletion |
 | See what is stored, where, and how large it is | No |
 
@@ -253,7 +254,6 @@ mechanics: [`design/plans/removal-options.md`](design/plans/removal-options.md).
 
 | ID | Work | Priority | Notes |
 |----|------|----------|-------|
-| `storage-roots` | Rename to `--dependencies-root` / `--downloads-root`, add `--storage-root`, default to `~/.cuppa` | High | Old options kept as deprecated aliases; existing trees still used. GitHub [#133](https://github.com/ja11sop/cuppa/issues/133) |
 | `storage-listing-removal` | `--list-*`, `--remove-*`, `--purge-*` for builds, dependencies, and downloads | Medium | Depends on the rename so one vocabulary is used throughout. GitHub [#134](https://github.com/ja11sop/cuppa/issues/134) |
 | `develop-clone` | `--clone-develop` for a develop working copy that is configured but not yet on disk, for a new machine or a dependency added since you last looked | Medium | Surface settled, remaining design to finalise first: pinned locations, submodules, whether retrieval machinery is reused. [`design/plans/removal-options.md`](design/plans/removal-options.md) §3.7. GitHub [#138](https://github.com/ja11sop/cuppa/issues/138) |
 | `artefact-removal` | Decide how to remove artefacts written outside the build root | Low | Design pass first; `--remove-build` deliberately stops at `_build`. GitHub [#135](https://github.com/ja11sop/cuppa/issues/135) |

--- a/cuppa/build_with_conan.py
+++ b/cuppa/build_with_conan.py
@@ -614,8 +614,8 @@ class base( object ):
         return digest, settings
 
     def _install_root( self, env ):
-        download_root = env.get( 'download_root' ) or os.path.join( os.getcwd(), '_cuppa' )
-        return os.path.join( os.path.expanduser( download_root ), 'conan', self._name )
+        dependencies_root = env.get( 'dependencies_root' ) or os.path.join( os.getcwd(), '_cuppa' )
+        return os.path.join( os.path.expanduser( dependencies_root ), 'conan', self._name )
 
     def _ensure_installed( self, env, toolchain, variant ):
         import SCons.Errors

--- a/cuppa/construct.py
+++ b/cuppa/construct.py
@@ -237,8 +237,9 @@ class Construct(object):
                 'base_path',
                 'branch_root',
                 'branch_dir',
-                'download_root',
-                'cache_root',
+                'storage_root',
+                'dependencies_root',
+                'downloads_root',
                 'thirdparty',
                 'build_root',
                 'default_dependencies',
@@ -788,9 +789,12 @@ class Construct(object):
             element = next( e for e in path.split(os.path.sep) if e )
             return element == ".."
 
-        exclude_dirs = [ re.escape(d) for d in exclude_dirs if not os.path.isabs(d) and not up_dir(d) ]
-        exclude_dirs = "|".join( exclude_dirs )
-        exclude_dirs_regex = re.compile( exclude_dirs, re.IGNORECASE )
+        exclude_dirs = [ re.escape(d) for d in exclude_dirs if d and not os.path.isabs(d) and not up_dir(d) ]
+
+        # An empty alternation matches every folder, which would discard the whole tree. Nothing
+        # to exclude is now the common case, because the dependencies root is outside the project
+        # by default and absolute paths are already skipped above.
+        exclude_dirs_regex = exclude_dirs and re.compile( "|".join( exclude_dirs ), re.IGNORECASE ) or None
 
         return cuppa.recursive_glob.glob(
                 path,
@@ -843,7 +847,7 @@ class Construct(object):
             if not projects or not cuppa_env['run_from_launch_dir']:
                 sub_sconscripts = self.get_sub_sconscripts(
                         cuppa_env['launch_dir'],
-                        [ cuppa_env['build_root'], cuppa_env['download_root'] ]
+                        [ cuppa_env['build_root'], cuppa_env['dependencies_root'] ]
                 )
                 if sub_sconscripts:
                     projects = sub_sconscripts
@@ -867,7 +871,7 @@ class Construct(object):
                         if os.path.isdir( path ):
                             sub_sconscripts = self.get_sub_sconscripts(
                                 project,
-                                [ cuppa_env['build_root'], cuppa_env['download_root'] ]
+                                [ cuppa_env['build_root'], cuppa_env['dependencies_root'] ]
                             )
                             if sub_sconscripts:
                                 logger.info( "Reading project folder [{}] and using sub-sconscripts [{}]".format(
@@ -880,7 +884,7 @@ class Construct(object):
                 elif os.path.exists( project ) and os.path.isdir( project ):
                     sub_sconscripts = self.get_sub_sconscripts(
                             project,
-                            [ cuppa_env['build_root'], cuppa_env['download_root'] ]
+                            [ cuppa_env['build_root'], cuppa_env['dependencies_root'] ]
                     )
                     if sub_sconscripts:
                         logger.info( "Reading project folder [{}] and using sub-sconscripts [{}]".format(

--- a/cuppa/core/storage_options.py
+++ b/cuppa/core/storage_options.py
@@ -1,4 +1,4 @@
-#          Copyright Jamie Allsop 2018-2018
+#          Copyright Jamie Allsop 2018-2026
 # Distributed under the Boost Software License, Version 1.0.
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)
@@ -7,21 +7,49 @@
 #   Storage Options
 #-------------------------------------------------------------------------------
 
+"""Where cuppa keeps what it builds, retrieves, and downloads.
+
+Three roots, decided in one place. `build_root` is the project's own output and stays
+project-relative. `dependencies_root` holds ready-to-use dependency trees and `downloads_root`
+holds the archives they came from; both are shared between projects by default and both derive
+from `storage_root` unless set individually.
+
+`resolve_root()` is the whole rule, so no subsystem re-implements the precedence and a report can
+never describe a path a build then ignores. It is a pure function of the values it is handed,
+which is what makes the precedence, the deprecated aliases, and the fallback to an older location
+testable without a filesystem beyond a directory check.
+"""
+
 # Python Standard
 import os
 
+from collections import namedtuple
+
 # Cuppa
-from cuppa.colourise import as_error
+from cuppa.colourise import as_error, as_info, as_notice
 from cuppa.log import logger
 
 
 
 class default(object):
 
-    build_root    = '_build'
-    download_root = '_cuppa'
-    cache_root    = '~/_cuppa/_cache'
+    build_root   = '_build'
+    storage_root = '~/.cuppa'
+    dependencies = 'dependencies'
+    downloads    = 'downloads'
 
+
+# Where a previous cuppa kept these. Honouring an existing tree matters more here than it would
+# for a pure rename, because the default location moves as well as the name: a machine that has
+# already retrieved everything must not silently re-fetch it into ~/.cuppa. The project-local
+# folder is listed first because that, not the shared one, is what the old default produced.
+LEGACY_DEPENDENCIES = ( '_cuppa', '~/_cuppa/_download' )
+LEGACY_DOWNLOADS    = ( '~/_cuppa/_cache', )
+
+
+# How a root was decided, so the caller can say so without repeating the rule. `origin` names the
+# thing that decided it: an option name, or the older folder that is being kept in use.
+Resolved = namedtuple( 'Resolved', [ 'path', 'source', 'origin' ] )
 
 
 def add_storage_options( add_option ):
@@ -31,33 +59,161 @@ def add_storage_options( add_option ):
                             help="The root directory for build output. If not specified"
                                  " then " +  default.build_root + " is used" )
 
+    add_option( '--storage-root', type='string', nargs=1, action='store',
+                            dest='storage_root',
+                            help="The parent directory for the dependencies and downloads roots."
+                                 " If not specified then " + default.storage_root + " is used."
+                                 " Set this to a path inside your project, for example"
+                                 " --storage-root=_cuppa, to keep all storage with the project" )
+
+    add_option( '--dependencies-root', type='string', nargs=1, action='store',
+                            dest='dependencies_root',
+                            help="The root directory holding retrieved dependency trees ready to"
+                                 " build against. If not specified then <storage-root>/"
+                                 + default.dependencies + " is used" )
+
+    add_option( '--downloads-root', type='string', nargs=1, action='store',
+                            dest='downloads_root',
+                            help="The root directory holding downloaded archives. If not"
+                                 " specified then <storage-root>/" + default.downloads
+                                 + " is used" )
+
     add_option( '--download-root', type='string', nargs=1, action='store',
                             dest='download_root',
-                            help="The root directory for downloading external libraries to."
-                                 " If not specified then " +  default.download_root + " is used" )
+                            help="Deprecated alias for --dependencies-root" )
 
     add_option( '--cache-root', type='string', nargs=1, action='store',
                             dest='cache_root',
-                            help="The root directory for caching downloaded external archived libraries."
-                                 " If not specified then " +  default.cache_root + " is used" )
+                            help="Deprecated alias for --downloads-root" )
 
+
+
+def normal_path( path ):
+    return os.path.normpath( os.path.expanduser( path ) )
+
+
+def existing_legacy_root( candidates, anchor ):
+    """The first older location that is actually there, in the form it was written in.
+
+    A relative candidate is tested against the project but returned relative, because the
+    dependencies root is excluded from sconscript discovery by folder name and only a relative
+    name matches. Resolving it here would quietly start scanning retrieved trees for sconscripts.
+    """
+    for candidate in candidates:
+        path = normal_path( candidate )
+        located = path if os.path.isabs( path ) else os.path.join( anchor or '', path )
+        if os.path.isdir( located ):
+            return path
+    return None
+
+
+def resolve_root( option, alias, legacy, derived, anchor=None ):
+    """Where a storage root is, and what decided it.
+
+    An explicit value wins; then a deprecated alias, which means the same thing said by an older
+    name; then an older location that already holds something, so an upgrade does not re-fetch a
+    machine's worth of dependencies; then the value derived from the storage root.
+    """
+    if option:
+        return Resolved( normal_path( option ), 'option', None )
+
+    if alias:
+        return Resolved( normal_path( alias ), 'deprecated', None )
+
+    kept = existing_legacy_root( legacy, anchor )
+    if kept:
+        return Resolved( kept, 'legacy', kept )
+
+    return Resolved( normal_path( derived ), 'derived', None )
+
+
+def report( resolved, name, deprecated_option, replaced_by ):
+    """Say how a root was decided when the reason is something to act on.
+
+    Using an old option name is a deprecation, which is the reader's to fix. Keeping an older
+    folder is cuppa choosing for them so that nothing is re-fetched, which they have not done
+    anything wrong to deserve, but do need to know about.
+    """
+    if resolved.source == 'deprecated':
+        logger.warn( "[{}] is deprecated, use [{}] instead. Using [{}] for {}".format(
+                as_notice( deprecated_option ),
+                as_info( replaced_by ),
+                as_notice( resolved.path ),
+                name
+        ) )
+    elif resolved.source == 'legacy':
+        logger.info( "Using the existing [{}] for {} rather than the new default. Move it and"
+                     " set [{}] when you want the new location".format(
+                as_notice( resolved.origin ),
+                name,
+                as_info( replaced_by )
+        ) )
 
 
 def process_storage_options( cuppa_env ):
 
-        def get_normal_path( option, defaults_to ):
-            path = cuppa_env.get_option( option, default=defaults_to )
-            return os.path.normpath( os.path.expanduser( path ) )
+    build_root = cuppa_env.get_option( 'build_root', default=default.build_root )
 
-        cuppa_env['build_root']     = get_normal_path( 'build_root', default.build_root )
-        cuppa_env['abs_build_root'] = os.path.abspath( cuppa_env['build_root'] )
-        cuppa_env['download_root']  = get_normal_path( 'download_root', default.download_root )
-        cuppa_env['cache_root']     = get_normal_path( 'cache_root', default.cache_root )
+    cuppa_env['build_root']     = normal_path( build_root )
+    cuppa_env['abs_build_root'] = os.path.abspath( cuppa_env['build_root'] )
 
-        if not os.path.exists( cuppa_env['cache_root'] ):
-            try:
-                os.makedirs( cuppa_env['cache_root'] )
-            except os.error as e:
-                logger.error( "Creating cache_root directory [{}] failed with error: {}"
-                             .format( cuppa_env['cache_root'], as_error(str(e)) ) )
-                raise
+    storage_root = normal_path(
+            cuppa_env.get_option( 'storage_root', default=default.storage_root ) )
+
+    anchor = cuppa_env.get( 'sconstruct_dir' )
+
+    dependencies = resolve_root(
+            cuppa_env.get_option( 'dependencies_root' ),
+            cuppa_env.get_option( 'download_root' ),
+            LEGACY_DEPENDENCIES,
+            os.path.join( storage_root, default.dependencies ),
+            anchor
+    )
+
+    downloads = resolve_root(
+            cuppa_env.get_option( 'downloads_root' ),
+            cuppa_env.get_option( 'cache_root' ),
+            LEGACY_DOWNLOADS,
+            os.path.join( storage_root, default.downloads ),
+            anchor
+    )
+
+    report( dependencies, "dependencies", "--download-root", "--dependencies-root" )
+    report( downloads, "downloads", "--cache-root", "--downloads-root" )
+
+    cuppa_env['storage_root']      = storage_root
+    cuppa_env['dependencies_root'] = dependencies.path
+    cuppa_env['downloads_root']    = downloads.path
+
+    # The old keys stay as aliases of the resolved values for at least one minor release, so a
+    # third-party dependency plugin reading env['download_root'] keeps working through the rename.
+    cuppa_env['download_root']     = dependencies.path
+    cuppa_env['cache_root']        = downloads.path
+
+    cuppa_env['storage_roots_reported'] = False
+
+    if not os.path.exists( cuppa_env['downloads_root'] ):
+        try:
+            os.makedirs( cuppa_env['downloads_root'] )
+        except os.error as e:
+            logger.error( "Creating downloads_root directory [{}] failed with error: {}"
+                         .format( cuppa_env['downloads_root'], as_error(str(e)) ) )
+            raise
+
+
+def report_roots( cuppa_env ):
+    """Name the roots the first time a run reaches for one.
+
+    They are shared between projects and hidden by default, so where they are needs to be visible
+    in build output rather than only in documentation. Saying it on the first retrieval, rather
+    than on every run, keeps it where it means something.
+    """
+    if cuppa_env.get( 'storage_roots_reported' ):
+        return
+
+    cuppa_env['storage_roots_reported'] = True
+
+    logger.info( "Using [{}] for dependencies and [{}] for downloads".format(
+            as_info( os.path.abspath( os.path.expanduser( cuppa_env['dependencies_root'] ) ) ),
+            as_info( os.path.abspath( os.path.expanduser( cuppa_env['downloads_root'] ) ) )
+    ) )

--- a/cuppa/location.py
+++ b/cuppa/location.py
@@ -38,6 +38,8 @@ import logging
 
 from .scms import scms, subversion, git, mercurial, bazaar
 
+import cuppa.core.storage_options
+
 from cuppa.colourise import as_notice, as_info, as_warning, as_error, as_info_label
 from cuppa.log import logger, register_secret
 from cuppa.path import split_common
@@ -330,7 +332,7 @@ class Location(object):
             return local_directory
 
         # If not we then check to see if we cached the download
-        cached_archive = self.get_cached_archive( self._cuppa_env['cache_root'], self._local_folder )
+        cached_archive = self.get_cached_archive( self._cuppa_env['downloads_root'], self._local_folder )
         if cached_archive:
             logger.debug( "Cached archive [{}] found for [{}]".format(
                     as_info( cached_archive ),
@@ -350,8 +352,8 @@ class Location(object):
                         as_info( filename )
                 ) )
                 self.extract( filename, local_dir_with_sub_dir )
-                if self._cuppa_env['cache_root']:
-                    cached_archive = os.path.join( self._cuppa_env['cache_root'], self._local_folder )
+                if self._cuppa_env['downloads_root']:
+                    cached_archive = os.path.join( self._cuppa_env['downloads_root'], self._local_folder )
                     logger.debug( "Caching downloaded file as [{}]".format( as_info( cached_archive ) ) )
                     shutil.copyfile( filename, cached_archive )
             except ContentTooShortError as error:
@@ -534,6 +536,8 @@ class Location(object):
 
     def get_local_directory( self, location, sub_dir, branch_path, full_url ):
 
+        cuppa.core.storage_options.report_roots( self._cuppa_env )
+
         reason = self.retrieval_disabled_reason()
 
         logger.debug( "Determine local directory for [{location}] when {retrieval}".format(
@@ -543,7 +547,7 @@ class Location(object):
 
         local_directory = None
 
-        base = self._cuppa_env['download_root']
+        base = self._cuppa_env['dependencies_root']
         if not os.path.isabs( base ):
             base = os.path.join( self._cuppa_env['working_dir'], base )
 

--- a/cuppa/methods/coverage.py
+++ b/cuppa/methods/coverage.py
@@ -35,8 +35,8 @@ class CoverageMethod(object):
 
         exclude_dependency_pattern = None
         if exclude_dependencies:
-            exclude_dependency_pattern = re.escape( env['download_root'] ).replace( r"\_", r"_" ).replace( r"\#", r"#" )
-            if os.path.isabs( env['download_root'] ):
+            exclude_dependency_pattern = re.escape( env['dependencies_root'] ).replace( r"\_", r"_" ).replace( r"\#", r"#" )
+            if os.path.isabs( env['dependencies_root'] ):
                 exclude_dependency_pattern = exclude_dependency_pattern + "#.*"
             else:
                 exclude_dependency_pattern = ".*##" + exclude_dependency_pattern + "#.*"

--- a/cuppa/methods/relative_recursive_glob.py
+++ b/cuppa/methods/relative_recursive_glob.py
@@ -61,7 +61,7 @@ class RecursiveGlobMethod:
         start, rel_start, base_path = relative_start( env, start, self.default )
 
         if exclude_dirs == self.default:
-            exclude_dirs = [ env['download_root'], env['build_root' ] ]
+            exclude_dirs = [ env['dependencies_root'], env['build_root' ] ]
 
         exclude_dirs_regex = None
 
@@ -69,9 +69,10 @@ class RecursiveGlobMethod:
             def up_dir( path ):
                 element = next( e for e in path.split(os.path.sep) if e )
                 return element == ".."
-            exclude_dirs = [ re.escape(d) for d in exclude_dirs if not os.path.isabs(d) and not up_dir(d) ]
-            exclude_dirs = "|".join( exclude_dirs )
-            exclude_dirs_regex = re.compile( exclude_dirs )
+            exclude_dirs = [ re.escape(d) for d in exclude_dirs if d and not os.path.isabs(d) and not up_dir(d) ]
+            # An empty alternation matches every folder. Absolute roots are already skipped above,
+            # which is the common case now that dependencies live outside the project by default.
+            exclude_dirs_regex = exclude_dirs and re.compile( "|".join( exclude_dirs ) ) or None
 
         matches = cuppa.recursive_glob.glob( start, pattern, exclude_dirs_pattern=exclude_dirs_regex )
 

--- a/cuppa/package_managers/gitlab.py
+++ b/cuppa/package_managers/gitlab.py
@@ -16,6 +16,8 @@ import shutil
 import subprocess
 
 # cuppa imports
+import cuppa.core.storage_options
+
 from cuppa.log import logger
 from cuppa.colourise import as_error, as_info, as_notice, as_info_label
 
@@ -232,7 +234,7 @@ class GitlabPackageInstaller:
 
         self._env = env
         if not target_dir:
-            self._target_dir = env['download_root']
+            self._target_dir = env['dependencies_root']
             if not os.path.isabs( self._target_dir ):
                 self._target_dir = os.path.abspath( os.path.join( env['sconstruct_dir'], self._target_dir ) )
         else:
@@ -504,11 +506,13 @@ class GitlabPackageDependency:
 
         self._package_id = "/".join( [ package, self.version(), variant ] )
 
-        cache_dir = os.path.join( cuppa_env['cache_root'], 'packages', package, version )
+        cuppa.core.storage_options.report_roots( cuppa_env )
+
+        cache_dir = os.path.join( cuppa_env['downloads_root'], 'packages', package, version )
         package_file = package_file_name( cuppa_env, package=package, variant=variant )
         self._download_target = os.path.join( cache_dir, package_file )
 
-        extraction_root = cuppa_env['download_root']
+        extraction_root = cuppa_env['dependencies_root']
         if not os.path.isabs( extraction_root ):
             extraction_root = os.path.abspath( os.path.join( cuppa_env['sconstruct_dir'], extraction_root ) )
 

--- a/cuppa/project_generators/codeblocks.py
+++ b/cuppa/project_generators/codeblocks.py
@@ -121,7 +121,7 @@ class Codeblocks(object):
         base_include = self._exclude_branches and env['base_path'] or env['branch_root']
 
         base = os.path.realpath( base_include )
-        download = os.path.realpath( env['download_root'] )
+        download = os.path.realpath( env['dependencies_root'] )
 
         thirdparty = env['thirdparty'] and os.path.realpath( env['thirdparty'] ) or None
 
@@ -138,7 +138,7 @@ class Codeblocks(object):
 
         if not self._include_thirdparty:
             if download_under_base:
-                self._exclude_paths.append( env['download_root'] )
+                self._exclude_paths.append( env['dependencies_root'] )
 
             if thirdparty and thirdparty_under_base:
                 self._exclude_paths.append( env['thirdparty'] )
@@ -147,7 +147,7 @@ class Codeblocks(object):
 
         if self._include_thirdparty:
             if not download_under_base:
-                self._include_paths.append( env['download_root'] )
+                self._include_paths.append( env['dependencies_root'] )
 
             if thirdparty and not thirdparty_under_base:
                 self._include_paths.append( env['thirdparty'] )

--- a/design/plans/removal-options.md
+++ b/design/plans/removal-options.md
@@ -4,25 +4,24 @@
 - **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Storage roots, listing, and removal; GitHub [#132](https://github.com/ja11sop/cuppa/issues/132), [#133](https://github.com/ja11sop/cuppa/issues/133), [#134](https://github.com/ja11sop/cuppa/issues/134), [#135](https://github.com/ja11sop/cuppa/issues/135), [#138](https://github.com/ja11sop/cuppa/issues/138)
 - **Updated:** 2026-08-01
 
-`--list-develop` and `--update-develop` (§3.5, §3.6) are implemented; cloning a missing develop
-copy (§3.7) came out of using them and is a proposal, as are the storage rename and the removal
-options. Follow-on from the `--clean` work in `cuppa/location.py` and
-`cuppa/package_managers/gitlab.py`, where a clean could not complete because a dependency was
-missing, and where the advice for leftover artefacts was "remove the folder by hand". Telling
-people to run `rm -rf` is unsatisfying: it is platform-specific, it is easy to aim at the wrong
-path, and cuppa already knows exactly which folders belong to which variant and which dependency.
+`--list-develop` and `--update-develop` (§3.5, §3.6) and the storage rename (§3.1, §8, Phase 1)
+are implemented. Cloning a missing develop copy (§3.7) came out of using the develop report and
+is a proposal, as are the listing and removal options. Follow-on from the `--clean` work in
+`cuppa/location.py` and `cuppa/package_managers/gitlab.py`, where a clean could not complete
+because a dependency was missing, and where the advice for leftover artefacts was "remove the
+folder by hand". Telling people to run `rm -rf` is unsatisfying: it is platform-specific, it is
+easy to aim at the wrong path, and cuppa already knows exactly which folders belong to which
+variant and which dependency.
 
-This plan proposes renaming the storage roots, a way to list what is in them, a family of
-explicit removal options, a report on the state of the local working copies `--develop`
-substitutes together with conservative ways to bring them up to date and to create the ones that
-are missing, and the safety model that governs all of it.
+This plan proposes a way to list what is in the storage roots, a family of explicit removal
+options, a report on the state of the local working copies `--develop` substitutes together with
+conservative ways to bring them up to date and to create the ones that are missing, and the
+safety model that governs all of it.
 
-The storage rename comes **first** (§6, Phase 1). Every later phase talks about paths, so doing
-the rename up front means each subsequent discussion and changeset uses one vocabulary, instead
-of every review having to translate between the old and new names. Throughout this document the
-new names are used: `dependencies_root` for what is currently `download_root`, and
-`downloads_root` for what is currently `cache_root`. Both default to subfolders of a single
-`storage_root`, which defaults to `~/.cuppa` and can be moved with one option.
+The storage rename came **first** (§6, Phase 1) so every later phase talks about one vocabulary.
+Throughout this document the new names are used: `dependencies_root` (was `download_root`) and
+`downloads_root` (was `cache_root`). Both default to subfolders of a single `storage_root`,
+which defaults to `~/.cuppa` and can be moved with one option.
 
 ---
 
@@ -819,27 +818,17 @@ could land at any point, and Phase 6 needs a design pass this plan does not atte
 | 5 | `--list-develop`, `--update-develop` | nothing in this plan |
 | 6 | `--remove-artefacts` | its own design pass first |
 
-**Phase 1 — storage naming** (§8, §3.1)
+**Phase 1 — storage naming** (§8, §3.1) — **done**
 
-- `cuppa/core/storage_options.py`: add `--storage-root`, `--dependencies-root` /
-  `--downloads-root` and the matching `storage_root` / `dependencies_root` / `downloads_root`
-  keys; keep `--download-root` / `--cache-root` and their keys as deprecated aliases that
-  resolve to the same values.
-- Resolution order in one place: explicit root, else derived from `storage_root`, else derived
-  from the default `storage_root`, with the deprecated aliases feeding the explicit slot. Every
-  reader takes the resolved value, so no subsystem re-implements the precedence.
-- Fallback: when an old folder exists and the new one does not, keep using the old one and log
-  once at info level explaining the new name and location.
-- Update every internal reader (`cuppa/location.py`, `cuppa/package_managers/gitlab.py`,
-  `cuppa/build_with_conan.py`, `cuppa/dependencies/…`) to the new keys.
-- Report the resolved roots at info level on the first retrieval of a run, so the new shared
-  location is visible in build output and not only in documentation (§8.3).
-- Docs and `CHANGELOG.md` in the same change: Deprecated for the old options, Changed for the
-  default location, and the shared-by-default explanation the change obliges us to write (§8.3).
-
-Landing this alone is low risk and self-contained: no behaviour changes beyond where the
-defaults point, and the alias layer keeps existing `~/.cuppaconfig` files and dependency plugins
-working.
+- `cuppa/core/storage_options.py`: `--storage-root`, `--dependencies-root` /
+  `--downloads-root` and the matching keys; `--download-root` / `--cache-root` and their keys
+  kept as deprecated aliases of the resolved values.
+- Resolution in one place (`resolve_root`): explicit option, else deprecated alias, else an
+  existing older folder, else derived from `storage_root`. Both the project-local `_cuppa` and
+  the shared `~/_cuppa/_download` are considered for dependencies, project-local first.
+- Internal readers moved to the new keys; the old keys remain as aliases for plugins.
+- Roots reported at info level on the first retrieval of a run.
+- Docs and `CHANGELOG.md` updated under Changed and Deprecated.
 
 **Phase 2 — build removal and `--list-builds`** (§3.3, §4.1, §4.2)
 
@@ -1152,6 +1141,19 @@ Renaming storage silently would strand existing trees and force re-downloads, so
    info level explaining the new name and how to move. This matters more than a pure rename
    would, because the default location changes too: an existing `~/_cuppa/_download` full of
    trees must not silently become an empty `~/.cuppa/dependencies` and a machine-wide re-fetch.
+
+   The fallback has to consider **two** old dependency locations, not one. `download_root`
+   defaults to `_cuppa` *inside the project* today, so the tree a project has by default is
+   `<project>/_cuppa`, and only a person who configured `download_root` themselves has the shared
+   `~/_cuppa/_download` this section originally named. Checking the shared path alone would leave
+   every unconfigured project re-fetching into `~/.cuppa/dependencies` with a perfectly good tree
+   sitting beside its sconstruct — the exact outcome the fallback exists to prevent. Both are
+   checked, project-local first, because that is what the old default produced.
+
+   A root kept by the fallback is kept in the form it was written in. A relative `_cuppa` stays
+   relative rather than being resolved to an absolute path, because `construct.py` excludes the
+   dependencies root from sconscript discovery by folder name and only a relative name matches:
+   resolving it would quietly start scanning every retrieved tree for sconscripts.
 4. Document the change in `CHANGELOG.md` under Deprecated, and give the `mv` commands in the docs.
 5. Consider a `--migrate-storage` action that performs the moves, once the machinery in this plan
    exists, since it needs the same containment and reporting code.

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -17,6 +17,7 @@
 ** xref:integration/test-minimal-example.adoc[Minimal example]
 ** xref:integration/test-configure-conf.adoc[configure.conf]
 ** xref:integration/test-scripts-scoping.adoc[Scripts scoping]
+** xref:integration/test-storage-roots.adoc[Storage roots]
 ** xref:integration/test-toolchains-matrix.adoc[Toolchains matrix]
 ** xref:integration/test-build.adoc[Build]
 ** xref:integration/test-build-test.adoc[BuildTest and Test]

--- a/docs/modules/ROOT/pages/build-layout.adoc
+++ b/docs/modules/ROOT/pages/build-layout.adoc
@@ -1,5 +1,5 @@
 = Build layout
-:description: Where cuppa places build products, downloads, and caches
+:description: Where cuppa places build products, dependencies, and downloads
 
 == Default roots
 
@@ -7,11 +7,42 @@
 | Purpose | Default | Override
 
 | Build output | `_build` | `--build-root`
-| Downloaded / checked-out dependencies | `_cuppa` | `--download-root`
-| Archive cache | `~/_cuppa/_cache` | `--cache-root`
+| Dependency trees, ready to build against | `~/.cuppa/dependencies` | `--dependencies-root`
+| Downloaded archives | `~/.cuppa/downloads` | `--downloads-root`
 |===
 
-These defaults live in `cuppa/core/storage_options.py`. Older documentation referred to `.build` / `.cuppa`; current cuppa uses the underscore-prefixed names above.
+These defaults live in `cuppa/core/storage_options.py`.
+
+Build output belongs to one project and stays beside it. The other two are the same for every
+project on the machine: a dependency you retrieved once is worth reusing, so they default to a
+shared `~/.cuppa` rather than to a folder inside whichever project fetched them first.
+
+`--storage-root` moves both of them together, which is the flag to reach for when you want a
+different location rather than a different arrangement:
+
+[source,sh]
+----
+cuppa -D --dbg --storage-root=/fast-disk/cuppa
+----
+
+Pass `--storage-root=_cuppa` to keep everything inside the project, which is worth doing when a
+build must not touch anything outside its own directory. Naming `--dependencies-root` or
+`--downloads-root` sets that one root and leaves the other derived from the storage root, so you
+can keep trees local while still sharing the archive downloads.
+
+NOTE: `--download-root` and `--cache-root` are the previous names for `--dependencies-root` and
+`--downloads-root`. They still work and still choose the same roots, and cuppa names the
+replacement when you use one.
+
+=== Storage from an earlier cuppa
+
+Before these names existed, dependencies went into a project-relative `_cuppa` folder by default,
+and downloads into `~/_cuppa/_cache`. Where such a folder already exists and you have not chosen a
+root yourself, cuppa keeps using it and says so once, so that upgrading does not turn a populated
+tree into an empty `~/.cuppa` and a machine-wide re-fetch. A project-local `_cuppa` beside your
+sconstruct is preferred over the shared one, because that is what the old default produced.
+
+To move to the new location, move or delete the old folder, or name the root you want explicitly.
 
 == Per-sconscript output tree
 
@@ -67,15 +98,15 @@ That removes objects, binaries, module BMIs (`.gcm` / `.pcm`), and the GCC
 for a fully cold tree.
 
 Cleaning never retrieves or updates dependencies. If a location or package dependency
-is not present in the download root, cuppa reports that at info level and treats it as
-absent rather than stopping the clean, so a partially populated download root does not
+is not present in the dependencies root, cuppa reports that at info level and treats it as
+absent rather than stopping the clean, so a partially populated dependencies root does not
 block you from clearing `_build`. In the usual case nothing is missed: a dependency you
 never downloaded cannot have contributed any files to remove, and your own targets are
 still described (and therefore still cleaned) with or without it.
 
 The exception is a location dependency that compiles its own sources through
 `build_library_from_source`, because those artefacts live under `_build/<location folder>/`
-rather than in the download root. If that folder exists while the location itself does not,
+rather than in the dependencies root. If that folder exists while the location itself does not,
 cuppa warns and names the folder, since the sources needed to describe those artefacts are
 gone and SCons cannot remove them. Delete the folder by hand, or restore the location and
 clean again.

--- a/docs/modules/ROOT/pages/cli-reference.adoc
+++ b/docs/modules/ROOT/pages/cli-reference.adoc
@@ -48,10 +48,17 @@ TIP: If cuppa fails early while reading sconscripts, re-run with `--verbosity=ex
 | Option | Default
 
 | `--build-root` | `_build`
-| `--download-root` | `_cuppa`
-| `--cache-root` | `~/_cuppa/_cache`
+| `--storage-root` | `~/.cuppa` -- the parent of the two roots below
+| `--dependencies-root` | `<storage-root>/dependencies` -- retrieved trees, ready to build against
+| `--downloads-root` | `<storage-root>/downloads` -- the archives they came from
+| `--download-root` | Deprecated alias for `--dependencies-root`
+| `--cache-root` | Deprecated alias for `--downloads-root`
 | `--thirdparty=DIR` | Third-party directory hint
 |===
+
+The dependencies and downloads roots are shared between projects. Set `--storage-root` to move
+both, or name one of them to move only that half. See xref:build-layout.adoc[Build layout] for
+what goes where and for how cuppa treats storage left by an earlier version.
 
 == Configuration persistence
 

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -35,6 +35,18 @@ Example -- save develop + offline as project defaults:
 cuppa -D --develop --offline --save-conf
 ----
 
+Storage choices are worth saving this way too. A project that must keep everything it retrieves
+inside its own directory can record that once rather than relying on everyone remembering the
+flag:
+
+[source,sh]
+----
+cuppa -D --storage-root=_cuppa --save-conf
+----
+
+Every later build in that project then resolves its dependencies and downloads roots under
+`_cuppa`. See xref:build-layout.adoc[Build layout] for what those roots hold.
+
 Conf-only operations skip a normal build when you are only saving or clearing settings.
 
 You can also seed defaults in code:

--- a/docs/modules/ROOT/pages/dependencies.adoc
+++ b/docs/modules/ROOT/pages/dependencies.adoc
@@ -81,7 +81,9 @@ cuppa.run(
 ----
 
 Locations may be filesystem paths, archive URLs, or VCS URLs (for example `git+https://…@branch`).
-Cuppa caches archives under `--cache-root` and checkouts under `--download-root`.
+Cuppa keeps checkouts and extracted archives under `--dependencies-root` and the downloaded
+archives themselves under `--downloads-root`, both shared between projects by default. See
+xref:build-layout.adoc[Build layout] for the defaults and for how to move them.
 
 With `--develop`, location dependencies that define a develop path use the local tree instead of fetching.
 
@@ -250,7 +252,7 @@ cuppa.run(
 )
 ----
 
-Cuppa maps the active toolchain and variant into Conan settings (`compiler`, `compiler.version`, `compiler.cppstd`, `compiler.libcxx`, `build_type`, `os`, `arch`), runs `conan install` once per settings fingerprint (cached under the download root), and merges the resulting flags.
+Cuppa maps the active toolchain and variant into Conan settings (`compiler`, `compiler.version`, `compiler.cppstd`, `compiler.libcxx`, `build_type`, `os`, `arch`), runs `conan install` once per settings fingerprint (cached under the dependencies root), and merges the resulting flags.
 
 Cuppa also passes Conan conf `tools.build:compiler_executables` from the active toolchain's C/C++ drivers.
 Without that, host settings can say `compiler=clang` while CMake still picks `g++` from `PATH` when building missing packages — a common failure on Linux CI images that ship both compilers.

--- a/docs/modules/ROOT/pages/extending.adoc
+++ b/docs/modules/ROOT/pages/extending.adoc
@@ -113,7 +113,7 @@ cuppa.run(
 )
 ----
 
-Cuppa fetches the archive on first use (cached under the download/cache roots). Pass `--offline` only after the tree is already cached.
+Cuppa fetches the archive on first use (kept under the dependencies and downloads roots). Pass `--offline` only after the tree is already cached.
 
 === Conan-based plugin (`cuppa-conan-fmt`)
 

--- a/docs/modules/ROOT/pages/integration-tests.adoc
+++ b/docs/modules/ROOT/pages/integration-tests.adoc
@@ -42,6 +42,7 @@ cuppa.run(default_variants=['dbg'])
 * xref:integration/test-minimal-example.adoc[`examples/minimal` build + test]
 * xref:integration/test-configure-conf.adoc[`configure.conf` save / show]
 * xref:integration/test-scripts-scoping.adoc[`--scripts=` scoping]
+* xref:integration/test-storage-roots.adoc[Storage root resolution]
 * xref:integration/test-toolchains-matrix.adoc[gcc / clang toolchains]
 
 == Method tests

--- a/docs/modules/ROOT/pages/integration/test-fmt-location-plugin.adoc
+++ b/docs/modules/ROOT/pages/integration/test-fmt-location-plugin.adoc
@@ -12,7 +12,7 @@ The example package `examples/cuppa_fmt_plugin` registers `fmt` through `cuppa.d
 
 == Prerequisites
 
-* Network (or a warm Cuppa download/cache) for the first fmt archive fetch
+* Network (or warm Cuppa dependencies / downloads roots) for the first fmt archive fetch
 * C++ compiler (suite default toolchain)
 
 == Generated consumer files

--- a/docs/modules/ROOT/pages/integration/test-storage-roots.adoc
+++ b/docs/modules/ROOT/pages/integration/test-storage-roots.adoc
@@ -1,0 +1,63 @@
+= `test_storage_roots` — where cuppa keeps dependencies and downloads
+:description: Cuppa integration test documentation for test_storage_roots
+
+
+== What is tested
+
+The storage roots resolve the way the command line says they should, in a real run rather than in
+isolation. Five behaviours are covered: `--storage-root` moving both roots together, naming one
+root leaving the other derived, the deprecated `--download-root` and `--cache-root` still working
+while saying they are deprecated, an existing project-local `_cuppa` folder being kept in use, and
+the defaults landing in the shared folder under the home directory.
+
+Each run uses `--dump`, so cuppa reports its resolved options and exits without building. That
+keeps the test about path resolution and quick to run.
+
+Every run is also given a home directory of its own through `HOME` and `USERPROFILE`. The defaults
+live under the home directory, and cuppa keeps an older folder in use when it finds one, so a run
+that shared the developer's home would report whatever that machine happens to have rather than
+what the test asked for.
+
+== Generated files
+
+The dummy project with the default `sconstruct`.
+
+=== `sconstruct`
+
+[source,python]
+----
+import cuppa
+
+cuppa.run(default_variants=['dbg'])
+----
+
+== Commands
+
+[source,sh]
+----
+cuppa -D --offline --dbg --dump --storage-root=<tmp>/storage
+cuppa -D --offline --dbg --dump --storage-root=<tmp>/storage --downloads-root=<tmp>/archives
+cuppa -D --offline --dbg --dump --download-root=<tmp>/trees --cache-root=<tmp>/archives
+cuppa -D --offline --dbg --dump
+----
+
+== Expectations
+
+With `--storage-root=<tmp>/storage`, the dump reports `dependencies_root` as
+`<tmp>/storage/dependencies` and `downloads_root` as `<tmp>/storage/downloads`, and the downloads
+folder exists on disk because cuppa creates it ready for an archive to land in.
+
+Adding `--downloads-root` moves only the downloads half; the dependencies root stays derived from
+the storage root.
+
+The deprecated names still choose their roots, and the output names both the old option and the
+one that replaces it.
+
+With a `_cuppa` folder beside the sconstruct, the dependencies root is reported as `_cuppa` and
+stays relative, so nothing that folder already holds is re-fetched into the new default location.
+
+With none of those flags, both roots are under `~/.cuppa`, which is the shared default.
+
+'''
+
+Related test module: `tests/integration/test_storage_roots.py`.

--- a/docs/modules/ROOT/pages/packages.adoc
+++ b/docs/modules/ROOT/pages/packages.adoc
@@ -42,7 +42,7 @@ The `cuppa` launcher redacts env values whose names contain `TOKEN` in logged ou
 == Develop vs package downloads
 
 `--develop` affects *location* develop paths and package develop flags where defined.
-It does *not* invent a local substitute for a missing registry archive: the matching package must exist in the registry or already be cached under the download/cache roots.
+It does *not* invent a local substitute for a missing registry archive: the matching package must exist in the registry or already be cached under the dependencies and downloads roots.
 
 == Boost package
 
@@ -69,7 +69,7 @@ Use `package.use_libs([...])` helpers where provided to append the correct stati
 
 From a sconscript, `env.PublishPackage(...)` with a `GitlabPackagePublisher` builds a toolchain-scoped tarball.
 Add `--publish-package` to upload it to the GitLab generic registry.
-`env.InstallPackage(...)` installs a package into the local cuppa download layout.
+`env.InstallPackage(...)` installs a package into the local cuppa dependencies layout.
 
 [#conan-package-publishing]
 == Conan 2 publishing (optional)

--- a/scripts/github_api.py
+++ b/scripts/github_api.py
@@ -18,6 +18,9 @@ Use it:
     github = GitHub()
     github.request( 'POST', '/repos/ja11sop/cuppa/issues/132/labels', { 'labels': [ 'bug' ] } )
 
+    # Public repository reads — no sealed token:
+    GitHub.public().request( 'GET', '/repos/ja11sop/cuppa/pulls/139' )
+
 Every run reports how long the token has left, so rotation is prompted by use rather than by a
 checklist nobody reads.
 """
@@ -141,22 +144,38 @@ def report_expiry( header_value ):
 
 
 class GitHub( object ):
-    """Minimal API client. Holds the token in memory only, and never in the environment."""
+    """Minimal API client.
 
-    def __init__( self, credential=None ):
-        self._token = credential if credential is not None else token()
+    Authenticated instances hold the token in memory only, and never in the environment.
+    Anonymous instances omit the credential entirely — enough for reads on a public repository,
+    which is what status helpers should use so watching CI does not unseal the token every poll.
+    """
+
+    def __init__( self, credential=None, anonymous=False ):
+        if anonymous:
+            self._token = None
+        else:
+            self._token = credential if credential is not None else token()
         self._expiry_reported = False
 
+    @classmethod
+    def public( cls ):
+        """Unauthenticated client for public repository reads."""
+        return cls( anonymous=True )
+
     def request( self, method, path, payload=None ):
+        headers = {
+            'Accept': 'application/vnd.github+json',
+            'User-Agent': USER_AGENT,
+        }
+        if self._token is not None:
+            headers['Authorization'] = 'Bearer ' + self._token
+
         request = urllib.request.Request(
             path if path.startswith( 'http' ) else API + path,
             data = json.dumps( payload ).encode( 'utf-8' ) if payload is not None else None,
             method = method,
-            headers = {
-                'Authorization': 'Bearer ' + self._token,
-                'Accept': 'application/vnd.github+json',
-                'User-Agent': USER_AGENT,
-            }
+            headers = headers,
         )
         try:
             with urllib.request.urlopen( request ) as response:
@@ -169,9 +188,10 @@ class GitHub( object ):
             return error.code, ( json.loads( body ) if body else {} )
 
     def _report_expiry_once( self, headers ):
-        if not self._expiry_reported:
-            self._expiry_reported = True
-            report_expiry( headers.get( EXPIRY_HEADER ) )
+        if self._token is None or self._expiry_reported:
+            return
+        self._expiry_reported = True
+        report_expiry( headers.get( EXPIRY_HEADER ) )
 
 
 def seal_command():

--- a/scripts/github_helpers.py
+++ b/scripts/github_helpers.py
@@ -1,0 +1,179 @@
+"""Higher-level GitHub operations for agents and maintenance, on top of ``github_api``.
+
+``scripts.github_api`` is the credential and transport layer. This module is the place to add
+repeated write workflows — create a pull request, apply the ``impact:`` label — so an agent does
+not rewrite the same ``urllib`` call every time. Grow it when the same sequence appears twice;
+do not invent helpers for a one-off.
+
+Pushing a branch is still ``git push -u origin HEAD``. These helpers only cover the GitHub API
+surface that needs the sealed token.
+
+Create a pull request from the current branch:
+
+    python -m scripts.github_helpers create-pr \\
+        --title "…" --body-file /tmp/pr.md --label impact:minor
+
+Or from Python:
+
+    from scripts.github_helpers import create_pull_request
+    create_pull_request( title='…', body='…', labels=['impact:minor'] )
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+from scripts.github_api import CredentialError, GitHub
+
+
+DEFAULT_OWNER = 'ja11sop'
+DEFAULT_REPO = 'cuppa'
+DEFAULT_BASE = 'master'
+
+
+class GitHubHelperError( Exception ):
+    pass
+
+
+def _run_git( *arguments ):
+    try:
+        return subprocess.run(
+            [ 'git', *arguments ],
+            stdout = subprocess.PIPE,
+            stderr = subprocess.PIPE,
+            check = True,
+            text = True,
+        ).stdout.strip()
+    except subprocess.CalledProcessError as error:
+        raise GitHubHelperError( error.stderr.strip() or str( error ) )
+
+
+def current_branch():
+    return _run_git( 'rev-parse', '--abbrev-ref', 'HEAD' )
+
+
+def repository( owner=None, repo=None ):
+    """``owner/repo`` for API paths.
+
+    Explicit arguments win. Otherwise the ``origin`` remote is parsed when it looks like this
+    repository; falling back to the defaults keeps the helpers usable outside a checkout.
+    """
+    if owner and repo:
+        return owner, repo
+
+    try:
+        url = _run_git( 'config', '--get', 'remote.origin.url' )
+    except GitHubHelperError:
+        return owner or DEFAULT_OWNER, repo or DEFAULT_REPO
+
+    match = re.search( r'[:/]([^/]+)/([^/]+?)(?:\.git)?$', url )
+    if match:
+        return match.group( 1 ), match.group( 2 )
+    return owner or DEFAULT_OWNER, repo or DEFAULT_REPO
+
+
+def create_pull_request(
+        title,
+        body,
+        head=None,
+        base=DEFAULT_BASE,
+        labels=None,
+        owner=None,
+        repo=None,
+        github=None,
+):
+    """Open a pull request and optionally label it. Returns the pull request dict from GitHub."""
+    owner, repo = repository( owner, repo )
+    head = head or current_branch()
+    client = github or GitHub()
+
+    status, pull = client.request(
+        'POST',
+        '/repos/{}/{}/pulls'.format( owner, repo ),
+        {
+            'title': title,
+            'body': body,
+            'head': head,
+            'base': base,
+        },
+    )
+    if status >= 400:
+        raise GitHubHelperError( "creating the pull request failed ({}): {}".format(
+            status, json.dumps( pull ) ) )
+
+    if labels:
+        number = pull['number']
+        label_status, labelled = client.request(
+            'POST',
+            '/repos/{}/{}/issues/{}/labels'.format( owner, repo, number ),
+            { 'labels': list( labels ) },
+        )
+        if label_status >= 400:
+            raise GitHubHelperError(
+                "pull request {} was created but labelling failed ({}): {}".format(
+                    pull.get( 'html_url' ), label_status, json.dumps( labelled ) )
+            )
+
+    return pull
+
+
+def _read_body( arguments ):
+    if arguments.body_file:
+        with open( arguments.body_file, encoding='utf-8' ) as body_file:
+            return body_file.read()
+    if arguments.body is not None:
+        return arguments.body
+    raise GitHubHelperError( "give --body or --body-file" )
+
+
+def create_pr_command( arguments ):
+    pull = create_pull_request(
+        title = arguments.title,
+        body = _read_body( arguments ),
+        head = arguments.head,
+        base = arguments.base,
+        labels = arguments.label,
+        owner = arguments.owner,
+        repo = arguments.repo,
+    )
+    print( pull['html_url'] )
+    return 0
+
+
+def main( argv=None ):
+    parser = argparse.ArgumentParser( description=__doc__ )
+    commands = parser.add_subparsers( dest='command' )
+
+    create = commands.add_parser( 'create-pr', help="open a pull request for the current branch" )
+    create.add_argument( '--title', required=True )
+    create.add_argument( '--body', default=None, help="pull request body text" )
+    create.add_argument( '--body-file', help="read the body from this file instead" )
+    create.add_argument( '--head', help="head branch (default: current branch)" )
+    create.add_argument( '--base', default=DEFAULT_BASE )
+    create.add_argument(
+        '--label', action='append', default=[],
+        help="label to apply; repeat for more than one (for example --label impact:minor)",
+    )
+    create.add_argument( '--owner' )
+    create.add_argument( '--repo' )
+
+    arguments = parser.parse_args( argv )
+    if not arguments.command:
+        parser.print_help()
+        return 1
+
+    try:
+        if arguments.command == 'create-pr':
+            return create_pr_command( arguments )
+    except ( CredentialError, GitHubHelperError ) as error:
+        print( error, file=sys.stderr )
+        return 1
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit( main() )

--- a/scripts/github_helpers.py
+++ b/scripts/github_helpers.py
@@ -1,19 +1,25 @@
 """Higher-level GitHub operations for agents and maintenance, on top of ``github_api``.
 
 ``scripts.github_api`` is the credential and transport layer. This module is the place to add
-repeated write workflows — create a pull request, apply the ``impact:`` label, watch CI — so an
-agent does not rewrite the same ``urllib`` call every time. Grow it when the same sequence appears
+repeated workflows — create a pull request, apply the ``impact:`` label, watch CI — so an agent
+does not rewrite the same ``urllib`` call every time. Grow it when the same sequence appears
 twice; do not invent helpers for a one-off.
 
-Pushing a branch is still ``git push -u origin HEAD``. These helpers only cover the GitHub API
-surface that needs the sealed token (or that is easier through the same client).
+Owner and repository always come from the local ``origin`` remote (or explicit ``--owner`` /
+``--repo``). There is no baked-in default, so a checkout of a fork cannot silently talk to the
+wrong repository.
+
+Reads on a public repository use the anonymous API. ``pr-status`` and ``watch-pr`` do not unseal
+the token. Writes (``create-pr``, labelling) still go through the sealed credential.
+
+Pushing a branch is still ``git push -u origin HEAD``.
 
 Create a pull request from the current branch:
 
     python -m scripts.github_helpers create-pr \\
         --title "…" --body-file /tmp/pr.md --label impact:minor
 
-After a push, watch the open pull request's checks until they finish:
+After a push, watch the open pull request's checks until they finish (public read, no seal):
 
     python -m scripts.github_helpers watch-pr
     python -m scripts.github_helpers pr-status --pr 139
@@ -36,10 +42,8 @@ from collections import namedtuple
 from scripts.github_api import CredentialError, GitHub
 
 
-DEFAULT_OWNER = 'ja11sop'
-DEFAULT_REPO = 'cuppa'
 DEFAULT_BASE = 'master'
-DEFAULT_POLL_SECONDS = 30
+DEFAULT_POLL_SECONDS = 180
 DEFAULT_WATCH_TIMEOUT = 3600
 
 # Exit codes for pr-status / watch-pr so agents can branch without parsing prose.
@@ -84,23 +88,29 @@ def current_branch():
 
 
 def repository( owner=None, repo=None ):
-    """``owner/repo`` for API paths.
+    """``owner/repo`` for API paths, taken from the local ``origin`` remote.
 
-    Explicit arguments win. Otherwise the ``origin`` remote is parsed when it looks like this
-    repository; falling back to the defaults keeps the helpers usable outside a checkout.
+    Explicit arguments win when both are given. Otherwise ``origin`` must be configured and parse
+    as a GitHub owner/repo URL — there is no fallback name, so a missing or exotic remote fails
+    loudly instead of talking to the wrong repository.
     """
     if owner and repo:
         return owner, repo
+    if owner or repo:
+        raise GitHubHelperError( "give both --owner and --repo, or neither" )
 
-    try:
-        url = _run_git( 'config', '--get', 'remote.origin.url' )
-    except GitHubHelperError:
-        return owner or DEFAULT_OWNER, repo or DEFAULT_REPO
-
+    url = _run_git( 'config', '--get', 'remote.origin.url' )
     match = re.search( r'[:/]([^/]+)/([^/]+?)(?:\.git)?$', url )
-    if match:
-        return match.group( 1 ), match.group( 2 )
-    return owner or DEFAULT_OWNER, repo or DEFAULT_REPO
+    if not match:
+        raise GitHubHelperError(
+            "could not parse owner/repo from origin remote [{}]".format( url )
+        )
+    return match.group( 1 ), match.group( 2 )
+
+
+def public_github( github=None ):
+    """Client for public reads. Reuses ``github`` when the caller already has one."""
+    return github if github is not None else GitHub.public()
 
 
 def create_pull_request(
@@ -152,7 +162,7 @@ def find_open_pull_request( head=None, owner=None, repo=None, github=None ):
     """The open pull request for ``head`` (default: current branch), or None."""
     owner, repo = repository( owner, repo )
     head = head or current_branch()
-    client = github or GitHub()
+    client = public_github( github )
 
     status, pulls = client.request(
         'GET',
@@ -169,7 +179,7 @@ def find_open_pull_request( head=None, owner=None, repo=None, github=None ):
 def resolve_pull_request( number=None, head=None, owner=None, repo=None, github=None ):
     """A pull request by number, or the open one for the current branch."""
     owner, repo = repository( owner, repo )
-    client = github or GitHub()
+    client = public_github( github )
 
     if number is not None:
         status, pull = client.request(
@@ -222,9 +232,9 @@ def outcome_for( checks ):
 
 
 def pull_request_status( number=None, head=None, owner=None, repo=None, github=None ):
-    """Where the pull request's checks stand right now."""
+    """Where the pull request's checks stand right now (public API; no sealed token)."""
     owner, repo = repository( owner, repo )
-    client = github or GitHub()
+    client = public_github( github )
     pull = resolve_pull_request(
         number=number, head=head, owner=owner, repo=repo, github=client
     )
@@ -386,7 +396,7 @@ def main( argv=None ):
     _add_pr_selection_arguments( watch )
     watch.add_argument(
         '--interval', type=int, default=DEFAULT_POLL_SECONDS,
-        help="seconds between polls (default {})".format( DEFAULT_POLL_SECONDS ),
+        help="seconds between polls (default {} = 3 minutes)".format( DEFAULT_POLL_SECONDS ),
     )
     watch.add_argument(
         '--timeout', type=int, default=DEFAULT_WATCH_TIMEOUT,

--- a/scripts/github_helpers.py
+++ b/scripts/github_helpers.py
@@ -1,22 +1,28 @@
 """Higher-level GitHub operations for agents and maintenance, on top of ``github_api``.
 
 ``scripts.github_api`` is the credential and transport layer. This module is the place to add
-repeated write workflows — create a pull request, apply the ``impact:`` label — so an agent does
-not rewrite the same ``urllib`` call every time. Grow it when the same sequence appears twice;
-do not invent helpers for a one-off.
+repeated write workflows — create a pull request, apply the ``impact:`` label, watch CI — so an
+agent does not rewrite the same ``urllib`` call every time. Grow it when the same sequence appears
+twice; do not invent helpers for a one-off.
 
 Pushing a branch is still ``git push -u origin HEAD``. These helpers only cover the GitHub API
-surface that needs the sealed token.
+surface that needs the sealed token (or that is easier through the same client).
 
 Create a pull request from the current branch:
 
     python -m scripts.github_helpers create-pr \\
         --title "…" --body-file /tmp/pr.md --label impact:minor
 
+After a push, watch the open pull request's checks until they finish:
+
+    python -m scripts.github_helpers watch-pr
+    python -m scripts.github_helpers pr-status --pr 139
+
 Or from Python:
 
-    from scripts.github_helpers import create_pull_request
+    from scripts.github_helpers import create_pull_request, watch_pull_request
     create_pull_request( title='…', body='…', labels=['impact:minor'] )
+    watch_pull_request( number=139 )
 """
 
 import argparse
@@ -24,6 +30,8 @@ import json
 import re
 import subprocess
 import sys
+import time
+from collections import namedtuple
 
 from scripts.github_api import CredentialError, GitHub
 
@@ -31,10 +39,31 @@ from scripts.github_api import CredentialError, GitHub
 DEFAULT_OWNER = 'ja11sop'
 DEFAULT_REPO = 'cuppa'
 DEFAULT_BASE = 'master'
+DEFAULT_POLL_SECONDS = 30
+DEFAULT_WATCH_TIMEOUT = 3600
+
+# Exit codes for pr-status / watch-pr so agents can branch without parsing prose.
+EXIT_SUCCESS = 0
+EXIT_FAILURE = 1
+EXIT_PENDING = 2
+EXIT_TIMEOUT = 3
+
+# A check counts as a failure for our purposes when GitHub marks it unsuccessful.
+FAILED_CONCLUSIONS = frozenset( {
+    'failure', 'cancelled', 'timed_out', 'action_required', 'stale', 'startup_failure',
+} )
 
 
 class GitHubHelperError( Exception ):
     pass
+
+
+PullRequestStatus = namedtuple(
+    'PullRequestStatus',
+    [ 'number', 'url', 'head_sha', 'state', 'mergeable_state', 'checks', 'outcome' ],
+)
+
+CheckRun = namedtuple( 'CheckRun', [ 'name', 'status', 'conclusion', 'url' ] )
 
 
 def _run_git( *arguments ):
@@ -119,6 +148,164 @@ def create_pull_request(
     return pull
 
 
+def find_open_pull_request( head=None, owner=None, repo=None, github=None ):
+    """The open pull request for ``head`` (default: current branch), or None."""
+    owner, repo = repository( owner, repo )
+    head = head or current_branch()
+    client = github or GitHub()
+
+    status, pulls = client.request(
+        'GET',
+        '/repos/{}/{}/pulls?state=open&head={}:{}'.format( owner, repo, owner, head ),
+    )
+    if status >= 400:
+        raise GitHubHelperError( "listing pull requests failed ({}): {}".format(
+            status, json.dumps( pulls ) ) )
+    if not pulls:
+        return None
+    return pulls[0]
+
+
+def resolve_pull_request( number=None, head=None, owner=None, repo=None, github=None ):
+    """A pull request by number, or the open one for the current branch."""
+    owner, repo = repository( owner, repo )
+    client = github or GitHub()
+
+    if number is not None:
+        status, pull = client.request(
+            'GET',
+            '/repos/{}/{}/pulls/{}'.format( owner, repo, number ),
+        )
+        if status >= 400:
+            raise GitHubHelperError( "reading pull request {} failed ({}): {}".format(
+                number, status, json.dumps( pull ) ) )
+        return pull
+
+    pull = find_open_pull_request( head=head, owner=owner, repo=repo, github=client )
+    if pull is None:
+        raise GitHubHelperError(
+            "no open pull request for branch [{}]; pass --pr".format( head or current_branch() )
+        )
+    return pull
+
+
+def _check_runs_for( sha, owner, repo, github ):
+    status, payload = github.request(
+        'GET',
+        '/repos/{}/{}/commits/{}/check-runs?per_page=100'.format( owner, repo, sha ),
+    )
+    if status >= 400:
+        raise GitHubHelperError( "reading check runs failed ({}): {}".format(
+            status, json.dumps( payload ) ) )
+
+    checks = []
+    for run in payload.get( 'check_runs', [] ):
+        checks.append( CheckRun(
+            name = run.get( 'name' ) or '(unnamed)',
+            status = run.get( 'status' ) or 'queued',
+            conclusion = run.get( 'conclusion' ),
+            url = ( run.get( 'html_url' ) or run.get( 'details_url' ) or '' ),
+        ) )
+    return sorted( checks, key=lambda check: check.name.lower() )
+
+
+def outcome_for( checks ):
+    """``pending``, ``success``, or ``failure`` for a set of check runs."""
+    if not checks:
+        return 'pending'
+    if any( check.status != 'completed' for check in checks ):
+        return 'pending'
+    if any( check.conclusion in FAILED_CONCLUSIONS for check in checks ):
+        return 'failure'
+    # success, neutral, and skipped are all fine to merge past.
+    return 'success'
+
+
+def pull_request_status( number=None, head=None, owner=None, repo=None, github=None ):
+    """Where the pull request's checks stand right now."""
+    owner, repo = repository( owner, repo )
+    client = github or GitHub()
+    pull = resolve_pull_request(
+        number=number, head=head, owner=owner, repo=repo, github=client
+    )
+    sha = pull['head']['sha']
+    checks = _check_runs_for( sha, owner, repo, client )
+    return PullRequestStatus(
+        number = pull['number'],
+        url = pull.get( 'html_url' ) or '',
+        head_sha = sha,
+        state = pull.get( 'state' ) or '',
+        mergeable_state = pull.get( 'mergeable_state' ) or '',
+        checks = checks,
+        outcome = outcome_for( checks ),
+    )
+
+
+def format_pull_request_status( status ):
+    lines = [
+        "PR #{} {}  head={}  mergeable_state={}  outcome={}".format(
+            status.number,
+            status.url,
+            status.head_sha[:8],
+            status.mergeable_state or '-',
+            status.outcome,
+        )
+    ]
+    if not status.checks:
+        lines.append( "  (no check runs yet)" )
+        return "\n".join( lines )
+
+    width = max( len( check.name ) for check in status.checks )
+    for check in status.checks:
+        detail = check.conclusion if check.status == 'completed' else check.status
+        lines.append( "  {:<{}}  {}".format( check.name, width, detail ) )
+    return "\n".join( lines )
+
+
+def exit_code_for( outcome ):
+    if outcome == 'success':
+        return EXIT_SUCCESS
+    if outcome == 'failure':
+        return EXIT_FAILURE
+    return EXIT_PENDING
+
+
+def watch_pull_request(
+        number=None,
+        head=None,
+        owner=None,
+        repo=None,
+        github=None,
+        interval=DEFAULT_POLL_SECONDS,
+        timeout=DEFAULT_WATCH_TIMEOUT,
+        out=None,
+        sleep=time.sleep,
+        clock=time.monotonic,
+):
+    """Poll until checks finish. Returns ``(exit_code, PullRequestStatus)``."""
+    out = out or sys.stdout
+    deadline = clock() + timeout
+    last = None
+
+    while True:
+        last = pull_request_status(
+            number=number, head=head, owner=owner, repo=repo, github=github
+        )
+        out.write( format_pull_request_status( last ) + "\n" )
+        out.flush()
+
+        if last.outcome != 'pending':
+            return exit_code_for( last.outcome ), last
+
+        remaining = deadline - clock()
+        if remaining <= 0:
+            out.write( "timed out after {}s while checks were still pending\n".format( timeout ) )
+            out.flush()
+            return EXIT_TIMEOUT, last
+
+        sleep( min( interval, remaining ) )
+
+
 def _read_body( arguments ):
     if arguments.body_file:
         with open( arguments.body_file, encoding='utf-8' ) as body_file:
@@ -142,6 +329,36 @@ def create_pr_command( arguments ):
     return 0
 
 
+def pr_status_command( arguments ):
+    status = pull_request_status(
+        number = arguments.pr,
+        head = arguments.head,
+        owner = arguments.owner,
+        repo = arguments.repo,
+    )
+    print( format_pull_request_status( status ) )
+    return exit_code_for( status.outcome )
+
+
+def watch_pr_command( arguments ):
+    code, _ = watch_pull_request(
+        number = arguments.pr,
+        head = arguments.head,
+        owner = arguments.owner,
+        repo = arguments.repo,
+        interval = arguments.interval,
+        timeout = arguments.timeout,
+    )
+    return code
+
+
+def _add_pr_selection_arguments( parser ):
+    parser.add_argument( '--pr', type=int, help="pull request number (default: open PR for branch)" )
+    parser.add_argument( '--head', help="branch used to find an open pull request" )
+    parser.add_argument( '--owner' )
+    parser.add_argument( '--repo' )
+
+
 def main( argv=None ):
     parser = argparse.ArgumentParser( description=__doc__ )
     commands = parser.add_subparsers( dest='command' )
@@ -159,6 +376,23 @@ def main( argv=None ):
     create.add_argument( '--owner' )
     create.add_argument( '--repo' )
 
+    status = commands.add_parser( 'pr-status', help="show check status once and exit" )
+    _add_pr_selection_arguments( status )
+
+    watch = commands.add_parser(
+        'watch-pr',
+        help="poll check status until the pull request finishes (or times out)",
+    )
+    _add_pr_selection_arguments( watch )
+    watch.add_argument(
+        '--interval', type=int, default=DEFAULT_POLL_SECONDS,
+        help="seconds between polls (default {})".format( DEFAULT_POLL_SECONDS ),
+    )
+    watch.add_argument(
+        '--timeout', type=int, default=DEFAULT_WATCH_TIMEOUT,
+        help="give up after this many seconds (default {})".format( DEFAULT_WATCH_TIMEOUT ),
+    )
+
     arguments = parser.parse_args( argv )
     if not arguments.command:
         parser.print_help()
@@ -167,6 +401,10 @@ def main( argv=None ):
     try:
         if arguments.command == 'create-pr':
             return create_pr_command( arguments )
+        if arguments.command == 'pr-status':
+            return pr_status_command( arguments )
+        if arguments.command == 'watch-pr':
+            return watch_pr_command( arguments )
     except ( CredentialError, GitHubHelperError ) as error:
         print( error, file=sys.stderr )
         return 1

--- a/scripts/github_helpers.py
+++ b/scripts/github_helpers.py
@@ -43,7 +43,7 @@ from scripts.github_api import CredentialError, GitHub
 
 
 DEFAULT_BASE = 'master'
-DEFAULT_POLL_SECONDS = 180
+DEFAULT_POLL_SECONDS = 30
 DEFAULT_WATCH_TIMEOUT = 3600
 
 # Exit codes for pr-status / watch-pr so agents can branch without parsing prose.
@@ -396,7 +396,7 @@ def main( argv=None ):
     _add_pr_selection_arguments( watch )
     watch.add_argument(
         '--interval', type=int, default=DEFAULT_POLL_SECONDS,
-        help="seconds between polls (default {} = 3 minutes)".format( DEFAULT_POLL_SECONDS ),
+        help="seconds between polls (default {})".format( DEFAULT_POLL_SECONDS ),
     )
     watch.add_argument(
         '--timeout', type=int, default=DEFAULT_WATCH_TIMEOUT,

--- a/tests/integration/methods/test_conan.py
+++ b/tests/integration/methods/test_conan.py
@@ -179,16 +179,16 @@ def _isolated_conan_home(tmp_path, conan):
     """
     Fresh CONAN_HOME + default profile for local export-pkg round-trips.
 
-    Also returns a ``--download-root=`` flag under ``tmp_path`` so Cuppa's Conan
+    Also returns a ``--dependencies-root=`` flag under ``tmp_path`` so Cuppa's Conan
     fingerprint cache (and embedded package paths in ``SConscript_conandeps``)
-    cannot leak across tests via ``~/.cuppaconfig`` / ``~/_cuppa``.
+    cannot leak across tests via ``~/.cuppaconfig`` / ``~/.cuppa``.
     """
     import os
 
     conan_home = tmp_path / "conan_home"
     conan_home.mkdir()
-    download_root = tmp_path / "cuppa_download"
-    download_root.mkdir()
+    dependencies_root = tmp_path / "cuppa_dependencies"
+    dependencies_root.mkdir()
     extra = {"CONAN_HOME": str(conan_home)}
     detect = subprocess.run(
         [conan, "profile", "detect", "--force"],
@@ -200,7 +200,7 @@ def _isolated_conan_home(tmp_path, conan):
     )
     if detect.returncode != 0:
         pytest.fail("conan profile detect failed:\n{}".format(detect.stdout))
-    return extra, "--download-root={}".format(download_root)
+    return extra, "--dependencies-root={}".format(dependencies_root)
 
 def _write_answer_library(project, package="cuppa_pub_mylib", answer=42):
     """Minimal header + source library used by Conan publish round-trips."""
@@ -458,12 +458,12 @@ def test_conan_offline_fails_when_cache_missing(tmp_path):
 
     empty_home = tmp_path / "empty_conan_home"
     empty_home.mkdir()
-    download_root = tmp_path / "cuppa_download"
-    download_root.mkdir()
+    dependencies_root = tmp_path / "cuppa_dependencies"
+    dependencies_root.mkdir()
     result = run_cuppa(
         project,
         "--dbg",
-        "--download-root={}".format(download_root),
+        "--dependencies-root={}".format(dependencies_root),
         offline=True,
         timeout=180,
         extra_env={"CONAN_HOME": str(empty_home)},
@@ -889,7 +889,7 @@ def test_conan_publish_generated_requires_round_trip(tmp_path):
     import shutil
 
     conan = _require_conan()
-    extra, download_root = _isolated_conan_home(tmp_path, conan)
+    extra, dependencies_root = _isolated_conan_home(tmp_path, conan)
 
     leaf = tmp_path / "leaf"
     leaf.mkdir()
@@ -909,7 +909,7 @@ def test_conan_publish_generated_requires_round_trip(tmp_path):
         "))\n",
     )
     assert_success(
-        run_cuppa(leaf, "--dbg", download_root, offline=True, timeout=300, extra_env=extra)
+        run_cuppa(leaf, "--dbg", dependencies_root, offline=True, timeout=300, extra_env=extra)
     )
 
     wrap = tmp_path / "wrapper"
@@ -944,7 +944,7 @@ def test_conan_publish_generated_requires_round_trip(tmp_path):
         "    requires=['cuppa_pub_mylib/0.1.0'],\n"
         "))\n",
     )
-    wrapped = run_cuppa(wrap, "--dbg", download_root, offline=True, timeout=300, extra_env=extra)
+    wrapped = run_cuppa(wrap, "--dbg", dependencies_root, offline=True, timeout=300, extra_env=extra)
     assert_success(wrapped)
 
     # Generated recipe must embed requires= (not a hand-written conanfile=).
@@ -990,7 +990,7 @@ def test_conan_publish_generated_requires_round_trip(tmp_path):
     write_sconscript(consumer, "Import('env')\nenv.Build('hello', 'hello.cpp')\n")
 
     consumed = run_cuppa(
-        consumer, "--dbg", download_root, offline=True, timeout=300, extra_env=extra
+        consumer, "--dbg", dependencies_root, offline=True, timeout=300, extra_env=extra
     )
     assert_success(consumed)
     binaries = find_final_binaries(consumer, "hello")
@@ -1009,7 +1009,7 @@ def test_conan_publish_generated_requires_round_trip(tmp_path):
 def test_conan_publish_shared_lib_round_trip(tmp_path):
     """BuildSharedLib + shared=True publish → consumer BuildTest with runtime paths."""
     conan = _require_conan()
-    extra, download_root = _isolated_conan_home(tmp_path, conan)
+    extra, dependencies_root = _isolated_conan_home(tmp_path, conan)
 
     producer = tmp_path / "publisher"
     producer.mkdir()
@@ -1031,7 +1031,7 @@ def test_conan_publish_shared_lib_round_trip(tmp_path):
     )
 
     produced = run_cuppa(
-        producer, "--dbg", download_root, offline=True, timeout=300, extra_env=extra
+        producer, "--dbg", dependencies_root, offline=True, timeout=300, extra_env=extra
     )
     assert_success(produced)
     shared_libs = [
@@ -1089,7 +1089,7 @@ def test_conan_publish_shared_lib_round_trip(tmp_path):
     consumed = run_cuppa(
         consumer,
         "--dbg",
-        download_root,
+        dependencies_root,
         "--test",
         "--show-test-output",
         offline=True,
@@ -1118,7 +1118,7 @@ def test_conan_publish_source_modules_dir_override(tmp_path):
         driver,
         major,
     )
-    extra, download_root = _isolated_conan_home(tmp_path, conan)
+    extra, dependencies_root = _isolated_conan_home(tmp_path, conan)
 
     fixtures = REPO_ROOT / "tests" / "fixtures" / "modules_project"
     producer = tmp_path / "mod_publisher"
@@ -1138,7 +1138,7 @@ def test_conan_publish_source_modules_dir_override(tmp_path):
         "--modules",
         "--stdcpp=c++20",
         toolchain_flag,
-        download_root,
+        dependencies_root,
         offline=True,
         timeout=300,
         extra_env=extra,
@@ -1182,7 +1182,7 @@ def test_conan_publish_source_modules_dir_override(tmp_path):
         "--modules",
         "--stdcpp=c++20",
         toolchain_flag,
-        download_root,
+        dependencies_root,
         offline=True,
         timeout=300,
         extra_env=extra,
@@ -1230,7 +1230,7 @@ def test_conan_publish_source_modules_dir_override(tmp_path):
         "--modules",
         "--stdcpp=c++20",
         toolchain_flag,
-        download_root,
+        dependencies_root,
         offline=True,
         timeout=300,
         extra_env=extra,

--- a/tests/integration/test_storage_roots.md
+++ b/tests/integration/test_storage_roots.md
@@ -1,0 +1,9 @@
+# test_storage_roots
+
+Canonical documentation for this integration test is on the Cuppa docs site:
+
+**[test_storage_roots](https://ja11sop.github.io/cuppa/cuppa/integration/test-storage-roots.html)**
+
+Source: [`docs/modules/ROOT/pages/integration/test-storage-roots.adoc`](../../../docs/modules/ROOT/pages/integration/test-storage-roots.adoc)
+
+Related test module: `test_storage_roots.py`

--- a/tests/integration/test_storage_roots.py
+++ b/tests/integration/test_storage_roots.py
@@ -1,0 +1,119 @@
+import json
+import re
+
+import pytest
+
+from tests.helpers.cuppa_runner import assert_success, run_cuppa
+from tests.helpers.project import copy_dummy_project, write_sconstruct
+
+
+pytestmark = pytest.mark.integration
+
+
+def a_project(tmp_path):
+    project = copy_dummy_project(tmp_path)
+    write_sconstruct(project)
+    return project
+
+
+def own_home(tmp_path):
+    """A home directory for the run, so it neither reads nor writes the real one.
+
+    The storage roots default to a folder under the home directory, and cuppa keeps an existing
+    older folder in use when it finds one, so a run that shared the developer's home would report
+    whatever that machine happens to have.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    return {"HOME": str(home), "USERPROFILE": str(home)}
+
+
+def dumped_options(result):
+    """The options object cuppa prints under --dump."""
+    match = re.search(r"^\{$.*?^\}$", result.stdout, re.MULTILINE | re.DOTALL)
+    assert match, "no options dump in cuppa output:\n{}".format(result.stdout)
+    return json.loads(match.group(0))
+
+
+def test_storage_root_puts_both_roots_underneath_it(tmp_path):
+    project = a_project(tmp_path)
+    storage = tmp_path / "storage"
+
+    result = run_cuppa(
+        project,
+        "--dbg",
+        "--dump",
+        "--storage-root={}".format(storage),
+        extra_env=own_home(tmp_path),
+    )
+    assert_success(result)
+
+    options = dumped_options(result)
+    assert options["dependencies_root"] == str(storage / "dependencies")
+    assert options["downloads_root"] == str(storage / "downloads")
+    assert (storage / "downloads").is_dir()
+
+
+def test_naming_the_downloads_root_moves_only_that_half(tmp_path):
+    project = a_project(tmp_path)
+    storage = tmp_path / "storage"
+    archives = tmp_path / "archives"
+
+    result = run_cuppa(
+        project,
+        "--dbg",
+        "--dump",
+        "--storage-root={}".format(storage),
+        "--downloads-root={}".format(archives),
+        extra_env=own_home(tmp_path),
+    )
+    assert_success(result)
+
+    options = dumped_options(result)
+    assert options["downloads_root"] == str(archives)
+    assert options["dependencies_root"] == str(storage / "dependencies")
+
+
+def test_the_old_option_names_still_work_and_say_they_are_deprecated(tmp_path):
+    project = a_project(tmp_path)
+    trees = tmp_path / "trees"
+    archives = tmp_path / "archives"
+
+    result = run_cuppa(
+        project,
+        "--dbg",
+        "--dump",
+        "--download-root={}".format(trees),
+        "--cache-root={}".format(archives),
+        extra_env=own_home(tmp_path),
+    )
+    assert_success(result)
+
+    options = dumped_options(result)
+    assert options["dependencies_root"] == str(trees)
+    assert options["downloads_root"] == str(archives)
+    assert "--download-root" in result.stdout
+    assert "--dependencies-root" in result.stdout
+
+
+def test_an_existing_project_local_cuppa_folder_is_kept_in_use(tmp_path):
+    project = a_project(tmp_path)
+    (project / "_cuppa").mkdir()
+
+    result = run_cuppa(project, "--dbg", "--dump", extra_env=own_home(tmp_path))
+    assert_success(result)
+
+    options = dumped_options(result)
+    assert options["dependencies_root"] == "_cuppa"
+
+
+def test_the_default_roots_are_shared_between_projects(tmp_path):
+    project = a_project(tmp_path)
+    home = own_home(tmp_path)
+
+    result = run_cuppa(project, "--dbg", "--dump", extra_env=home)
+    assert_success(result)
+
+    options = dumped_options(result)
+    assert options["dependencies_root"] == str(tmp_path / "home" / ".cuppa" / "dependencies")
+    assert options["downloads_root"] == str(tmp_path / "home" / ".cuppa" / "downloads")

--- a/tests/unit/test_build_with_conan.py
+++ b/tests/unit/test_build_with_conan.py
@@ -261,7 +261,7 @@ def test_load_and_apply_fixture_via_generators_folder( tmp_path, monkeypatch ):
     Dep = conan_deps( name='conan', generators_folder=str( install ) )
     env = RecordingEnv(
             sconstruct_dir=str( tmp_path ),
-            download_root=str( tmp_path / 'dl' ),
+            dependencies_root=str( tmp_path / 'dl' ),
             offline=False,
             stdcpp='c++20',
             target_arch='x86_64',
@@ -299,7 +299,7 @@ def test_offline_install_fails_without_conan( tmp_path, monkeypatch ):
     Dep = conan_deps( name='conan', conanfile=str( conanfile ) )
     env = RecordingEnv(
             sconstruct_dir=str( tmp_path ),
-            download_root=str( tmp_path / 'dl' ),
+            dependencies_root=str( tmp_path / 'dl' ),
             offline=True,
             stdcpp='c++20',
             target_arch='x86_64',

--- a/tests/unit/test_construct_helpers.py
+++ b/tests/unit/test_construct_helpers.py
@@ -181,3 +181,23 @@ def test_get_sub_sconscripts_discovers_tree(tmp_path):
     assert any(p.endswith("app/foo.sconscript") for p in found_str)
     assert not any("_build" in p for p in found_str)
     assert not any("vendor/other" in p for p in found_str)
+
+
+def test_get_sub_sconscripts_with_only_absolute_excludes_still_finds_scripts(tmp_path):
+    """Absolute roots are skipped from the exclude pattern; that must not discard the tree.
+
+    Dependencies now default outside the project, so the exclude list can be empty after
+    absolute paths are filtered out. An empty alternation would match every folder.
+    """
+    construct = Construct.__new__(Construct)
+    root = tmp_path / "proj"
+    (root / "lib").mkdir(parents=True)
+    (root / "lib" / "sconscript").write_text("", encoding="utf-8")
+
+    found = construct.get_sub_sconscripts(str(root), [str(tmp_path / "elsewhere"), "_build"])
+    found_str = [str(p).replace("\\", "/") for p in found]
+    assert any(p.endswith("lib/sconscript") for p in found_str)
+
+    found = construct.get_sub_sconscripts(str(root), [str(tmp_path / "elsewhere")])
+    found_str = [str(p).replace("\\", "/") for p in found]
+    assert any(p.endswith("lib/sconscript") for p in found_str)

--- a/tests/unit/test_github_helpers.py
+++ b/tests/unit/test_github_helpers.py
@@ -1,0 +1,75 @@
+import pytest
+
+from scripts import github_helpers
+
+
+pytestmark = pytest.mark.unit
+
+
+class FakeGitHub( object ):
+
+    def __init__( self ):
+        self.calls = []
+
+    def request( self, method, path, payload=None ):
+        self.calls.append( ( method, path, payload ) )
+        if path.endswith( '/pulls' ):
+            return 201, { 'number': 42, 'html_url': 'https://example.com/pr/42' }
+        if path.endswith( '/labels' ):
+            return 200, [ { 'name': label } for label in payload['labels'] ]
+        return 404, {}
+
+
+def test_repository_parses_ssh_and_https_remotes( monkeypatch ):
+    monkeypatch.setattr(
+        github_helpers, '_run_git',
+        lambda *args: 'git@github.com:ja11sop/cuppa.git' if args[-1] == 'remote.origin.url' else '',
+    )
+    assert github_helpers.repository() == ( 'ja11sop', 'cuppa' )
+
+    monkeypatch.setattr(
+        github_helpers, '_run_git',
+        lambda *args: 'https://github.com/ja11sop/cuppa.git',
+    )
+    assert github_helpers.repository() == ( 'ja11sop', 'cuppa' )
+
+
+def test_repository_falls_back_when_git_is_unavailable( monkeypatch ):
+    def fail( *args ):
+        raise github_helpers.GitHubHelperError( 'no git' )
+    monkeypatch.setattr( github_helpers, '_run_git', fail )
+    assert github_helpers.repository() == ( 'ja11sop', 'cuppa' )
+
+
+def test_create_pull_request_opens_and_labels( monkeypatch ):
+    monkeypatch.setattr( github_helpers, 'current_branch', lambda: 'feature' )
+    client = FakeGitHub()
+
+    pull = github_helpers.create_pull_request(
+        title = 'A change',
+        body = 'Why',
+        labels = [ 'impact:minor' ],
+        github = client,
+    )
+
+    assert pull['html_url'] == 'https://example.com/pr/42'
+    assert client.calls[0][0] == 'POST'
+    assert client.calls[0][1].endswith( '/pulls' )
+    assert client.calls[0][2]['head'] == 'feature'
+    assert client.calls[0][2]['base'] == 'master'
+    assert client.calls[1][1].endswith( '/issues/42/labels' )
+    assert client.calls[1][2] == { 'labels': [ 'impact:minor' ] }
+
+
+def test_create_pull_request_reports_api_failure():
+    class Failing( object ):
+        def request( self, method, path, payload=None ):
+            return 422, { 'message': 'Validation Failed' }
+
+    with pytest.raises( github_helpers.GitHubHelperError, match='422' ):
+        github_helpers.create_pull_request(
+            title = 'A change',
+            body = 'Why',
+            head = 'feature',
+            github = Failing(),
+        )

--- a/tests/unit/test_github_helpers.py
+++ b/tests/unit/test_github_helpers.py
@@ -1,3 +1,5 @@
+import io
+
 import pytest
 
 from scripts import github_helpers
@@ -8,12 +10,15 @@ pytestmark = pytest.mark.unit
 
 class FakeGitHub( object ):
 
-    def __init__( self ):
+    def __init__( self, responses=None ):
         self.calls = []
+        self.responses = list( responses or [] )
 
     def request( self, method, path, payload=None ):
         self.calls.append( ( method, path, payload ) )
-        if path.endswith( '/pulls' ):
+        if self.responses:
+            return self.responses.pop( 0 )
+        if path.endswith( '/pulls' ) and method == 'POST':
             return 201, { 'number': 42, 'html_url': 'https://example.com/pr/42' }
         if path.endswith( '/labels' ):
             return 200, [ { 'name': label } for label in payload['labels'] ]
@@ -73,3 +78,136 @@ def test_create_pull_request_reports_api_failure():
             head = 'feature',
             github = Failing(),
         )
+
+
+def test_outcome_for_pending_success_and_failure():
+    pending = [ github_helpers.CheckRun( 'unit', 'in_progress', None, '' ) ]
+    assert github_helpers.outcome_for( pending ) == 'pending'
+    assert github_helpers.outcome_for( [] ) == 'pending'
+
+    ok = [
+        github_helpers.CheckRun( 'unit', 'completed', 'success', '' ),
+        github_helpers.CheckRun( 'docs', 'completed', 'skipped', '' ),
+    ]
+    assert github_helpers.outcome_for( ok ) == 'success'
+
+    bad = [
+        github_helpers.CheckRun( 'unit', 'completed', 'success', '' ),
+        github_helpers.CheckRun( 'integration', 'completed', 'failure', '' ),
+    ]
+    assert github_helpers.outcome_for( bad ) == 'failure'
+
+
+def test_pull_request_status_summarises_checks( monkeypatch ):
+    monkeypatch.setattr( github_helpers, 'current_branch', lambda: 'feature' )
+    client = FakeGitHub( responses=[
+        ( 200, [ {
+            'number': 139,
+            'html_url': 'https://example.com/pr/139',
+            'state': 'open',
+            'mergeable_state': 'unstable',
+            'head': { 'sha': 'abcdef0123456789' },
+        } ] ),
+        ( 200, {
+            'check_runs': [
+                {
+                    'name': 'unit',
+                    'status': 'completed',
+                    'conclusion': 'success',
+                    'html_url': 'https://example.com/unit',
+                },
+                {
+                    'name': 'integration',
+                    'status': 'in_progress',
+                    'conclusion': None,
+                    'html_url': 'https://example.com/integration',
+                },
+            ]
+        } ),
+    ] )
+
+    status = github_helpers.pull_request_status( github=client )
+    assert status.number == 139
+    assert status.outcome == 'pending'
+    assert [ check.name for check in status.checks ] == [ 'integration', 'unit' ]
+
+    rendered = github_helpers.format_pull_request_status( status )
+    assert 'PR #139' in rendered
+    assert 'outcome=pending' in rendered
+    assert 'integration' in rendered and 'in_progress' in rendered
+
+
+def test_watch_pull_request_returns_when_checks_finish( monkeypatch ):
+    monkeypatch.setattr( github_helpers, 'current_branch', lambda: 'feature' )
+    pending = github_helpers.PullRequestStatus(
+        number=139,
+        url='https://example.com/pr/139',
+        head_sha='abcdef01',
+        state='open',
+        mergeable_state='unstable',
+        checks=[ github_helpers.CheckRun( 'unit', 'in_progress', None, '' ) ],
+        outcome='pending',
+    )
+    success = pending._replace(
+        checks=[ github_helpers.CheckRun( 'unit', 'completed', 'success', '' ) ],
+        outcome='success',
+        mergeable_state='clean',
+    )
+    states = [ pending, success ]
+    monkeypatch.setattr(
+        github_helpers, 'pull_request_status',
+        lambda **kwargs: states.pop( 0 ),
+    )
+
+    sleeps = []
+    out = io.StringIO()
+    code, last = github_helpers.watch_pull_request(
+        interval=1,
+        timeout=60,
+        out=out,
+        sleep=lambda seconds: sleeps.append( seconds ),
+        clock=lambda: 0 if len( sleeps ) == 0 else 10,
+    )
+
+    assert code == github_helpers.EXIT_SUCCESS
+    assert last.outcome == 'success'
+    assert sleeps == [ 1 ]
+    assert 'outcome=pending' in out.getvalue()
+    assert 'outcome=success' in out.getvalue()
+
+
+def test_watch_pull_request_times_out( monkeypatch ):
+    monkeypatch.setattr(
+        github_helpers, 'pull_request_status',
+        lambda **kwargs: github_helpers.PullRequestStatus(
+            number=139,
+            url='https://example.com/pr/139',
+            head_sha='abcdef01',
+            state='open',
+            mergeable_state='unstable',
+            checks=[ github_helpers.CheckRun( 'unit', 'queued', None, '' ) ],
+            outcome='pending',
+        ),
+    )
+
+    out = io.StringIO()
+    now = [ 0 ]
+
+    def clock():
+        return now[0]
+
+    def sleep( seconds ):
+        now[0] += seconds
+
+    code, last = github_helpers.watch_pull_request(
+        number=139,
+        interval=5,
+        timeout=5,
+        out=out,
+        sleep=sleep,
+        clock=clock,
+    )
+
+    assert code == github_helpers.EXIT_TIMEOUT
+    assert last.outcome == 'pending'
+    assert 'timed out' in out.getvalue()

--- a/tests/unit/test_github_helpers.py
+++ b/tests/unit/test_github_helpers.py
@@ -39,11 +39,46 @@ def test_repository_parses_ssh_and_https_remotes( monkeypatch ):
     assert github_helpers.repository() == ( 'ja11sop', 'cuppa' )
 
 
-def test_repository_falls_back_when_git_is_unavailable( monkeypatch ):
+def test_repository_fails_when_origin_is_missing_or_unparseable( monkeypatch ):
     def fail( *args ):
         raise github_helpers.GitHubHelperError( 'no git' )
     monkeypatch.setattr( github_helpers, '_run_git', fail )
-    assert github_helpers.repository() == ( 'ja11sop', 'cuppa' )
+    with pytest.raises( github_helpers.GitHubHelperError, match='no git' ):
+        github_helpers.repository()
+
+    monkeypatch.setattr( github_helpers, '_run_git', lambda *args: 'not-a-github-remote' )
+    with pytest.raises( github_helpers.GitHubHelperError, match='could not parse' ):
+        github_helpers.repository()
+
+
+def test_pull_request_status_uses_a_public_client_by_default( monkeypatch ):
+    created = []
+
+    class CapturingPublic( object ):
+        @classmethod
+        def public( cls ):
+            client = FakeGitHub( responses=[
+                ( 200, {
+                    'number': 139,
+                    'html_url': 'https://example.com/pr/139',
+                    'state': 'open',
+                    'mergeable_state': 'clean',
+                    'head': { 'sha': 'abcdef0123456789' },
+                } ),
+                ( 200, { 'check_runs': [] } ),
+            ] )
+            created.append( client )
+            return client
+
+    monkeypatch.setattr( github_helpers, 'GitHub', CapturingPublic )
+    monkeypatch.setattr(
+        github_helpers, 'repository',
+        lambda owner=None, repo=None: ( 'ja11sop', 'cuppa' ),
+    )
+
+    status = github_helpers.pull_request_status( number=139 )
+    assert status.number == 139
+    assert created, "status helpers must use GitHub.public(), not the sealed client"
 
 
 def test_create_pull_request_opens_and_labels( monkeypatch ):

--- a/tests/unit/test_storage_options.py
+++ b/tests/unit/test_storage_options.py
@@ -1,16 +1,295 @@
+import os
+
 import pytest
 
 from cuppa.core import storage_options
+from cuppa.core.storage_options import default, resolve_root, LEGACY_DEPENDENCIES, LEGACY_DOWNLOADS
 from tests.helpers.fakes import FakeEnv
 
 
 pytestmark = pytest.mark.unit
 
 
-def test_process_storage_options_defaults(monkeypatch, tmp_path):
-    monkeypatch.chdir(tmp_path)
-    env = FakeEnv()
+@pytest.fixture
+def elsewhere(monkeypatch, tmp_path):
+    """A home and a working directory of our own.
+
+    Storage defaults live under the home directory and the fallback to an older location looks at
+    the filesystem, so a test that did not move both would read the machine running it.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.chdir(project)
+    return home, project
+
+
+def env_for(project, **options):
+    env = FakeEnv(options)
+    env["sconstruct_dir"] = str(project)
+    return env
+
+
+def test_both_roots_default_to_a_shared_folder_under_the_home_directory(elsewhere):
+    home, project = elsewhere
+    env = env_for(project)
+
     storage_options.process_storage_options(env)
-    assert env["build_root"] == "_build"
-    assert env["download_root"] == "_cuppa"
-    assert "cache" in env["cache_root"] or env["cache_root"].endswith("_cache")
+
+    assert env["storage_root"] == str(home / ".cuppa")
+    assert env["dependencies_root"] == str(home / ".cuppa" / "dependencies")
+    assert env["downloads_root"] == str(home / ".cuppa" / "downloads")
+
+
+def test_the_build_root_stays_with_the_project(elsewhere):
+    home, project = elsewhere
+    env = env_for(project)
+
+    storage_options.process_storage_options(env)
+
+    assert env["build_root"] == default.build_root
+    assert env["abs_build_root"] == os.path.join(str(project), default.build_root)
+
+
+def test_the_storage_root_moves_both_roots_together(elsewhere):
+    home, project = elsewhere
+    env = env_for(project, storage_root=str(project / "_cuppa"))
+
+    storage_options.process_storage_options(env)
+
+    assert env["dependencies_root"] == str(project / "_cuppa" / "dependencies")
+    assert env["downloads_root"] == str(project / "_cuppa" / "downloads")
+
+
+def test_a_root_named_on_its_own_leaves_the_other_derived(elsewhere):
+    home, project = elsewhere
+    env = env_for(project, downloads_root=str(project / "archives"))
+
+    storage_options.process_storage_options(env)
+
+    assert env["downloads_root"] == str(project / "archives")
+    assert env["dependencies_root"] == str(home / ".cuppa" / "dependencies")
+
+
+def test_a_named_root_wins_over_the_storage_root_it_would_otherwise_derive_from(elsewhere):
+    home, project = elsewhere
+    env = env_for(
+        project,
+        storage_root=str(project / "_cuppa"),
+        dependencies_root=str(project / "elsewhere"),
+    )
+
+    storage_options.process_storage_options(env)
+
+    assert env["dependencies_root"] == str(project / "elsewhere")
+    assert env["downloads_root"] == str(project / "_cuppa" / "downloads")
+
+
+def test_a_home_relative_root_is_expanded(elsewhere):
+    home, project = elsewhere
+    env = env_for(project, storage_root="~/somewhere")
+
+    storage_options.process_storage_options(env)
+
+    assert env["dependencies_root"] == str(home / "somewhere" / "dependencies")
+
+
+def test_the_downloads_root_is_created_so_an_archive_has_somewhere_to_land(elsewhere):
+    home, project = elsewhere
+    env = env_for(project)
+
+    storage_options.process_storage_options(env)
+
+    assert os.path.isdir(env["downloads_root"])
+
+
+# Deprecated aliases
+
+
+def test_the_old_option_names_still_choose_the_roots(elsewhere):
+    home, project = elsewhere
+    env = env_for(
+        project,
+        download_root=str(project / "old_download"),
+        cache_root=str(project / "old_cache"),
+    )
+
+    storage_options.process_storage_options(env)
+
+    assert env["dependencies_root"] == str(project / "old_download")
+    assert env["downloads_root"] == str(project / "old_cache")
+
+
+def test_using_an_old_option_name_is_reported_as_deprecated(elsewhere, caplog):
+    home, project = elsewhere
+    env = env_for(project, download_root=str(project / "old_download"))
+
+    with caplog.at_level("WARNING"):
+        storage_options.process_storage_options(env)
+
+    assert "--download-root" in caplog.text
+    assert "--dependencies-root" in caplog.text
+
+
+def test_a_new_option_wins_over_the_old_name_for_the_same_root(elsewhere):
+    home, project = elsewhere
+    env = env_for(
+        project,
+        dependencies_root=str(project / "new"),
+        download_root=str(project / "old"),
+    )
+
+    storage_options.process_storage_options(env)
+
+    assert env["dependencies_root"] == str(project / "new")
+
+
+def test_the_old_env_keys_alias_the_resolved_roots(elsewhere):
+    home, project = elsewhere
+    env = env_for(project)
+
+    storage_options.process_storage_options(env)
+
+    assert env["download_root"] == env["dependencies_root"]
+    assert env["cache_root"] == env["downloads_root"]
+
+
+# Keeping an older location in use
+
+
+def test_a_project_local_cuppa_folder_is_kept_rather_than_re_fetched(elsewhere):
+    home, project = elsewhere
+    (project / "_cuppa").mkdir()
+    env = env_for(project)
+
+    storage_options.process_storage_options(env)
+
+    assert env["dependencies_root"] == "_cuppa"
+
+
+def test_a_kept_project_local_folder_stays_relative_so_it_is_still_excluded_from_discovery(elsewhere):
+    home, project = elsewhere
+    (project / "_cuppa").mkdir()
+    env = env_for(project)
+
+    storage_options.process_storage_options(env)
+
+    assert not os.path.isabs(env["dependencies_root"])
+
+
+def test_the_shared_download_folder_from_an_older_cuppa_is_kept(elsewhere):
+    home, project = elsewhere
+    (home / "_cuppa" / "_download").mkdir(parents=True)
+    (home / "_cuppa" / "_cache").mkdir(parents=True)
+    env = env_for(project)
+
+    storage_options.process_storage_options(env)
+
+    assert env["dependencies_root"] == str(home / "_cuppa" / "_download")
+    assert env["downloads_root"] == str(home / "_cuppa" / "_cache")
+
+
+def test_a_project_local_folder_is_preferred_over_the_shared_one(elsewhere):
+    home, project = elsewhere
+    (project / "_cuppa").mkdir()
+    (home / "_cuppa" / "_download").mkdir(parents=True)
+    env = env_for(project)
+
+    storage_options.process_storage_options(env)
+
+    assert env["dependencies_root"] == "_cuppa"
+
+
+def test_a_project_local_folder_is_found_next_to_the_sconstruct_not_the_launch_directory(
+    elsewhere, monkeypatch
+):
+    home, project = elsewhere
+    (project / "_cuppa").mkdir()
+    leaf = project / "component"
+    leaf.mkdir()
+    monkeypatch.chdir(leaf)
+    env = env_for(project)
+
+    storage_options.process_storage_options(env)
+
+    assert env["dependencies_root"] == "_cuppa"
+
+
+def test_keeping_an_older_folder_is_reported_with_the_option_that_moves_it(elsewhere, caplog):
+    home, project = elsewhere
+    (project / "_cuppa").mkdir()
+    env = env_for(project)
+
+    with caplog.at_level("INFO"):
+        storage_options.process_storage_options(env)
+
+    assert "_cuppa" in caplog.text
+    assert "--dependencies-root" in caplog.text
+
+
+def test_a_named_root_wins_over_an_older_folder_that_is_still_there(elsewhere):
+    home, project = elsewhere
+    (project / "_cuppa").mkdir()
+    env = env_for(project, dependencies_root=str(project / "chosen"))
+
+    storage_options.process_storage_options(env)
+
+    assert env["dependencies_root"] == str(project / "chosen")
+
+
+def test_an_old_option_name_wins_over_an_older_folder_that_is_still_there(elsewhere):
+    home, project = elsewhere
+    (project / "_cuppa").mkdir()
+    env = env_for(project, download_root=str(project / "chosen"))
+
+    storage_options.process_storage_options(env)
+
+    assert env["dependencies_root"] == str(project / "chosen")
+
+
+# The rule on its own
+
+
+def test_resolve_root_names_what_decided_the_path(tmp_path):
+    chosen = resolve_root("chosen", None, (), "derived")
+    assert chosen == ("chosen", "option", None)
+
+    aliased = resolve_root(None, "aliased", (), "derived")
+    assert aliased == ("aliased", "deprecated", None)
+
+    derived = resolve_root(None, None, (), "derived")
+    assert derived == ("derived", "derived", None)
+
+
+def test_resolve_root_reports_the_older_folder_it_kept(tmp_path):
+    (tmp_path / "_cuppa").mkdir()
+
+    kept = resolve_root(None, None, LEGACY_DEPENDENCIES, "derived", str(tmp_path))
+
+    assert kept.source == "legacy"
+    assert kept.origin == "_cuppa"
+
+
+def test_resolve_root_derives_when_no_older_folder_is_there(elsewhere, tmp_path):
+    resolved = resolve_root(None, None, LEGACY_DOWNLOADS, str(tmp_path / "downloads"), str(tmp_path))
+
+    assert resolved.source == "derived"
+    assert resolved.path == str(tmp_path / "downloads")
+
+
+# Reporting the roots in build output
+
+
+def test_the_roots_are_named_once_however_many_dependencies_are_retrieved(elsewhere, caplog):
+    home, project = elsewhere
+    env = env_for(project)
+    storage_options.process_storage_options(env)
+
+    with caplog.at_level("INFO"):
+        storage_options.report_roots(env)
+        storage_options.report_roots(env)
+
+    assert caplog.text.count("for dependencies and") == 1


### PR DESCRIPTION
## Summary

- Renames storage to `--dependencies-root` / `--downloads-root` under a shared `--storage-root` defaulting to `~/.cuppa`, so retrieved trees are reused across projects instead of living in each project's `_cuppa` (#133).
- Keeps `--download-root` / `--cache-root` and the old env keys as deprecated aliases; if a project-local `_cuppa` or `~/_cuppa/_download` / `~/_cuppa/_cache` already exists and no root is named, that tree is kept in use so upgrades do not re-fetch.
- Resolves all four cases in one `resolve_root()`; reports the roots on first retrieval; fixes empty sconscript/Glob exclusion when only absolute roots remain after filtering.

## Test plan

- [x] `pytest -m unit` (includes new storage precedence / legacy fallback cases)
- [x] `pytest tests/integration/test_storage_roots.py`
- [ ] CI: unit + Linux/Windows integration matrix
- [ ] Smoke on a project with an existing `_cuppa` and confirm the fallback message and no re-fetch
- [ ] Smoke with `--storage-root=_cuppa` and with `--downloads-root=` alone
