### PR TITLE
Add --list-builds and --remove-builds for clearing variant trees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,8 @@ cuppa -D --toolchains=gcc,clang
 cuppa -D --scripts=path/to/sconscript
 cuppa -D --list-develop
 cuppa -D --update-develop
+cuppa -D --list-builds
+cuppa -D --dbg --remove-build -n
 ```
 
 `cuppa` wraps `scons`, appends `--cuppa-mode`, masks `*TOKEN*` env values in output, and may restrict CPU affinity with `--parallel`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,11 +160,27 @@ work on a machine with no TPM.
 
 ### Using it
 
-`scripts.github_api` is the credential and transport layer. It reads the sealed token into the
-calling process only — never into the environment — and makes authenticated API calls:
+**Reads** go through the public API — no sealed token. Prefer `scripts.github_helpers`
+(`pr-status` / `watch-pr`) for pull-request CI, or an anonymous client for ad-hoc GETs:
 
 ```sh
 python -m scripts.github_api GET /repos/ja11sop/cuppa/issues/132
+python -m scripts.github_helpers pr-status --pr 140
+```
+
+```python
+from scripts.github_api import GitHub
+GitHub.public().request( 'GET', '/repos/ja11sop/cuppa/pulls/140' )
+```
+
+The CLI uses the anonymous client for `GET` / `HEAD` by default. Pass `--auth` only when a read
+truly needs the sealed credential (private resources). Do not unseal just to poll CI.
+
+**Writes** use the sealed credential. `scripts.github_api` reads the token into the calling
+process only — never into the environment:
+
+```sh
+python -m scripts.github_api PATCH /repos/ja11sop/cuppa/pulls/140 --data '{"title":"…"}'
 ```
 
 ```python

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,7 +232,7 @@ cuppa -D --scripts=path/to/sconscript
 cuppa -D --list-develop
 cuppa -D --update-develop
 cuppa -D --list-builds
-cuppa -D --dbg --remove-build -n
+cuppa -D --dbg --remove-builds -n
 ```
 
 `cuppa` wraps `scons`, appends `--cuppa-mode`, masks `*TOKEN*` env values in output, and may restrict CPU affinity with `--parallel`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,12 +40,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   name rows emphasise size, mark, and name in the info colour; partial and unselected rows are
   dimmed. A closing summary emphasises the selected size (info-coloured when less than the total)
   and prints an explicit `cuppa -D …` command for the selected builds present on disk (for use
-  with `--remove-build`). `--list-format=json` makes the same structures scriptable (#134).
-- `--remove-build` removes the variant subtrees that match the current toolchain and variant
-  selection (the same composition the build uses), then prunes empty parents. `--remove-all-builds`
-  removes the entire build root. Both refuse suspicious roots and symlink traversal, report before
-  acting, and honour SCons `-n` as a dry run. Neither touches artefact trees outside the build
-  root (#134).
+  with `--remove-builds`). `--list-format=json` makes the same structures scriptable (#134).
+- `--remove-builds` removes the variant subtrees that match the current toolchain and variant
+  selection (the same composition the build uses), then prunes empty parents. It announces the
+  removal, acts, then prints the same three views as `--list-builds` with a `REMOVED` column
+  (error colour and checks for success; warning/error colour and ballots for failures, with a
+  reason tree using short paths), and finishes with `Removed N entries freeing up SIZE` plus an
+  explicit `cuppa -D … --list-builds` verification command. Mixed success/failure rollups use
+  `✓-✗`. Dry-run (`-n`) shows the plan without deleting.
+  `--remove-all-builds` removes the entire build root, with the same short-path announce styling,
+  the same three REMOVED tables afterwards, and the same failure reason tree when the root cannot
+  be deleted.
+  Both refuse suspicious roots and symlink
+  traversal and honour SCons `-n`. Neither touches artefact trees outside the build root.
+  Annotated example output for `--list-builds`, `--remove-builds`, and `--remove-all-builds` is in
+  the build-layout documentation (#134).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a build retrieves inside the project (#133).
 - The dependencies and downloads roots are named at info level the first time a run retrieves
   anything, so where a build is reading from and writing to is visible in its output (#133).
+- `--list-builds` reports the build root in three views and exits without building: an info-coloured
+  folder total with the selected subset hung beneath it (`all N entries selected` when every entry
+  matches), a toolchain → `variant/arch/abi` tree with `✓✓✓` / `-✓-` / `---` selection marks
+  (ASCII `*`), and a sconscript tree with rolled-up sizes. Fully selected sconscript and toolchain
+  name rows emphasise size, mark, and name in the info colour; partial and unselected rows are
+  dimmed. A closing summary emphasises the selected size (info-coloured when less than the total)
+  and prints an explicit `cuppa -D …` command for the selected builds present on disk (for use
+  with `--remove-build`). `--list-format=json` makes the same structures scriptable (#134).
+- `--remove-build` removes the variant subtrees that match the current toolchain and variant
+  selection (the same composition the build uses), then prunes empty parents. `--remove-all-builds`
+  removes the entire build root. Both refuse suspicious roots and symlink traversal, report before
+  acting, and honour SCons `-n` as a dry run. Neither touches artefact trees outside the build
+  root (#134).
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -247,14 +247,14 @@ mechanics: [`design/plans/removal-options.md`](design/plans/removal-options.md).
 | `--clean` removes the current variant's build outputs | Yes |
 | `--list-develop` / `--update-develop` for the working copies `--develop` builds against | Yes — [#132](https://github.com/ja11sop/cuppa/issues/132) |
 | Shared storage under `~/.cuppa`, named `--dependencies-root` / `--downloads-root`, with `--storage-root` to move both | Yes — [#133](https://github.com/ja11sop/cuppa/issues/133) |
-| Remove a whole build tree, a dependency, or a stale download | No — manual deletion |
-| See what is stored, where, and how large it is | No |
+| Remove a whole build tree, a dependency, or a stale download | Builds: `--remove-build` / `--remove-all-builds` in progress ([#134](https://github.com/ja11sop/cuppa/issues/134)); dependencies and downloads still manual |
+| See what is stored, where, and how large it is | Builds: `--list-builds` in progress ([#134](https://github.com/ja11sop/cuppa/issues/134)); dependencies and downloads still no |
 
 ### Planned / potential
 
 | ID | Work | Priority | Notes |
 |----|------|----------|-------|
-| `storage-listing-removal` | `--list-*`, `--remove-*`, `--purge-*` for builds, dependencies, and downloads | Medium | Depends on the rename so one vocabulary is used throughout. GitHub [#134](https://github.com/ja11sop/cuppa/issues/134) |
+| `storage-listing-removal` | `--list-*`, `--remove-*`, `--purge-*` for builds, dependencies, and downloads | Medium | Build half in progress on `134_list_and_remove_builds`; dependency/download halves follow. GitHub [#134](https://github.com/ja11sop/cuppa/issues/134) |
 | `develop-clone` | `--clone-develop` for a develop working copy that is configured but not yet on disk, for a new machine or a dependency added since you last looked | Medium | Surface settled, remaining design to finalise first: pinned locations, submodules, whether retrieval machinery is reused. [`design/plans/removal-options.md`](design/plans/removal-options.md) §3.7. GitHub [#138](https://github.com/ja11sop/cuppa/issues/138) |
 | `artefact-removal` | Decide how to remove artefacts written outside the build root | Low | Design pass first; `--remove-build` deliberately stops at `_build`. GitHub [#135](https://github.com/ja11sop/cuppa/issues/135) |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -275,3 +275,27 @@ Add new `##` headings here as larger efforts start, for example:
 - Additional toolchains or platforms
 
 Each new section should follow the same shape: **Today** → **Planned / potential** → **Out of scope**.
+
+---
+
+## Documentation tooling
+
+### Today
+
+| Capability | Status |
+|------------|--------|
+| Antora site under `docs/` with Mermaid and Lunr | Yes |
+| Plain-text examples of report output in AsciiDoc | Yes — e.g. build-layout listing/removal samples |
+| Terminal colour via colorama meanings (`as_error`, `as_info`, …) | Yes |
+
+### Planned / potential
+
+| ID | Work | Priority | Notes |
+|----|------|----------|-------|
+| `doc-output-samples` | Capture report output as semantic HTML for Antora and local preview | Low | Prefer meaning→CSS over ANSI scrape. [`design/plans/colourised-doc-samples.md`](design/plans/colourised-doc-samples.md) |
+
+### Out of scope (docs tooling)
+
+| ID | Item | Reason |
+|----|------|--------|
+| `doc-ansi-only` | Rely solely on ANSI→HTML for committed samples | Terminal palette and light/dark subdued handling make samples drift |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -247,14 +247,14 @@ mechanics: [`design/plans/removal-options.md`](design/plans/removal-options.md).
 | `--clean` removes the current variant's build outputs | Yes |
 | `--list-develop` / `--update-develop` for the working copies `--develop` builds against | Yes — [#132](https://github.com/ja11sop/cuppa/issues/132) |
 | Shared storage under `~/.cuppa`, named `--dependencies-root` / `--downloads-root`, with `--storage-root` to move both | Yes — [#133](https://github.com/ja11sop/cuppa/issues/133) |
-| Remove a whole build tree, a dependency, or a stale download | Builds: `--remove-builds` / `--remove-all-builds` in progress ([#134](https://github.com/ja11sop/cuppa/issues/134)); dependencies and downloads still manual |
-| See what is stored, where, and how large it is | Builds: `--list-builds` in progress ([#134](https://github.com/ja11sop/cuppa/issues/134)); dependencies and downloads still no |
+| Remove a whole build tree, a dependency, or a stale download | Builds: `--remove-builds` / `--remove-all-builds` ([#134](https://github.com/ja11sop/cuppa/issues/134) / #140); dependencies and downloads still manual |
+| See what is stored, where, and how large it is | Builds: `--list-builds` ([#134](https://github.com/ja11sop/cuppa/issues/134) / #140); dependencies and downloads still no |
 
 ### Planned / potential
 
 | ID | Work | Priority | Notes |
 |----|------|----------|-------|
-| `storage-listing-removal` | `--list-*`, `--remove-*`, `--purge-*` for builds, dependencies, and downloads | Medium | Build half in progress on `134_list_and_remove_builds`; dependency/download halves follow. GitHub [#134](https://github.com/ja11sop/cuppa/issues/134) |
+| `storage-listing-removal` | `--list-*`, `--remove-*`, `--purge-*` for builds, dependencies, and downloads | Medium | Build half done (#140); dependency/download halves follow. GitHub [#134](https://github.com/ja11sop/cuppa/issues/134) |
 | `develop-clone` | `--clone-develop` for a develop working copy that is configured but not yet on disk, for a new machine or a dependency added since you last looked | Medium | Surface settled, remaining design to finalise first: pinned locations, submodules, whether retrieval machinery is reused. [`design/plans/removal-options.md`](design/plans/removal-options.md) §3.7. GitHub [#138](https://github.com/ja11sop/cuppa/issues/138) |
 | `artefact-removal` | Decide how to remove artefacts written outside the build root | Low | Design pass first; `--remove-builds` deliberately stops at `_build`. GitHub [#135](https://github.com/ja11sop/cuppa/issues/135) |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -247,7 +247,7 @@ mechanics: [`design/plans/removal-options.md`](design/plans/removal-options.md).
 | `--clean` removes the current variant's build outputs | Yes |
 | `--list-develop` / `--update-develop` for the working copies `--develop` builds against | Yes — [#132](https://github.com/ja11sop/cuppa/issues/132) |
 | Shared storage under `~/.cuppa`, named `--dependencies-root` / `--downloads-root`, with `--storage-root` to move both | Yes — [#133](https://github.com/ja11sop/cuppa/issues/133) |
-| Remove a whole build tree, a dependency, or a stale download | Builds: `--remove-build` / `--remove-all-builds` in progress ([#134](https://github.com/ja11sop/cuppa/issues/134)); dependencies and downloads still manual |
+| Remove a whole build tree, a dependency, or a stale download | Builds: `--remove-builds` / `--remove-all-builds` in progress ([#134](https://github.com/ja11sop/cuppa/issues/134)); dependencies and downloads still manual |
 | See what is stored, where, and how large it is | Builds: `--list-builds` in progress ([#134](https://github.com/ja11sop/cuppa/issues/134)); dependencies and downloads still no |
 
 ### Planned / potential
@@ -256,7 +256,7 @@ mechanics: [`design/plans/removal-options.md`](design/plans/removal-options.md).
 |----|------|----------|-------|
 | `storage-listing-removal` | `--list-*`, `--remove-*`, `--purge-*` for builds, dependencies, and downloads | Medium | Build half in progress on `134_list_and_remove_builds`; dependency/download halves follow. GitHub [#134](https://github.com/ja11sop/cuppa/issues/134) |
 | `develop-clone` | `--clone-develop` for a develop working copy that is configured but not yet on disk, for a new machine or a dependency added since you last looked | Medium | Surface settled, remaining design to finalise first: pinned locations, submodules, whether retrieval machinery is reused. [`design/plans/removal-options.md`](design/plans/removal-options.md) §3.7. GitHub [#138](https://github.com/ja11sop/cuppa/issues/138) |
-| `artefact-removal` | Decide how to remove artefacts written outside the build root | Low | Design pass first; `--remove-build` deliberately stops at `_build`. GitHub [#135](https://github.com/ja11sop/cuppa/issues/135) |
+| `artefact-removal` | Decide how to remove artefacts written outside the build root | Low | Design pass first; `--remove-builds` deliberately stops at `_build`. GitHub [#135](https://github.com/ja11sop/cuppa/issues/135) |
 
 ### Out of scope (storage)
 

--- a/cuppa/construct.py
+++ b/cuppa/construct.py
@@ -24,8 +24,10 @@ import SCons.Script
 import cuppa.core.environment
 import cuppa.core.base_options
 import cuppa.core.storage_options
+import cuppa.core.storage_actions
 import cuppa.core.location_options
 import cuppa.core.options
+import cuppa.core.build_layout
 import cuppa.modules.registration
 import cuppa.build_platform
 import cuppa.output_processor
@@ -402,6 +404,7 @@ class Construct(object):
         cuppa_env['thirdparty'] = thirdparty
 
         cuppa.core.storage_options.process_storage_options( cuppa_env )
+        cuppa.core.storage_actions.process_storage_action_options( cuppa_env )
         cuppa.core.location_options.process_location_options( cuppa_env )
 
         cuppa_env['current_branch'] = ''
@@ -558,6 +561,11 @@ class Construct(object):
                 logger.info( as_info_label(
                         "Running in LIST DEVELOP mode, no building will be attempted" ) )
                 SCons.Script.Exit( cuppa.develop.list_develop( cuppa_env ) )
+
+            if cuppa.core.storage_actions.wants_storage_action( cuppa_env ):
+                SCons.Script.Exit(
+                        cuppa.core.storage_actions.run( self, cuppa_env )
+                )
 
             job_count = cuppa_env.get_option( 'num_jobs' )
             parallel  = cuppa_env.get_option( 'parallel' )
@@ -737,9 +745,6 @@ class Construct(object):
         logger.debug( "Using active_variants = [{}]".format( colour_items( active_variants, as_info ) ) )
         logger.debug( "Using active_actions = [{}]".format( colour_items( active_actions, as_info ) ) )
 
-        def sanitise_abi( abi ):
-            return abi.replace( "+", "x" )
-
         build_envs = []
 
         for key, variant in active_variants.items():
@@ -750,7 +755,7 @@ class Construct(object):
 
                 if env:
 
-                    abi = sanitise_abi( toolchain.abi( env ) )
+                    abi = cuppa.core.build_layout.sanitise_abi( toolchain.abi( env ) )
 
                     self.propagate_env_variables(
                             env,
@@ -774,7 +779,7 @@ class Construct(object):
                     env['toolchain']       = toolchain
                     env['variant']         = variant
                     env['target_arch']     = target_arch
-                    env['abi']             = sanitise_abi( toolchain.abi( env ) )
+                    env['abi']             = cuppa.core.build_layout.sanitise_abi( toolchain.abi( env ) )
                     env['raw_abi']         = toolchain.abi( env )
                     env['variant_actions'] = self.get_active_actions( cuppa_env, variant, active_variants, active_actions )
 
@@ -949,7 +954,9 @@ class Construct(object):
             sconscript_env['sconscript_dir'] = os.path.join( sconscript_env['base_path'], sconstruct_offset_path )
             sconscript_env['abs_sconscript_dir'] = os.path.abspath( sconscript_env['sconscript_dir'] )
             sconscript_env['tool_arch_abi_dir'] = os.path.join( toolchain.name(), target_arch, abi )
-            sconscript_env['tool_variant_dir'] = os.path.join( toolchain.name(), variant, target_arch, abi )
+            sconscript_env['tool_variant_dir'] = cuppa.core.build_layout.tool_variant_dir(
+                    toolchain.name(), variant, target_arch, abi
+            )
             sconscript_env['package_tool_variant_dir'] = os.path.join( toolchain.package_name(), variant, target_arch, abi )
             sconscript_env['tool_variant_working_dir'] = os.path.join( sconscript_env['tool_variant_dir'], working_folder )
 

--- a/cuppa/core/base_options.py
+++ b/cuppa/core/base_options.py
@@ -16,6 +16,7 @@ import SCons.Script
 # Custom
 import cuppa.core.options
 import cuppa.core.storage_options
+import cuppa.core.storage_actions
 import cuppa.core.location_options
 
 
@@ -120,5 +121,7 @@ def add_base_options():
                                  " is used. DECIDER may be one of {}".format( str(decider_choices) ) )
 
     cuppa.core.storage_options.add_storage_options( add_option )
+
+    cuppa.core.storage_actions.add_storage_action_options( add_option )
 
     cuppa.core.location_options.add_location_options( add_option )

--- a/cuppa/core/build_layout.py
+++ b/cuppa/core/build_layout.py
@@ -1,0 +1,126 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   Build layout
+#-------------------------------------------------------------------------------
+
+"""Where a variant's build output lives under the build root.
+
+`tool_variant_dir` is the path segment shared by every sconscript that builds for a given
+toolchain, variant, architecture, and ABI. Removal and listing compose it here so they cannot
+drift from `construct.call_project_sconscript_files`.
+"""
+
+import os
+from collections import namedtuple
+
+
+WORKING = 'working'
+FINAL = 'final'
+
+
+def sanitise_abi( abi ):
+    """Path-safe ABI segment. Matches construct.py: ``c++2c`` becomes ``cxx2c``."""
+    return abi.replace( '+', 'x' )
+
+
+def tool_variant_dir( toolchain_name, variant, target_arch, abi ):
+    """``<toolchain>/<variant>/<arch>/<abi>`` — the suffix under each sconscript's build path."""
+    return os.path.join( toolchain_name, variant, target_arch, abi )
+
+
+BuildVariant = namedtuple(
+    'BuildVariant',
+    [ 'path', 'relpath', 'sconscript', 'tool_variant', 'selected' ],
+)
+
+
+def is_variant_root( path ):
+    """True when ``path`` is the directory that holds ``working`` and/or ``final``."""
+    if not os.path.isdir( path ):
+        return False
+    working = os.path.join( path, WORKING )
+    final = os.path.join( path, FINAL )
+    return os.path.isdir( working ) or os.path.isdir( final )
+
+
+def discover_build_variants( abs_build_root, selected_suffixes=() ):
+    """Every variant root under the build root.
+
+    A variant root is a directory that directly contains ``working`` and/or ``final``. The
+    sconscript column is the path between the build root and the four-segment tool-variant
+    suffix; ``selected`` is true when that suffix is one of ``selected_suffixes``.
+    """
+    if not abs_build_root or not os.path.isdir( abs_build_root ):
+        return []
+
+    selected = set( os.path.normpath( suffix ) for suffix in selected_suffixes )
+    found = []
+    abs_build_root = os.path.realpath( abs_build_root )
+
+    for root, dirnames, _filenames in os.walk( abs_build_root, followlinks=False ):
+        # Do not descend into working/final; the parent is the variant root we care about.
+        if os.path.basename( root ) in ( WORKING, FINAL ):
+            dirnames[:] = []
+            continue
+
+        if not is_variant_root( root ):
+            continue
+
+        relpath = os.path.relpath( root, abs_build_root )
+        parts = relpath.split( os.sep )
+        if len( parts ) < 4:
+            # toolchain / variant / arch / abi — anything shorter is not our layout.
+            continue
+
+        tool_variant = os.path.join( *parts[-4:] )
+        sconscript = os.path.join( *parts[:-4] ) if len( parts ) > 4 else '.'
+        found.append( BuildVariant(
+            path = root,
+            relpath = relpath,
+            sconscript = sconscript,
+            tool_variant = tool_variant,
+            selected = os.path.normpath( tool_variant ) in selected,
+        ) )
+        # Children of a variant root are working/final (and their contents); skip them.
+        dirnames[:] = []
+
+    return sorted( found, key=lambda entry: entry.relpath )
+
+
+def _path_ends_with( relpath, suffix ):
+    relpath = os.path.normpath( relpath )
+    return relpath == suffix or relpath.endswith( os.sep + suffix )
+
+
+def paths_ending_with( abs_build_root, suffix ):
+    """Directories under ``abs_build_root`` whose relative path ends with ``suffix``.
+
+    ``os.walk(..., followlinks=False)`` does not visit symlink directories, so symlink
+    children are checked explicitly — callers (removal) need to see them in order to refuse.
+    """
+    suffix = os.path.normpath( suffix )
+    matches = []
+    if not abs_build_root or not os.path.isdir( abs_build_root ):
+        return matches
+
+    abs_build_root = os.path.realpath( abs_build_root )
+    for root, dirnames, _filenames in os.walk( abs_build_root, followlinks=False ):
+        relpath = os.path.relpath( root, abs_build_root )
+        if _path_ends_with( relpath, suffix ):
+            matches.append( root )
+            dirnames[:] = []
+            continue
+
+        for name in list( dirnames ):
+            child = os.path.join( root, name )
+            if not os.path.islink( child ):
+                continue
+            child_rel = os.path.relpath( child, abs_build_root )
+            if _path_ends_with( child_rel, suffix ):
+                matches.append( child )
+                dirnames.remove( name )
+    return sorted( matches )

--- a/cuppa/core/storage_actions.py
+++ b/cuppa/core/storage_actions.py
@@ -1,0 +1,941 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   Storage actions — list and remove builds
+#-------------------------------------------------------------------------------
+
+"""Opt-in actions that report or remove what cuppa wrote under the build root.
+
+Listings and removals run instead of a build: resolve selection, report, act, exit. Scope follows
+the same toolchain and variant options that decide where a build writes. Artefacts outside
+`build_root` are deliberately out of scope.
+"""
+
+import os
+import sys
+from collections import defaultdict
+
+import SCons.Script
+
+from cuppa.colourise import as_emphasised, as_error, as_info, as_info_label, as_subdued, as_warning
+from cuppa.core import build_layout
+from cuppa.log import logger
+from cuppa.utility import storage
+
+
+INDENT = '  '
+RULE = '-'
+# Shared across all three sections so SIZE / middle / tree columns share one grid.
+SIZE_WIDTH = 8
+# Fits "LAST BUILD", "SELECTED", ages such as "2 months ago", and centered marks.
+MIDDLE_WIDTH = 12
+
+
+def add_storage_action_options( add_option ):
+
+    add_option(
+        '--list-builds', dest='list_builds', action='store_true',
+        help="List build trees under the build root (folder, toolchain, sconscript views) and exit",
+    )
+    add_option(
+        '--remove-build', dest='remove_build', action='store_true',
+        help="Remove every variant subtree under the build root that matches the current"
+             " toolchain / variant selection, then exit",
+    )
+    add_option(
+        '--remove-all-builds', dest='remove_all_builds', action='store_true',
+        help="Remove the entire build root, then exit",
+    )
+    add_option(
+        '--list-format', dest='list_format', choices=( 'text', 'json' ),
+        nargs=1, action='store', default='text',
+        help="Output format for --list-* options: text (default) or json",
+    )
+
+
+def process_storage_action_options( cuppa_env ):
+    cuppa_env['list_builds'] = bool( cuppa_env.get_option( 'list_builds' ) )
+    cuppa_env['remove_build'] = bool( cuppa_env.get_option( 'remove_build' ) )
+    cuppa_env['remove_all_builds'] = bool( cuppa_env.get_option( 'remove_all_builds' ) )
+    list_format = cuppa_env.get_option( 'list_format', default='text' )
+    if isinstance( list_format, ( list, tuple ) ):
+        list_format = list_format[0] if list_format else 'text'
+    cuppa_env['list_format'] = list_format or 'text'
+
+
+def wants_storage_action( cuppa_env ):
+    return bool(
+        cuppa_env.get( 'list_builds' )
+        or cuppa_env.get( 'remove_build' )
+        or cuppa_env.get( 'remove_all_builds' )
+    )
+
+
+def dry_run( cuppa_env ):
+    """SCons ``-n`` / ``--no-exec``: report what would be removed, remove nothing."""
+    try:
+        return bool( SCons.Script.GetOption( 'no_exec' ) )
+    except Exception:
+        return bool( cuppa_env.get_option( 'no_exec' ) )
+
+
+def selected_tool_variant_dirs( construct, cuppa_env ):
+    """Tool-variant path suffixes the current options would write."""
+    suffixes = []
+    for toolchain in cuppa_env.get( 'active_toolchains' ) or []:
+        for build_env in construct.create_build_envs( toolchain, cuppa_env ):
+            suffixes.append( build_layout.tool_variant_dir(
+                toolchain.name(),
+                build_env['variant'],
+                build_env['target_arch'],
+                build_env['abi'],
+            ) )
+    # Unique, stable order.
+    seen = set()
+    ordered = []
+    for suffix in suffixes:
+        key = os.path.normpath( suffix )
+        if key not in seen:
+            seen.add( key )
+            ordered.append( suffix )
+    return ordered
+
+
+def _split_tool_variant( tool_variant ):
+    """``toolchain`` and ``variant/arch/abi`` — the collapse used in the sconscript tree."""
+    parts = tool_variant.split( os.sep )
+    if len( parts ) < 4:
+        return tool_variant, ''
+    return parts[0], os.path.join( *parts[1:] )
+
+
+def _sconscript_segments( entry ):
+    toolchain, rest = _split_tool_variant( entry['tool_variant'] )
+    sconscript = entry['sconscript']
+    if sconscript == '.':
+        return [ toolchain, rest ]
+    return sconscript.split( os.sep ) + [ toolchain, rest ]
+
+
+def _max_mtime( left, right ):
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return max( left, right )
+
+
+class _TreeNode( object ):
+    __slots__ = (
+        'name', 'children', 'size_bytes', 'mtime', 'selected', 'selection',
+        'is_leaf', 'is_sconscript_name', 'is_toolchain',
+    )
+
+    def __init__( self, name ):
+        self.name = name
+        self.children = {}
+        self.size_bytes = 0
+        self.mtime = None
+        self.selected = False
+        self.selection = 'none'
+        self.is_leaf = False
+        self.is_sconscript_name = False
+        self.is_toolchain = False
+
+
+def _sconscript_path_parts( sconscript ):
+    if sconscript == '.':
+        return []
+    return sconscript.split( os.sep )
+
+
+def _child_names( node ):
+    """Toolchain children first, then remaining folders, each group alphabetically."""
+    return sorted(
+        node.children,
+        key=lambda name: ( 0 if node.children[name].is_toolchain else 1, name ),
+    )
+
+
+def _build_sconscript_tree( entries ):
+    root = _TreeNode( '' )
+    for entry in entries:
+        parts = _sconscript_path_parts( entry['sconscript'] )
+        toolchain, rest = _split_tool_variant( entry['tool_variant'] )
+        segments = parts + [ toolchain, rest ]
+        node = root
+        for index, segment in enumerate( segments ):
+            if segment not in node.children:
+                node.children[segment] = _TreeNode( segment )
+            node = node.children[segment]
+            # The last sconscript path segment is the sconscript "name" (parent of toolchains).
+            if parts and index == len( parts ) - 1:
+                node.is_sconscript_name = True
+            if index == len( parts ):
+                node.is_toolchain = True
+        node.is_leaf = True
+        node.size_bytes = entry['size_bytes']
+        node.mtime = entry.get( 'mtime' )
+        node.selected = entry['selected']
+        node.selection = 'full' if entry['selected'] else 'none'
+
+    def rollup( node ):
+        if node.is_leaf and not node.children:
+            return node.size_bytes, node.mtime, node.selection
+        total = 0
+        newest = None
+        child_selections = []
+        for child in node.children.values():
+            size, mtime, selection = rollup( child )
+            total += size
+            newest = _max_mtime( newest, mtime )
+            child_selections.append( selection )
+        node.size_bytes = total
+        node.mtime = newest
+        if child_selections and all( status == 'full' for status in child_selections ):
+            node.selection = 'full'
+        elif child_selections and all( status == 'none' for status in child_selections ):
+            node.selection = 'none'
+        else:
+            node.selection = 'partial'
+        node.selected = node.selection == 'full'
+        return total, newest, node.selection
+
+    rollup( root )
+    return root
+
+
+def _tree_to_json( node ):
+    children = [
+        _tree_to_json( node.children[name] )
+        for name in _child_names( node )
+    ]
+    payload = {
+        'name': node.name,
+        'size': storage.human_size( node.size_bytes ),
+        'size_bytes': node.size_bytes,
+        'last_build': storage.relative_age( node.mtime ),
+        'mtime': node.mtime,
+        'selected': node.selected,
+        'selection': node.selection,
+        'sconscript_name': node.is_sconscript_name,
+        'toolchain': node.is_toolchain,
+    }
+    if children:
+        payload['children'] = children
+    return payload
+
+
+def _collect_variant_rows( abs_build_root, selected_suffixes ):
+    variants = build_layout.discover_build_variants( abs_build_root, selected_suffixes )
+    rows = []
+    for entry in variants:
+        stats = storage.directory_stats( entry.path )
+        rows.append( {
+            'size': storage.human_size( stats.bytes ),
+            'size_bytes': stats.bytes,
+            'mtime': stats.mtime,
+            'last_build': storage.relative_age( stats.mtime ),
+            'sconscript': entry.sconscript,
+            'tool_variant': entry.tool_variant,
+            'selected': entry.selected,
+            'path': entry.path,
+        } )
+    return rows
+
+
+def _toolchain_name( tool_variant ):
+    return tool_variant.split( os.sep )[0]
+
+
+def _variant_arch_abi( tool_variant ):
+    parts = tool_variant.split( os.sep )
+    if len( parts ) < 4:
+        return os.path.join( *parts[1:] ) if len( parts ) > 1 else tool_variant
+    return os.path.join( *parts[1:] )
+
+
+def _selection_from_children( child_selections ):
+    if child_selections and all( status == 'full' for status in child_selections ):
+        return 'full'
+    if child_selections and all( status == 'none' for status in child_selections ):
+        return 'none'
+    return 'partial'
+
+
+def _toolchain_variant_tree( rows ):
+    """Roll up rows into ``toolchain → variant/arch/abi`` nodes for the toolchain section."""
+    groups = defaultdict( lambda: { 'size_bytes': 0, 'mtime': None, 'selected': False } )
+    for row in rows:
+        group = groups[row['tool_variant']]
+        group['size_bytes'] += row['size_bytes']
+        group['mtime'] = _max_mtime( group['mtime'], row['mtime'] )
+        group['selected'] = group['selected'] or row['selected']
+
+    by_toolchain = defaultdict( list )
+    for tool_variant in sorted( groups ):
+        group = groups[tool_variant]
+        selected = group['selected']
+        by_toolchain[_toolchain_name( tool_variant )].append( {
+            'name': _variant_arch_abi( tool_variant ),
+            'tool_variant': tool_variant,
+            'size': storage.human_size( group['size_bytes'] ),
+            'size_bytes': group['size_bytes'],
+            'mtime': group['mtime'],
+            'last_build': storage.relative_age( group['mtime'] ),
+            'selected': selected,
+            'selection': 'full' if selected else 'none',
+            'children': [],
+        } )
+
+    tree = []
+    for toolchain in sorted( by_toolchain ):
+        children = by_toolchain[toolchain]
+        selection = _selection_from_children( [ child['selection'] for child in children ] )
+        size_bytes = sum( child['size_bytes'] for child in children )
+        mtime = None
+        for child in children:
+            mtime = _max_mtime( mtime, child['mtime'] )
+        tree.append( {
+            'name': toolchain,
+            'tool_variant': toolchain,
+            'size': storage.human_size( size_bytes ),
+            'size_bytes': size_bytes,
+            'mtime': mtime,
+            'last_build': storage.relative_age( mtime ),
+            'selected': selection == 'full',
+            'selection': selection,
+            'children': children,
+        } )
+    return tree
+
+
+def _toolchain_variant_to_json( node ):
+    payload = {
+        'name': node['name'],
+        'tool_variant': node['tool_variant'],
+        'size': node['size'],
+        'size_bytes': node['size_bytes'],
+        'last_build': node['last_build'],
+        'mtime': node['mtime'],
+        'selected': node['selected'],
+        'selection': node['selection'],
+    }
+    if node.get( 'children' ):
+        payload['children'] = [
+            _toolchain_variant_to_json( child ) for child in node['children']
+        ]
+    return payload
+
+
+def _folder_summary( abs_build_root, rows ):
+    folder = storage.directory_stats( abs_build_root )
+    selected = [ row for row in rows if row['selected'] ]
+    selected_bytes = sum( row['size_bytes'] for row in selected )
+    selected_mtime = None
+    for row in selected:
+        selected_mtime = _max_mtime( selected_mtime, row['mtime'] )
+    return {
+        'path': abs_build_root,
+        'display_path': storage.display_path( abs_build_root ),
+        'size': storage.human_size( folder.bytes ),
+        'size_bytes': folder.bytes,
+        'mtime': folder.mtime,
+        'last_build': storage.relative_age( folder.mtime ),
+        'entries': len( rows ),
+        'selected_entries': len( selected ),
+        'selected_size': storage.human_size( selected_bytes ),
+        'selected_bytes': selected_bytes,
+        'selected_mtime': selected_mtime,
+        'selected_last_build': storage.relative_age( selected_mtime ),
+    }
+
+
+def _size_cell( size_bytes ):
+    return storage.human_size( size_bytes ).rjust( SIZE_WIDTH )
+
+
+def _middle_cell( text ):
+    return text.ljust( MIDDLE_WIDTH )
+
+
+def _age_cell( mtime ):
+    return _middle_cell( storage.relative_age( mtime ) )
+
+
+def _mark_cell( text ):
+    """Place a mark under the SELECTED heading (one column left of field-centre)."""
+    if not text:
+        return ' ' * MIDDLE_WIDTH
+    centered = text.center( MIDDLE_WIDTH )
+    if centered.startswith( ' ' ):
+        return centered[1:] + ' '
+    return centered
+
+
+def _node_selected_cell( node ):
+    """Leaves use a single check; rollups use the full / partial / blank triple."""
+    if node.is_leaf:
+        return _mark_cell( storage.selected_mark() if node.selected else '' )
+    if node.selection == 'none':
+        return _mark_cell( '' )
+    return _mark_cell( storage.selection_triple( node.selection ) )
+
+
+def _paint( text, dim ):
+    return as_subdued( text ) if dim else text
+
+
+def _paint_name_row_size( size, is_name_row, dim ):
+    """Size on a fully selected sconscript/toolchain name row is emphasised."""
+    if dim:
+        return as_subdued( size )
+    if is_name_row:
+        return as_emphasised( size )
+    return size
+
+
+def _paint_sconscript_name( name, is_sconscript_name, dim ):
+    """Sconscript/toolchain names are info-coloured; fully selected names are also emphasised."""
+    if is_sconscript_name:
+        coloured = as_info( name )
+        if dim:
+            return as_subdued( coloured )
+        return as_emphasised( coloured )
+    return as_subdued( name ) if dim else name
+
+
+def _paint_sconscript_mark( mark, is_sconscript_name, dim ):
+    """Info-coloured marks; fully selected name-row marks are also emphasised."""
+    if is_sconscript_name and mark.strip():
+        coloured = as_info( mark )
+        if dim:
+            return as_subdued( coloured )
+        return as_emphasised( coloured )
+    return as_subdued( mark ) if dim else mark
+
+
+def _ruled_header( columns, width ):
+    """Header ruled above and below, matching the develop-report shape."""
+    rule = as_subdued( INDENT + RULE * max( width - len( INDENT ), len( columns ) ) )
+    return [ rule, INDENT + columns, rule ]
+
+
+def _closing_rule( width ):
+    return as_subdued( INDENT + RULE * ( width - len( INDENT ) ) )
+
+
+def _section_width( *lines ):
+    return max( len( line ) for line in lines ) if lines else 40
+
+
+def _columns( middle_heading, third_heading ):
+    return "{}  {}  {}".format(
+        'SIZE'.rjust( SIZE_WIDTH ),
+        middle_heading.ljust( MIDDLE_WIDTH ),
+        third_heading,
+    )
+
+
+def _selected_folder_label( folder ):
+    total = folder['entries']
+    selected = folder['selected_entries']
+    unit = "entry" if total == 1 else "entries"
+    if total and selected == total:
+        return "all {} {} selected".format( total, unit )
+    return "selected ({} of {} {})".format( selected, total, unit )
+
+
+def _folder_lines( folder, colour=False ):
+    """Folder rows; ``colour`` info-paints the totals row and subdues the hang branch."""
+    _tee, elbow, _pipe, _gap = storage.glyphs()
+    root = INDENT + "{}  {}  {}".format(
+        _size_cell( folder['size_bytes'] ),
+        _age_cell( folder['mtime'] ),
+        folder['display_path'],
+    )
+    if colour:
+        root = as_info( root )
+    branch = as_subdued( elbow ) if colour else elbow
+    size = _size_cell( folder['selected_bytes'] )
+    age = _age_cell( folder['selected_mtime'] )
+    label = _selected_folder_label( folder )
+    if (
+            colour
+        and folder['entries']
+        and folder['selected_entries'] == folder['entries']
+    ):
+        size = as_emphasised( size )
+        label = as_emphasised( label )
+    selected = INDENT + "{}  {}  {}{}".format( size, age, branch, label )
+    return root, selected
+
+
+def _toolchain_label_parts( node ):
+    return (
+        storage.selection_triple( node['selection'] ),
+        node['name'],
+    )
+
+
+# Width of ``✓✓✓ `` / ``--- `` so variant children hang under the toolchain name.
+_TOOLCHAIN_MARK_PAD = '    '
+
+
+def _toolchain_lines( tree, colour=False ):
+    tee, elbow, pipe, gap = storage.glyphs()
+    lines = []
+
+    def emit( node, prefix, is_last ):
+        branch = elbow if is_last else tee
+        size = _size_cell( node['size_bytes'] )
+        age = _age_cell( node['mtime'] )
+        mark, name = _toolchain_label_parts( node )
+        stem = prefix + branch
+        if colour:
+            dim = node['selection'] != 'full'
+            is_toolchain_name = bool( node.get( 'children' ) )
+            size = _paint_name_row_size( size, is_toolchain_name, dim )
+            age = _paint( age, dim )
+            stem = as_subdued( stem )
+            # Toolchain parents use the same info colour as sconscript names/marks.
+            if is_toolchain_name:
+                mark = _paint_sconscript_mark( mark, True, dim )
+                name = _paint_sconscript_name( name, True, dim )
+            else:
+                mark = _paint( mark, dim )
+                name = _paint( name, dim )
+        lines.append( INDENT + "{}  {}  {}{} {}".format(
+            size, age, stem, mark, name
+        ) )
+        children = node.get( 'children' ) or []
+        # Indent past the selection triple so children hang under the toolchain name.
+        child_prefix = prefix + ( gap if is_last else pipe ) + _TOOLCHAIN_MARK_PAD
+        for index, child in enumerate( children ):
+            emit( child, child_prefix, index == len( children ) - 1 )
+
+    for index, node in enumerate( tree ):
+        emit( node, '', index == len( tree ) - 1 )
+    return lines
+
+
+def _sconscript_rows( tree ):
+    """Plain sconscript-tree rows as data, so width and colour can share one walk."""
+    tee, elbow, pipe, gap = storage.glyphs()
+    rows = []
+
+    def walk( node, prefix ):
+        names = _child_names( node )
+        for index, name in enumerate( names ):
+            child = node.children[name]
+            last = index == len( names ) - 1
+            branch = elbow if last else tee
+            rows.append( {
+                'size': _size_cell( child.size_bytes ),
+                'mark': _node_selected_cell( child ),
+                'stem': prefix + branch,
+                'name': child.name,
+                'dim': child.selection != 'full',
+                'is_sconscript_name': child.is_sconscript_name,
+            } )
+            walk( child, prefix + ( gap if last else pipe ) )
+
+    walk( tree, '' )
+    return rows
+
+
+def _format_sconscript_line( row, colour=False ):
+    size = row['size']
+    mark = row['mark']
+    stem = row['stem']
+    name = row['name']
+    if colour:
+        size = _paint_name_row_size( size, row['is_sconscript_name'], row['dim'] )
+        mark = _paint_sconscript_mark(
+            mark, row['is_sconscript_name'], row['dim']
+        )
+        stem = as_subdued( stem )
+        name = _paint_sconscript_name(
+            name, row['is_sconscript_name'], row['dim']
+        )
+    return INDENT + "{}  {}  {}{}".format( size, mark, stem, name )
+
+
+def _render_folder_section( folder, width ):
+    heading = _columns( 'LAST BUILD', 'BUILD FOLDER' )
+    root_line, selected_line = _folder_lines( folder, colour=True )
+    lines = _ruled_header( heading, width )
+    lines.append( root_line )
+    lines.append( selected_line )
+    lines.append( _closing_rule( width ) )
+    return lines
+
+
+def _render_toolchain_section( tree, width ):
+    heading = _columns( 'LAST BUILD', 'BY TOOLCHAIN VARIANT' )
+    lines = _ruled_header( heading, width )
+    body = _toolchain_lines( tree, colour=True )
+    lines.extend( body )
+    if body:
+        lines.append( _closing_rule( width ) )
+    return lines
+
+
+def _render_sconscript_section( tree, width ):
+    heading = _columns( 'SELECTED', 'BY SCONSCRIPT' )
+    lines = _ruled_header( heading, width )
+    rows = _sconscript_rows( tree )
+    for row in rows:
+        lines.append( _format_sconscript_line( row, colour=True ) )
+    if rows:
+        lines.append( _closing_rule( width ) )
+    return lines
+
+
+def _report_width( folder, toolchain_tree, sconscript_tree ):
+    """One rule width for every section, based on the widest plain-text line."""
+    root_line, selected_line = _folder_lines( folder, colour=False )
+    candidates = [
+        INDENT + _columns( 'LAST BUILD', 'BUILD FOLDER' ),
+        INDENT + _columns( 'LAST BUILD', 'BY TOOLCHAIN VARIANT' ),
+        INDENT + _columns( 'SELECTED', 'BY SCONSCRIPT' ),
+        root_line,
+        selected_line,
+    ]
+    candidates.extend( _toolchain_lines( toolchain_tree, colour=False ) )
+    candidates.extend(
+        _format_sconscript_line( row, colour=False )
+        for row in _sconscript_rows( sconscript_tree )
+    )
+    return _section_width( *candidates )
+
+
+def _effective_selection_settings( construct, cuppa_env, rows=None ):
+    """Variant and toolchain flags for the selected builds that exist on disk.
+
+    Defaults and CLI flags can name variants that are not present under the build root. The
+    summary command is for ``--remove-build``, so it only includes variants and toolchains that
+    appear in selected entries discovered on disk. When nothing selected exists yet, it falls
+    back to the active option selection.
+    """
+    settings = {}
+    selected_rows = [ row for row in ( rows or [] ) if row.get( 'selected' ) ]
+    if selected_rows:
+        variants = set()
+        toolchains = []
+        seen = set()
+        for row in selected_rows:
+            parts = row['tool_variant'].split( os.sep )
+            if not parts:
+                continue
+            toolchain = parts[0]
+            if toolchain not in seen:
+                seen.add( toolchain )
+                toolchains.append( toolchain )
+            if len( parts ) > 1:
+                variants.add( parts[1] )
+        for variant in sorted( variants ):
+            settings[variant] = True
+        if toolchains:
+            settings['toolchains'] = toolchains
+        return settings
+
+    variants = set()
+    toolchain_names = []
+    seen = set()
+    for toolchain in cuppa_env.get( 'active_toolchains' ) or []:
+        name = toolchain.name()
+        if name not in seen:
+            seen.add( name )
+            toolchain_names.append( name )
+        for build_env in construct.create_build_envs( toolchain, cuppa_env ):
+            variants.add( build_env['variant'] )
+    for variant in sorted( variants ):
+        settings[variant] = True
+    requested = cuppa_env.get_option( 'toolchains' )
+    if requested:
+        if isinstance( requested, ( list, tuple ) ):
+            settings['toolchains'] = [ str( name ) for name in requested ]
+        else:
+            settings['toolchains'] = [ str( requested ) ]
+    elif toolchain_names:
+        settings['toolchains'] = toolchain_names
+    return settings
+
+
+def _command_line_from_settings( settings, colour=True ):
+    """Format settings as a cuppa command suffix, matching ``--show-conf`` style."""
+    emphasise = as_emphasised if colour else ( lambda text: text )
+    info = as_info if colour else ( lambda text: text )
+    commands = []
+    for key in sorted( settings ):
+        value = settings[key]
+        command = emphasise( "--" + key )
+        if value is not True and value is not False:
+            if isinstance( value, list ):
+                command += "=" + info( ",".join( value ) )
+            else:
+                command += "=" + info( str( value ) )
+        commands.append( command )
+    return " ".join( commands )
+
+
+def _selection_summary( construct, cuppa_env, folder, rows=None ):
+    """Closing note: selected size plus an explicit command for those builds."""
+    settings = _effective_selection_settings( construct, cuppa_env, rows=rows )
+    command_suffix = _command_line_from_settings( settings, colour=False )
+    equivalent = "cuppa -D"
+    if command_suffix:
+        equivalent = "cuppa -D " + command_suffix
+    return {
+        'selected_bytes': folder['selected_bytes'],
+        'selected_size': folder['selected_size'],
+        'total_bytes': folder['size_bytes'],
+        'total_size': folder['size'],
+        'selected_entries': folder['selected_entries'],
+        'entries': folder['entries'],
+        'settings': settings,
+        'equivalent_command': equivalent,
+    }
+
+
+def _render_summary( summary ):
+    settings = summary.get( 'settings' ) or {}
+    coloured = "cuppa -D"
+    suffix = _command_line_from_settings( settings, colour=True )
+    if suffix:
+        coloured = "cuppa -D " + suffix
+    selected_size = summary['selected_size']
+    total_size = as_emphasised( summary['total_size'] )
+    if summary['selected_bytes'] < summary['total_bytes']:
+        selected_size = as_emphasised( as_info( selected_size ) )
+    else:
+        selected_size = as_emphasised( selected_size )
+    return [
+        "Selected {} of {} ({} of {} entries)".format(
+            selected_size,
+            total_size,
+            summary['selected_entries'],
+            summary['entries'],
+        ),
+        "",
+        "Explicit command for the selected builds:",
+        "",
+        coloured,
+        "",
+        "Append --remove-build to clear those folders.",
+    ]
+
+
+def list_builds( construct, cuppa_env, out=None ):
+    """Print folder, toolchain-variant, and sconscript views of the build root."""
+    out = out or sys.stdout
+    abs_build_root = cuppa_env['abs_build_root']
+    selected = selected_tool_variant_dirs( construct, cuppa_env )
+    rows = _collect_variant_rows( abs_build_root, selected )
+    folder = _folder_summary( abs_build_root, rows )
+    toolchain_tree = _toolchain_variant_tree( rows )
+    sconscript_tree = _build_sconscript_tree( rows )
+    summary = _selection_summary( construct, cuppa_env, folder, rows=rows )
+
+    if cuppa_env.get( 'list_format' ) == 'json':
+        payload = {
+            'build_root': abs_build_root,
+            'folder': folder,
+            'by_toolchain_variant': [
+                _toolchain_variant_to_json( node ) for node in toolchain_tree
+            ],
+            'by_sconscript': [
+                _tree_to_json( sconscript_tree.children[name] )
+                for name in _child_names( sconscript_tree )
+            ],
+            'entries': [
+                {
+                    'size': row['size'],
+                    'size_bytes': row['size_bytes'],
+                    'last_build': row['last_build'],
+                    'mtime': row['mtime'],
+                    'sconscript': row['sconscript'],
+                    'tool_variant': row['tool_variant'],
+                    'selected': row['selected'],
+                    'path': row['path'],
+                }
+                for row in rows
+            ],
+            'summary': summary,
+            'total_bytes': folder['size_bytes'],
+            'total': folder['size'],
+        }
+        out.write( storage.render_json_payload( payload ) )
+        out.write( "\n" )
+        return 0
+
+    width = _report_width( folder, toolchain_tree, sconscript_tree )
+    for line in _render_folder_section( folder, width ):
+        out.write( line + "\n" )
+    out.write( "\n" )
+    for line in _render_toolchain_section( toolchain_tree, width ):
+        out.write( line + "\n" )
+    out.write( "\n" )
+    for line in _render_sconscript_section( sconscript_tree, width ):
+        out.write( line + "\n" )
+    out.write( "\n" )
+    for line in _render_summary( summary ):
+        out.write( line + "\n" )
+    return 0
+
+
+def _refuse_suspicious_build_root( abs_build_root, sconstruct_dir ):
+    if storage.is_suspicious_root( abs_build_root ):
+        raise storage.StorageError(
+            "refusing to remove build root [{}]: it is a filesystem or home directory".format(
+                abs_build_root
+            )
+        )
+    if storage.real_path( abs_build_root ) == storage.real_path( sconstruct_dir ):
+        raise storage.StorageError(
+            "refusing to remove build root [{}]: it is the sconstruct directory".format(
+                abs_build_root
+            )
+        )
+
+
+def remove_build( construct, cuppa_env, out=None ):
+    """Remove variant subtrees matching the current selection. Returns an exit status."""
+    out = out or sys.stdout
+    abs_build_root = cuppa_env['abs_build_root']
+    _refuse_suspicious_build_root( abs_build_root, cuppa_env['sconstruct_dir'] )
+
+    suffixes = selected_tool_variant_dirs( construct, cuppa_env )
+    if not suffixes:
+        out.write( "nothing to remove (no active toolchain / variant selection)\n" )
+        return 0
+
+    candidates = []
+    for suffix in suffixes:
+        for path in build_layout.paths_ending_with( abs_build_root, suffix ):
+            # Symlinks first: realpath containment would otherwise mis-report an escape.
+            if os.path.islink( path ):
+                raise storage.StorageError(
+                    "refusing to remove through symlink [{}]".format( path )
+                )
+            storage.ensure_contained( path, abs_build_root, what="build path" )
+            candidates.append( path )
+
+    # Unique paths, deepest first so parents prune cleanly afterwards.
+    candidates = sorted( set( candidates ), key=lambda path: path.count( os.sep ), reverse=True )
+
+    if not candidates:
+        out.write( "nothing to remove (no matching variant trees under {})\n".format(
+            abs_build_root
+        ) )
+        return 0
+
+    planning = dry_run( cuppa_env )
+    out.write( "{} {} matching variant {} under {}\n".format(
+        "Would remove" if planning else "Removing",
+        len( candidates ),
+        "tree" if len( candidates ) == 1 else "trees",
+        abs_build_root,
+    ) )
+    for path in sorted( candidates ):
+        size = storage.human_size( storage.directory_size( path ) )
+        out.write( "  {}  {}\n".format( size, path ) )
+
+    failed = 0
+    for path in candidates:
+        try:
+            storage.ensure_contained( path, abs_build_root, what="build path" )
+            storage.remove_path( path, dry_run=planning )
+            if not planning:
+                storage.prune_empty_parents( os.path.dirname( path ), abs_build_root )
+        except ( storage.StorageError, OSError ) as error:
+            out.write( "failed: {}\n".format( error ) )
+            failed += 1
+
+    if planning:
+        out.write( "dry run (-n); nothing removed\n" )
+    elif failed:
+        out.write( "removed with {} failure{}\n".format(
+            failed, "" if failed == 1 else "s"
+        ) )
+    else:
+        out.write( "removed {}\n".format(
+            "1 tree" if len( candidates ) == 1 else "{} trees".format( len( candidates ) )
+        ) )
+    return 1 if failed else 0
+
+
+def remove_all_builds( cuppa_env, out=None ):
+    """Remove the entire build root. Returns an exit status."""
+    out = out or sys.stdout
+    abs_build_root = cuppa_env['abs_build_root']
+    _refuse_suspicious_build_root( abs_build_root, cuppa_env['sconstruct_dir'] )
+
+    if not os.path.exists( abs_build_root ):
+        out.write( "nothing to remove (build root [{}] does not exist)\n".format(
+            abs_build_root
+        ) )
+        return 0
+
+    if os.path.islink( abs_build_root ):
+        raise storage.StorageError(
+            "refusing to remove build root through symlink [{}]".format( abs_build_root )
+        )
+
+    planning = dry_run( cuppa_env )
+    size = storage.human_size( storage.directory_size( abs_build_root ) )
+    out.write( "{} build root {} ({})\n".format(
+        "Would remove" if planning else "Removing",
+        abs_build_root,
+        size,
+    ) )
+
+    try:
+        storage.remove_path( abs_build_root, dry_run=planning )
+    except OSError as error:
+        out.write( "failed: {}\n".format( error ) )
+        return 1
+
+    if planning:
+        out.write( "dry run (-n); nothing removed\n" )
+    else:
+        out.write( "removed {}\n".format( abs_build_root ) )
+    return 0
+
+
+def run( construct, cuppa_env, out=None ):
+    """Dispatch the requested storage action. Returns an exit status."""
+    out = out or sys.stdout
+    try:
+        if cuppa_env.get( 'remove_all_builds' ) and (
+                cuppa_env.get( 'remove_build' ) or cuppa_env.get( 'list_builds' )
+        ):
+            logger.warn( "[{}] takes precedence over the other build storage actions".format(
+                    as_warning( "--remove-all-builds" )
+            ) )
+
+        if cuppa_env.get( 'remove_all_builds' ):
+            logger.info( as_info_label(
+                    "Running in REMOVE ALL BUILDS mode, no building will be attempted" ) )
+            return remove_all_builds( cuppa_env, out=out )
+
+        if cuppa_env.get( 'remove_build' ):
+            logger.info( as_info_label(
+                    "Running in REMOVE BUILD mode, no building will be attempted" ) )
+            return remove_build( construct, cuppa_env, out=out )
+
+        if cuppa_env.get( 'list_builds' ):
+            logger.info( as_info_label(
+                    "Running in LIST BUILDS mode, no building will be attempted" ) )
+            return list_builds( construct, cuppa_env, out=out )
+
+    except storage.StorageError as error:
+        logger.error( as_error( str( error ) ) )
+        out.write( "error: {}\n".format( error ) )
+        return 1
+
+    return 0

--- a/cuppa/core/storage_actions.py
+++ b/cuppa/core/storage_actions.py
@@ -15,6 +15,7 @@ the same toolchain and variant options that decide where a build writes. Artefac
 """
 
 import os
+import re
 import sys
 from collections import defaultdict
 
@@ -41,7 +42,7 @@ def add_storage_action_options( add_option ):
         help="List build trees under the build root (folder, toolchain, sconscript views) and exit",
     )
     add_option(
-        '--remove-build', dest='remove_build', action='store_true',
+        '--remove-builds', dest='remove_builds', action='store_true',
         help="Remove every variant subtree under the build root that matches the current"
              " toolchain / variant selection, then exit",
     )
@@ -58,7 +59,7 @@ def add_storage_action_options( add_option ):
 
 def process_storage_action_options( cuppa_env ):
     cuppa_env['list_builds'] = bool( cuppa_env.get_option( 'list_builds' ) )
-    cuppa_env['remove_build'] = bool( cuppa_env.get_option( 'remove_build' ) )
+    cuppa_env['remove_builds'] = bool( cuppa_env.get_option( 'remove_builds' ) )
     cuppa_env['remove_all_builds'] = bool( cuppa_env.get_option( 'remove_all_builds' ) )
     list_format = cuppa_env.get_option( 'list_format', default='text' )
     if isinstance( list_format, ( list, tuple ) ):
@@ -69,7 +70,7 @@ def process_storage_action_options( cuppa_env ):
 def wants_storage_action( cuppa_env ):
     return bool(
         cuppa_env.get( 'list_builds' )
-        or cuppa_env.get( 'remove_build' )
+        or cuppa_env.get( 'remove_builds' )
         or cuppa_env.get( 'remove_all_builds' )
     )
 
@@ -131,7 +132,7 @@ def _max_mtime( left, right ):
 class _TreeNode( object ):
     __slots__ = (
         'name', 'children', 'size_bytes', 'mtime', 'selected', 'selection',
-        'is_leaf', 'is_sconscript_name', 'is_toolchain',
+        'result', 'is_leaf', 'is_sconscript_name', 'is_toolchain',
     )
 
     def __init__( self, name ):
@@ -141,9 +142,22 @@ class _TreeNode( object ):
         self.mtime = None
         self.selected = False
         self.selection = 'none'
+        self.result = 'none'
         self.is_leaf = False
         self.is_sconscript_name = False
         self.is_toolchain = False
+
+
+def _combine_results( results ):
+    """Roll child removal results up to a parent: removed, failed, mixed, or none."""
+    active = [ result for result in results if result != 'none' ]
+    if not active:
+        return 'none'
+    if all( result == 'removed' for result in active ):
+        return 'removed'
+    if all( result == 'failed' for result in active ):
+        return 'failed'
+    return 'mixed'
 
 
 def _sconscript_path_parts( sconscript ):
@@ -181,18 +195,21 @@ def _build_sconscript_tree( entries ):
         node.mtime = entry.get( 'mtime' )
         node.selected = entry['selected']
         node.selection = 'full' if entry['selected'] else 'none'
+        node.result = entry.get( 'result' ) or 'none'
 
     def rollup( node ):
         if node.is_leaf and not node.children:
-            return node.size_bytes, node.mtime, node.selection
+            return node.size_bytes, node.mtime, node.selection, node.result
         total = 0
         newest = None
         child_selections = []
+        child_results = []
         for child in node.children.values():
-            size, mtime, selection = rollup( child )
+            size, mtime, selection, result = rollup( child )
             total += size
             newest = _max_mtime( newest, mtime )
             child_selections.append( selection )
+            child_results.append( result )
         node.size_bytes = total
         node.mtime = newest
         if child_selections and all( status == 'full' for status in child_selections ):
@@ -202,7 +219,8 @@ def _build_sconscript_tree( entries ):
         else:
             node.selection = 'partial'
         node.selected = node.selection == 'full'
-        return total, newest, node.selection
+        node.result = _combine_results( child_results )
+        return total, newest, node.selection, node.result
 
     rollup( root )
     return root
@@ -221,6 +239,7 @@ def _tree_to_json( node ):
         'mtime': node.mtime,
         'selected': node.selected,
         'selection': node.selection,
+        'result': node.result,
         'sconscript_name': node.is_sconscript_name,
         'toolchain': node.is_toolchain,
     }
@@ -247,6 +266,14 @@ def _collect_variant_rows( abs_build_root, selected_suffixes ):
     return rows
 
 
+def _collect_all_variant_rows( abs_build_root ):
+    """Every variant under the build root, all marked selected (for --remove-all-builds)."""
+    rows = _collect_variant_rows( abs_build_root, selected_suffixes=() )
+    for row in rows:
+        row['selected'] = True
+    return rows
+
+
 def _toolchain_name( tool_variant ):
     return tool_variant.split( os.sep )[0]
 
@@ -268,12 +295,17 @@ def _selection_from_children( child_selections ):
 
 def _toolchain_variant_tree( rows ):
     """Roll up rows into ``toolchain → variant/arch/abi`` nodes for the toolchain section."""
-    groups = defaultdict( lambda: { 'size_bytes': 0, 'mtime': None, 'selected': False } )
+    groups = defaultdict( lambda: {
+        'size_bytes': 0, 'mtime': None, 'selected': False, 'result': 'none',
+    } )
     for row in rows:
         group = groups[row['tool_variant']]
         group['size_bytes'] += row['size_bytes']
         group['mtime'] = _max_mtime( group['mtime'], row['mtime'] )
         group['selected'] = group['selected'] or row['selected']
+        group['result'] = _combine_results( [
+            group['result'], row.get( 'result' ) or 'none'
+        ] )
 
     by_toolchain = defaultdict( list )
     for tool_variant in sorted( groups ):
@@ -288,6 +320,7 @@ def _toolchain_variant_tree( rows ):
             'last_build': storage.relative_age( group['mtime'] ),
             'selected': selected,
             'selection': 'full' if selected else 'none',
+            'result': group['result'] if selected else 'none',
             'children': [],
         } )
 
@@ -295,6 +328,7 @@ def _toolchain_variant_tree( rows ):
     for toolchain in sorted( by_toolchain ):
         children = by_toolchain[toolchain]
         selection = _selection_from_children( [ child['selection'] for child in children ] )
+        result = _combine_results( [ child['result'] for child in children ] )
         size_bytes = sum( child['size_bytes'] for child in children )
         mtime = None
         for child in children:
@@ -308,6 +342,7 @@ def _toolchain_variant_tree( rows ):
             'last_build': storage.relative_age( mtime ),
             'selected': selection == 'full',
             'selection': selection,
+            'result': result,
             'children': children,
         } )
     return tree
@@ -323,6 +358,7 @@ def _toolchain_variant_to_json( node ):
         'mtime': node['mtime'],
         'selected': node['selected'],
         'selection': node['selection'],
+        'result': node.get( 'result', 'none' ),
     }
     if node.get( 'children' ):
         payload['children'] = [
@@ -385,12 +421,41 @@ def _node_selected_cell( node ):
     return _mark_cell( storage.selection_triple( node.selection ) )
 
 
+def _node_outcome_cell( node ):
+    """Removal report marks: check for success, ballot for failure."""
+    if node.is_leaf:
+        if node.result == 'removed':
+            return _mark_cell( storage.selected_mark() )
+        if node.result == 'failed':
+            return _mark_cell( storage.failed_mark() )
+        return _mark_cell( '' )
+    if node.result == 'none' or node.selection == 'none':
+        return _mark_cell( '' )
+    return _mark_cell( storage.outcome_triple( node.selection, node.result ) )
+
+
+def _accent_for_result( result ):
+    if result in ( 'failed', 'mixed' ):
+        return 'warning'
+    if result == 'removed':
+        return 'error'
+    return 'info'
+
+
 def _paint( text, dim ):
     return as_subdued( text ) if dim else text
 
 
+def _accent_colour( accent ):
+    if accent == 'error':
+        return as_error
+    if accent == 'warning':
+        return as_warning
+    return as_info
+
+
 def _paint_name_row_size( size, is_name_row, dim ):
-    """Size on a fully selected sconscript/toolchain name row is emphasised."""
+    """Size on a fully selected/removed sconscript or toolchain name row is emphasised."""
     if dim:
         return as_subdued( size )
     if is_name_row:
@@ -398,23 +463,30 @@ def _paint_name_row_size( size, is_name_row, dim ):
     return size
 
 
-def _paint_sconscript_name( name, is_sconscript_name, dim ):
-    """Sconscript/toolchain names are info-coloured; fully selected names are also emphasised."""
+def _paint_sconscript_name( name, is_sconscript_name, dim, accent='info' ):
+    """Name rows use the accent colour; fully matched names are also emphasised."""
     if is_sconscript_name:
-        coloured = as_info( name )
+        coloured = _accent_colour( accent )( name )
         if dim:
             return as_subdued( coloured )
         return as_emphasised( coloured )
     return as_subdued( name ) if dim else name
 
 
-def _paint_sconscript_mark( mark, is_sconscript_name, dim ):
-    """Info-coloured marks; fully selected name-row marks are also emphasised."""
-    if is_sconscript_name and mark.strip():
-        coloured = as_info( mark )
+def _paint_sconscript_mark( mark, is_sconscript_name, dim, accent='info' ):
+    """Accent-coloured marks; fully matched name-row marks are also emphasised."""
+    colour_mark = is_sconscript_name or accent in ( 'error', 'warning' )
+    if colour_mark and mark.strip():
+        display = mark
+        # Emphasised name rows use the heavier check / ballot so they read as settled.
+        if is_sconscript_name and not dim:
+            display = storage.with_heavy_marks( mark )
+        coloured = _accent_colour( accent )( display )
         if dim:
             return as_subdued( coloured )
-        return as_emphasised( coloured )
+        if is_sconscript_name:
+            return as_emphasised( coloured )
+        return coloured
     return as_subdued( mark ) if dim else mark
 
 
@@ -440,17 +512,25 @@ def _columns( middle_heading, third_heading ):
     )
 
 
-def _selected_folder_label( folder ):
+def _folder_hang_label( folder, hang='selected' ):
     total = folder['entries']
-    selected = folder['selected_entries']
+    matched = folder['selected_entries']
     unit = "entry" if total == 1 else "entries"
-    if total and selected == total:
+    if hang == 'removing':
+        if total and matched == total:
+            return "removing all {} {}".format( total, unit )
+        return "removing ({} of {} {})".format( matched, total, unit )
+    if hang == 'removed':
+        if total and matched == total:
+            return "removed all {} {}".format( total, unit )
+        return "removed ({} of {} {})".format( matched, total, unit )
+    if total and matched == total:
         return "all {} {} selected".format( total, unit )
-    return "selected ({} of {} {})".format( selected, total, unit )
+    return "selected ({} of {} {})".format( matched, total, unit )
 
 
-def _folder_lines( folder, colour=False ):
-    """Folder rows; ``colour`` info-paints the totals row and subdues the hang branch."""
+def _folder_lines( folder, colour=False, accent='info', hang='selected' ):
+    """Folder rows; ``colour`` paints the totals row and subdues the hang branch."""
     _tee, elbow, _pipe, _gap = storage.glyphs()
     root = INDENT + "{}  {}  {}".format(
         _size_cell( folder['size_bytes'] ),
@@ -458,11 +538,11 @@ def _folder_lines( folder, colour=False ):
         folder['display_path'],
     )
     if colour:
-        root = as_info( root )
+        root = _accent_colour( accent )( root )
     branch = as_subdued( elbow ) if colour else elbow
     size = _size_cell( folder['selected_bytes'] )
     age = _age_cell( folder['selected_mtime'] )
-    label = _selected_folder_label( folder )
+    label = _folder_hang_label( folder, hang=hang )
     if (
             colour
         and folder['entries']
@@ -474,7 +554,14 @@ def _folder_lines( folder, colour=False ):
     return root, selected
 
 
-def _toolchain_label_parts( node ):
+def _toolchain_label_parts( node, mode='selection' ):
+    if mode == 'outcome':
+        result = node.get( 'result', 'none' )
+        if result == 'none' or node['selection'] == 'none':
+            mark = storage.selection_triple( 'none' )
+        else:
+            mark = storage.outcome_triple( node['selection'], result )
+        return mark, node['name']
     return (
         storage.selection_triple( node['selection'] ),
         node['name'],
@@ -485,7 +572,7 @@ def _toolchain_label_parts( node ):
 _TOOLCHAIN_MARK_PAD = '    '
 
 
-def _toolchain_lines( tree, colour=False ):
+def _toolchain_lines( tree, colour=False, accent='info', mode='selection' ):
     tee, elbow, pipe, gap = storage.glyphs()
     lines = []
 
@@ -493,18 +580,24 @@ def _toolchain_lines( tree, colour=False ):
         branch = elbow if is_last else tee
         size = _size_cell( node['size_bytes'] )
         age = _age_cell( node['mtime'] )
-        mark, name = _toolchain_label_parts( node )
+        mark, name = _toolchain_label_parts( node, mode=mode )
         stem = prefix + branch
+        row_accent = accent
+        if mode == 'outcome':
+            row_accent = _accent_for_result( node.get( 'result', 'none' ) )
         if colour:
             dim = node['selection'] != 'full'
             is_toolchain_name = bool( node.get( 'children' ) )
             size = _paint_name_row_size( size, is_toolchain_name, dim )
             age = _paint( age, dim )
             stem = as_subdued( stem )
-            # Toolchain parents use the same info colour as sconscript names/marks.
+            # Toolchain parents use the same accent as sconscript names/marks.
             if is_toolchain_name:
-                mark = _paint_sconscript_mark( mark, True, dim )
-                name = _paint_sconscript_name( name, True, dim )
+                mark = _paint_sconscript_mark( mark, True, dim, accent=row_accent )
+                name = _paint_sconscript_name( name, True, dim, accent=row_accent )
+            elif mode == 'outcome':
+                mark = _paint_sconscript_mark( mark, False, dim, accent=row_accent )
+                name = _paint( name, dim )
             else:
                 mark = _paint( mark, dim )
                 name = _paint( name, dim )
@@ -522,7 +615,7 @@ def _toolchain_lines( tree, colour=False ):
     return lines
 
 
-def _sconscript_rows( tree ):
+def _sconscript_rows( tree, mode='selection' ):
     """Plain sconscript-tree rows as data, so width and colour can share one walk."""
     tee, elbow, pipe, gap = storage.glyphs()
     rows = []
@@ -533,13 +626,20 @@ def _sconscript_rows( tree ):
             child = node.children[name]
             last = index == len( names ) - 1
             branch = elbow if last else tee
+            if mode == 'outcome':
+                mark = _node_outcome_cell( child )
+                accent = _accent_for_result( child.result )
+            else:
+                mark = _node_selected_cell( child )
+                accent = 'info'
             rows.append( {
                 'size': _size_cell( child.size_bytes ),
-                'mark': _node_selected_cell( child ),
+                'mark': mark,
                 'stem': prefix + branch,
                 'name': child.name,
                 'dim': child.selection != 'full',
                 'is_sconscript_name': child.is_sconscript_name,
+                'accent': accent,
             } )
             walk( child, prefix + ( gap if last else pipe ) )
 
@@ -547,26 +647,29 @@ def _sconscript_rows( tree ):
     return rows
 
 
-def _format_sconscript_line( row, colour=False ):
+def _format_sconscript_line( row, colour=False, accent='info' ):
     size = row['size']
     mark = row['mark']
     stem = row['stem']
     name = row['name']
+    row_accent = row.get( 'accent', accent )
     if colour:
         size = _paint_name_row_size( size, row['is_sconscript_name'], row['dim'] )
         mark = _paint_sconscript_mark(
-            mark, row['is_sconscript_name'], row['dim']
+            mark, row['is_sconscript_name'], row['dim'], accent=row_accent
         )
         stem = as_subdued( stem )
         name = _paint_sconscript_name(
-            name, row['is_sconscript_name'], row['dim']
+            name, row['is_sconscript_name'], row['dim'], accent=row_accent
         )
     return INDENT + "{}  {}  {}{}".format( size, mark, stem, name )
 
 
-def _render_folder_section( folder, width ):
+def _render_folder_section( folder, width, accent='info', hang='selected' ):
     heading = _columns( 'LAST BUILD', 'BUILD FOLDER' )
-    root_line, selected_line = _folder_lines( folder, colour=True )
+    root_line, selected_line = _folder_lines(
+        folder, colour=True, accent=accent, hang=hang
+    )
     lines = _ruled_header( heading, width )
     lines.append( root_line )
     lines.append( selected_line )
@@ -574,50 +677,79 @@ def _render_folder_section( folder, width ):
     return lines
 
 
-def _render_toolchain_section( tree, width ):
+def _render_toolchain_section( tree, width, accent='info', mode='selection' ):
     heading = _columns( 'LAST BUILD', 'BY TOOLCHAIN VARIANT' )
     lines = _ruled_header( heading, width )
-    body = _toolchain_lines( tree, colour=True )
+    body = _toolchain_lines( tree, colour=True, accent=accent, mode=mode )
     lines.extend( body )
     if body:
         lines.append( _closing_rule( width ) )
     return lines
 
 
-def _render_sconscript_section( tree, width ):
-    heading = _columns( 'SELECTED', 'BY SCONSCRIPT' )
+def _render_sconscript_section(
+        tree, width, middle_heading='SELECTED', accent='info', mode='selection'
+):
+    heading = _columns( middle_heading, 'BY SCONSCRIPT' )
     lines = _ruled_header( heading, width )
-    rows = _sconscript_rows( tree )
+    rows = _sconscript_rows( tree, mode=mode )
     for row in rows:
-        lines.append( _format_sconscript_line( row, colour=True ) )
+        lines.append( _format_sconscript_line( row, colour=True, accent=accent ) )
     if rows:
         lines.append( _closing_rule( width ) )
     return lines
 
 
-def _report_width( folder, toolchain_tree, sconscript_tree ):
+def _report_width(
+        folder, toolchain_tree, sconscript_tree,
+        middle_heading='SELECTED', hang='selected', mode='selection'
+):
     """One rule width for every section, based on the widest plain-text line."""
-    root_line, selected_line = _folder_lines( folder, colour=False )
+    root_line, selected_line = _folder_lines( folder, colour=False, hang=hang )
     candidates = [
         INDENT + _columns( 'LAST BUILD', 'BUILD FOLDER' ),
         INDENT + _columns( 'LAST BUILD', 'BY TOOLCHAIN VARIANT' ),
-        INDENT + _columns( 'SELECTED', 'BY SCONSCRIPT' ),
+        INDENT + _columns( middle_heading, 'BY SCONSCRIPT' ),
         root_line,
         selected_line,
     ]
-    candidates.extend( _toolchain_lines( toolchain_tree, colour=False ) )
+    candidates.extend( _toolchain_lines( toolchain_tree, colour=False, mode=mode ) )
     candidates.extend(
         _format_sconscript_line( row, colour=False )
-        for row in _sconscript_rows( sconscript_tree )
+        for row in _sconscript_rows( sconscript_tree, mode=mode )
     )
     return _section_width( *candidates )
+
+
+def _write_build_report(
+        out, folder, toolchain_tree, sconscript_tree,
+        accent='info', middle_heading='SELECTED', hang='selected', mode='selection'
+):
+    """Print the three list/remove views with a shared rule width."""
+    width = _report_width(
+        folder, toolchain_tree, sconscript_tree,
+        middle_heading=middle_heading, hang=hang, mode=mode,
+    )
+    for line in _render_folder_section( folder, width, accent=accent, hang=hang ):
+        out.write( line + "\n" )
+    out.write( "\n" )
+    for line in _render_toolchain_section(
+            toolchain_tree, width, accent=accent, mode=mode
+    ):
+        out.write( line + "\n" )
+    out.write( "\n" )
+    for line in _render_sconscript_section(
+            sconscript_tree, width,
+            middle_heading=middle_heading, accent=accent, mode=mode,
+    ):
+        out.write( line + "\n" )
 
 
 def _effective_selection_settings( construct, cuppa_env, rows=None ):
     """Variant and toolchain flags for the selected builds that exist on disk.
 
     Defaults and CLI flags can name variants that are not present under the build root. The
-    summary command is for ``--remove-build``, so it only includes variants and toolchains that
+    summary command is for ``--remove-builds``, so it only includes variants and toolchains that
     appear in selected entries discovered on disk. When nothing selected exists yet, it falls
     back to the active option selection.
     """
@@ -726,8 +858,184 @@ def _render_summary( summary ):
         "",
         coloured,
         "",
-        "Append --remove-build to clear those folders.",
+        "Append --remove-builds to clear those folders.",
     ]
+
+
+def _confirm_list_builds_lines( construct, cuppa_env, rows ):
+    """After a removal, point at the same selection with ``--list-builds`` to verify."""
+    settings = _effective_selection_settings( construct, cuppa_env, rows=rows )
+    coloured = "cuppa -D"
+    suffix = _command_line_from_settings( settings, colour=True )
+    if suffix:
+        coloured = "cuppa -D " + suffix
+    coloured += " " + as_emphasised( "--list-builds" )
+    return [
+        "",
+        "Verify the removal with the same selection by adding --list-builds:",
+        "",
+        coloured,
+    ]
+
+
+def _removal_announce_line(
+        planning, candidate_count, size_bytes, abs_build_root, project_dir=None
+):
+    unit = "entry" if candidate_count == 1 else "entries"
+    path = storage.short_path( abs_build_root, project_dir=project_dir )
+    return "{} {} {} ({}) under {}".format(
+        "Would remove" if planning else "Removing",
+        as_emphasised( str( candidate_count ) ),
+        unit,
+        as_emphasised( storage.human_size( size_bytes ) ),
+        as_info( path ),
+    )
+
+
+def _removal_result_line( planning, removed_count, removed_bytes ):
+    unit = "entry" if removed_count == 1 else "entries"
+    size = storage.human_size( removed_bytes )
+    if planning:
+        return "Would remove {} {} freeing up {} of disk space.".format(
+            removed_count, unit, size
+        )
+    return "Removed {} {} freeing up {} of disk space.".format(
+        removed_count, unit, size
+    )
+
+
+def _plural( count, noun, plural_noun=None ):
+    if count == 1:
+        return "{} {}".format( count, noun )
+    return "{} {}".format( count, plural_noun or noun + "s" )
+
+
+def _format_removal_reason( error, project_dir, path=None ):
+    """Human reason for a failed removal; values live in ``[...]`` for highlighting."""
+    if isinstance( error, OSError ) and getattr( error, 'filename', None ):
+        short = storage.short_path( error.filename, project_dir=project_dir )
+        if error.errno is not None and error.strerror:
+            return "[Errno {}] {}: [{}]".format( error.errno, error.strerror, short )
+        if error.strerror:
+            return "{}: [{}]".format( error.strerror, short )
+        return "[{}]".format( short )
+    text = storage.shorten_paths_in_text( str( error ), project_dir=project_dir )
+    if path and '[' not in text:
+        short = storage.short_path( path, project_dir=project_dir )
+        return "{}: [{}]".format( text, short )
+    # Prefer bracketed paths over quotes so highlight_values can pick them out.
+    return re.sub(
+        r"(['\"])([^'\"]+)\1",
+        lambda match: "[{}]".format( match.group( 2 ) ),
+        text,
+    )
+
+
+def _removal_failure_summary( failures ):
+    errors = sum( 1 for item in failures if item['severity'] == 'error' )
+    warnings = sum( 1 for item in failures if item['severity'] == 'warning' )
+    parts = []
+    if errors:
+        parts.append( _plural( errors, 'error' ) )
+    if warnings:
+        parts.append( _plural( warnings, 'warning' ) )
+    return ", ".join( parts )
+
+
+def _removal_error_lines(
+        failures, width=None,
+        intro="Not all requested build entries could be removed"
+):
+    """Judgement tree for paths that could not be removed, matching --list-develop shape."""
+    if not failures:
+        return []
+
+    tee, elbow, pipe, gap = storage.glyphs()
+    stub = pipe.rstrip()
+    colour_for = { 'error': as_error, 'warning': as_warning }
+    heading_for = { 'error': 'error', 'warning': 'warning' }
+    prose_width = width if width is not None else storage.WIDEST_PROSE
+
+    summary = _removal_failure_summary( failures )
+    summary_colour = as_error if any(
+        item['severity'] == 'error' for item in failures
+    ) else as_warning
+    lines = [
+        "",
+        "{}: {}".format(
+            intro,
+            storage.highlight_values( "[{}]".format( summary ), summary_colour ),
+        ),
+        "",
+    ]
+
+    groups = []
+    for severity in ( 'error', 'warning' ):
+        group = [ item for item in failures if item['severity'] == severity ]
+        if group:
+            groups.append( ( severity, group ) )
+
+    for group_index, ( severity, group ) in enumerate( groups ):
+        if group_index:
+            lines.append( "" )
+        colour = colour_for[severity]
+        lines.append( INDENT + colour( _plural( len( group ), heading_for[severity] ) ) )
+        lines.append( as_subdued( INDENT + stub ) )
+        for index, failure in enumerate( group ):
+            last = index == len( group ) - 1
+            branch = elbow if last else tee
+            lines.append( as_subdued( INDENT + branch ) + colour( failure['label'] ) )
+            note_under = gap if last else pipe
+            note_branch = INDENT + note_under + elbow
+            note_carried = INDENT + note_under + gap
+            wrap_width = prose_width - len( note_branch )
+            for piece in storage.wrapped( failure['reason'], wrap_width ):
+                lines.append(
+                    as_subdued( note_branch )
+                    + storage.highlight_values( piece, colour )
+                )
+                note_branch = note_carried
+            if not last:
+                lines.append( as_subdued( INDENT + pipe.rstrip() ) )
+    return lines
+
+
+def _remove_all_announce_line( planning, abs_build_root, size_bytes, project_dir=None ):
+    path = storage.short_path( abs_build_root, project_dir=project_dir )
+    return "{} build root {} ({})".format(
+        "Would remove" if planning else "Removing",
+        as_info( path ),
+        as_emphasised( storage.human_size( size_bytes ) ),
+    )
+
+
+def _remove_all_result_line( planning, abs_build_root, size_bytes, project_dir=None ):
+    path = storage.short_path( abs_build_root, project_dir=project_dir )
+    size = storage.human_size( size_bytes )
+    if planning:
+        return "Would remove build root {} freeing up {} of disk space.".format(
+            as_info( path ),
+            as_emphasised( size ),
+        )
+    return "Removed build root {} freeing up {} of disk space.".format(
+        as_info( path ),
+        as_emphasised( size ),
+    )
+
+
+def _apply_removal_outcomes( rows, outcomes_by_path ):
+    """Stamp each selected row with removed/failed from the attempt map."""
+    for row in rows:
+        if not row['selected']:
+            row['result'] = 'none'
+            continue
+        outcome = outcomes_by_path.get( row['path'] )
+        if outcome is None:
+            row['result'] = 'none'
+            continue
+        row['result'] = outcome['result']
+        if outcome.get( 'reason' ):
+            row['error'] = outcome['reason']
 
 
 def list_builds( construct, cuppa_env, out=None ):
@@ -773,15 +1081,7 @@ def list_builds( construct, cuppa_env, out=None ):
         out.write( "\n" )
         return 0
 
-    width = _report_width( folder, toolchain_tree, sconscript_tree )
-    for line in _render_folder_section( folder, width ):
-        out.write( line + "\n" )
-    out.write( "\n" )
-    for line in _render_toolchain_section( toolchain_tree, width ):
-        out.write( line + "\n" )
-    out.write( "\n" )
-    for line in _render_sconscript_section( sconscript_tree, width ):
-        out.write( line + "\n" )
+    _write_build_report( out, folder, toolchain_tree, sconscript_tree )
     out.write( "\n" )
     for line in _render_summary( summary ):
         out.write( line + "\n" )
@@ -803,7 +1103,7 @@ def _refuse_suspicious_build_root( abs_build_root, sconstruct_dir ):
         )
 
 
-def remove_build( construct, cuppa_env, out=None ):
+def remove_builds( construct, cuppa_env, out=None ):
     """Remove variant subtrees matching the current selection. Returns an exit status."""
     out = out or sys.stdout
     abs_build_root = cuppa_env['abs_build_root']
@@ -834,77 +1134,252 @@ def remove_build( construct, cuppa_env, out=None ):
         ) )
         return 0
 
+    # Measure before acting so the post-removal report still has sizes to show.
+    rows = _collect_variant_rows( abs_build_root, suffixes )
+    folder = _folder_summary( abs_build_root, rows )
+    planned_bytes = sum( row['size_bytes'] for row in rows if row['selected'] )
     planning = dry_run( cuppa_env )
-    out.write( "{} {} matching variant {} under {}\n".format(
-        "Would remove" if planning else "Removing",
-        len( candidates ),
-        "tree" if len( candidates ) == 1 else "trees",
-        abs_build_root,
-    ) )
-    for path in sorted( candidates ):
-        size = storage.human_size( storage.directory_size( path ) )
-        out.write( "  {}  {}\n".format( size, path ) )
+    project_dir = cuppa_env['sconstruct_dir']
 
-    failed = 0
+    out.write( _removal_announce_line(
+        planning, len( candidates ), planned_bytes, abs_build_root,
+        project_dir=project_dir,
+    ) + "\n" )
+    out.write( "\n" )
+
+    outcomes_by_path = {}
+    failures = []
     for path in candidates:
+        label = os.path.relpath( path, abs_build_root )
+        if planning:
+            outcomes_by_path[path] = { 'result': 'removed' }
+            continue
         try:
             storage.ensure_contained( path, abs_build_root, what="build path" )
-            storage.remove_path( path, dry_run=planning )
-            if not planning:
-                storage.prune_empty_parents( os.path.dirname( path ), abs_build_root )
-        except ( storage.StorageError, OSError ) as error:
-            out.write( "failed: {}\n".format( error ) )
-            failed += 1
+            if not os.path.lexists( path ):
+                raise storage.StorageError(
+                    "not found (possibly already deleted)"
+                )
+            storage.remove_path( path, dry_run=False )
+            storage.prune_empty_parents( os.path.dirname( path ), abs_build_root )
+            outcomes_by_path[path] = { 'result': 'removed' }
+        except storage.StorageError as error:
+            reason = _format_removal_reason( error, project_dir, path=path )
+            already_gone = "already deleted" in str( error ).lower() or (
+                "not found" in str( error ).lower()
+            )
+            severity = 'warning' if already_gone else 'error'
+            outcomes_by_path[path] = { 'result': 'failed', 'reason': reason }
+            failures.append( {
+                'label': label,
+                'reason': reason,
+                'path': path,
+                'severity': severity,
+            } )
+        except OSError as error:
+            reason = _format_removal_reason( error, project_dir, path=path )
+            outcomes_by_path[path] = { 'result': 'failed', 'reason': reason }
+            failures.append( {
+                'label': label,
+                'reason': reason,
+                'path': path,
+                'severity': 'error',
+            } )
 
+    _apply_removal_outcomes( rows, outcomes_by_path )
+    removed_rows = [ row for row in rows if row.get( 'result' ) == 'removed' ]
+    removed_bytes = sum( row['size_bytes'] for row in removed_rows )
+    # Hang / accent reflect what succeeded; folder totals stay the pre-removal snapshot.
+    folder['selected_entries'] = len( removed_rows )
+    folder['selected_bytes'] = removed_bytes
+    folder['selected_size'] = storage.human_size( removed_bytes )
+    has_errors = any( item['severity'] == 'error' for item in failures )
+    if has_errors:
+        folder_accent = 'error'
+    elif failures:
+        folder_accent = 'warning'
+    else:
+        folder_accent = 'error'
+    toolchain_tree = _toolchain_variant_tree( rows )
+    sconscript_tree = _build_sconscript_tree( rows )
+
+    _write_build_report(
+        out, folder, toolchain_tree, sconscript_tree,
+        accent=folder_accent, middle_heading='REMOVED', hang='removed', mode='outcome',
+    )
+
+    for line in _removal_error_lines( failures ):
+        out.write( line + "\n" )
+
+    out.write( "\n" )
+    out.write( _removal_result_line( planning, len( removed_rows ), removed_bytes ) + "\n" )
     if planning:
         out.write( "dry run (-n); nothing removed\n" )
-    elif failed:
-        out.write( "removed with {} failure{}\n".format(
-            failed, "" if failed == 1 else "s"
-        ) )
+
+    for line in _confirm_list_builds_lines( construct, cuppa_env, rows ):
+        out.write( line + "\n" )
+    return 1 if has_errors else 0
+
+
+def _emit_outcome_tables( out, folder, rows, failures=None, intro=None ):
+    """Print REMOVED tables (and optional failure tree) from stamped outcome rows."""
+    removed_rows = [ row for row in rows if row.get( 'result' ) == 'removed' ]
+    removed_bytes = sum( row['size_bytes'] for row in removed_rows )
+    folder = dict( folder )
+    folder['selected_entries'] = len( removed_rows )
+    folder['selected_bytes'] = removed_bytes
+    folder['selected_size'] = storage.human_size( removed_bytes )
+    has_errors = any( item['severity'] == 'error' for item in ( failures or [] ) )
+    if has_errors:
+        folder_accent = 'error'
+    elif failures:
+        folder_accent = 'warning'
     else:
-        out.write( "removed {}\n".format(
-            "1 tree" if len( candidates ) == 1 else "{} trees".format( len( candidates ) )
-        ) )
-    return 1 if failed else 0
+        folder_accent = 'error'
+    toolchain_tree = _toolchain_variant_tree( rows )
+    sconscript_tree = _build_sconscript_tree( rows )
+    _write_build_report(
+        out, folder, toolchain_tree, sconscript_tree,
+        accent=folder_accent, middle_heading='REMOVED', hang='removed', mode='outcome',
+    )
+    if failures:
+        kwargs = {}
+        if intro:
+            kwargs['intro'] = intro
+        for line in _removal_error_lines( failures, **kwargs ):
+            out.write( line + "\n" )
+    return removed_rows, removed_bytes, has_errors
+
+
+def _failure_label_for_path( path, abs_build_root, project_dir ):
+    """Prefer a path relative to the build root; otherwise a short project/home path."""
+    if path and storage.is_contained( path, abs_build_root ):
+        return os.path.relpath( path, abs_build_root )
+    if path:
+        return storage.short_path( path, project_dir=project_dir )
+    return storage.short_path( abs_build_root, project_dir=project_dir )
+
+
+def _stamp_remove_all_outcomes( rows, succeeded, error=None ):
+    """Mark each variant removed or failed after a whole-root removal attempt."""
+    culprit = None
+    if error is not None and getattr( error, 'filename', None ):
+        culprit = os.path.realpath( error.filename )
+    for row in rows:
+        row['selected'] = True
+        if succeeded:
+            row['result'] = 'removed'
+            continue
+        if not os.path.lexists( row['path'] ):
+            row['result'] = 'removed'
+            continue
+        row['result'] = 'failed'
+        if culprit and (
+                os.path.realpath( row['path'] ) == culprit
+                or storage.is_contained( culprit, row['path'] )
+        ):
+            row['error'] = str( error )
 
 
 def remove_all_builds( cuppa_env, out=None ):
     """Remove the entire build root. Returns an exit status."""
     out = out or sys.stdout
     abs_build_root = cuppa_env['abs_build_root']
-    _refuse_suspicious_build_root( abs_build_root, cuppa_env['sconstruct_dir'] )
+    project_dir = cuppa_env['sconstruct_dir']
+    _refuse_suspicious_build_root( abs_build_root, project_dir )
 
+    short_root = storage.short_path( abs_build_root, project_dir=project_dir )
     if not os.path.exists( abs_build_root ):
-        out.write( "nothing to remove (build root [{}] does not exist)\n".format(
-            abs_build_root
-        ) )
+        out.write( storage.highlight_values(
+            "nothing to remove (build root [{}] does not exist)".format( short_root ),
+            as_info,
+        ) + "\n" )
         return 0
 
     if os.path.islink( abs_build_root ):
         raise storage.StorageError(
-            "refusing to remove build root through symlink [{}]".format( abs_build_root )
+            "refusing to remove build root through symlink [{}]".format( short_root )
         )
 
+    # Inventory before acting so the report can still name what was under the root.
+    rows = _collect_all_variant_rows( abs_build_root )
+    folder = _folder_summary( abs_build_root, rows )
+    size_bytes = folder['size_bytes']
     planning = dry_run( cuppa_env )
-    size = storage.human_size( storage.directory_size( abs_build_root ) )
-    out.write( "{} build root {} ({})\n".format(
-        "Would remove" if planning else "Removing",
-        abs_build_root,
-        size,
-    ) )
 
-    try:
-        storage.remove_path( abs_build_root, dry_run=planning )
-    except OSError as error:
-        out.write( "failed: {}\n".format( error ) )
-        return 1
+    out.write( _remove_all_announce_line(
+        planning, abs_build_root, size_bytes, project_dir=project_dir
+    ) + "\n" )
+    out.write( "\n" )
 
     if planning:
+        for row in rows:
+            row['result'] = 'removed'
+        _emit_outcome_tables( out, folder, rows )
+        out.write( "\n" )
+        out.write( _remove_all_result_line(
+            True, abs_build_root, size_bytes, project_dir=project_dir
+        ) + "\n" )
         out.write( "dry run (-n); nothing removed\n" )
+        out.write( "\nVerify with --list-builds:\n\n" )
+        out.write( as_emphasised( "cuppa -D --list-builds" ) + "\n" )
+        return 0
+
+    error = None
+    already_gone = False
+    try:
+        if not os.path.lexists( abs_build_root ):
+            raise storage.StorageError( "not found (possibly already deleted)" )
+        storage.remove_path( abs_build_root, dry_run=False )
+        succeeded = True
+    except storage.StorageError as caught:
+        succeeded = False
+        error = caught
+        already_gone = (
+            "already deleted" in str( caught ).lower()
+            or "not found" in str( caught ).lower()
+        )
+    except OSError as caught:
+        succeeded = False
+        error = caught
+
+    _stamp_remove_all_outcomes( rows, succeeded, error=error )
+
+    failures = []
+    if not succeeded:
+        severity = 'warning' if already_gone else 'error'
+        fail_path = getattr( error, 'filename', None ) or abs_build_root
+        label = _failure_label_for_path( fail_path, abs_build_root, project_dir )
+        reason = _format_removal_reason( error, project_dir, path=fail_path )
+        failures.append( {
+            'label': label,
+            'reason': reason,
+            'path': fail_path,
+            'severity': severity,
+        } )
+
+    removed_rows, removed_bytes, has_errors = _emit_outcome_tables(
+        out, folder, rows, failures=failures,
+        intro="The build root could not be removed" if failures else None,
+    )
+
+    out.write( "\n" )
+    if succeeded:
+        out.write( _remove_all_result_line(
+            False, abs_build_root, size_bytes, project_dir=project_dir
+        ) + "\n" )
+    elif already_gone:
+        out.write( "nothing removed (build root was already gone)\n" )
     else:
-        out.write( "removed {}\n".format( abs_build_root ) )
-    return 0
+        out.write( "Build root was not removed.\n" )
+        if removed_rows:
+            out.write( _removal_result_line(
+                False, len( removed_rows ), removed_bytes
+            ) + "\n" )
+
+    out.write( "\nVerify with --list-builds:\n\n" )
+    out.write( as_emphasised( "cuppa -D --list-builds" ) + "\n" )
+    return 1 if has_errors else 0
 
 
 def run( construct, cuppa_env, out=None ):
@@ -912,7 +1387,7 @@ def run( construct, cuppa_env, out=None ):
     out = out or sys.stdout
     try:
         if cuppa_env.get( 'remove_all_builds' ) and (
-                cuppa_env.get( 'remove_build' ) or cuppa_env.get( 'list_builds' )
+                cuppa_env.get( 'remove_builds' ) or cuppa_env.get( 'list_builds' )
         ):
             logger.warn( "[{}] takes precedence over the other build storage actions".format(
                     as_warning( "--remove-all-builds" )
@@ -923,10 +1398,10 @@ def run( construct, cuppa_env, out=None ):
                     "Running in REMOVE ALL BUILDS mode, no building will be attempted" ) )
             return remove_all_builds( cuppa_env, out=out )
 
-        if cuppa_env.get( 'remove_build' ):
+        if cuppa_env.get( 'remove_builds' ):
             logger.info( as_info_label(
-                    "Running in REMOVE BUILD mode, no building will be attempted" ) )
-            return remove_build( construct, cuppa_env, out=out )
+                    "Running in REMOVE BUILDS mode, no building will be attempted" ) )
+            return remove_builds( construct, cuppa_env, out=out )
 
         if cuppa_env.get( 'list_builds' ):
             logger.info( as_info_label(

--- a/cuppa/utility/storage.py
+++ b/cuppa/utility/storage.py
@@ -1,0 +1,276 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   Storage helpers — sizing, containment, removal, tables
+#-------------------------------------------------------------------------------
+
+"""Shared helpers for listing and removing what cuppa keeps on disk.
+
+Phase 2 uses these for builds; later phases reuse the same table shape, containment rules, and
+sizing for dependencies and downloads so the reports never disagree about how a path is judged.
+"""
+
+import json
+import locale
+import os
+import shutil
+import stat
+import sys
+import time
+from collections import namedtuple
+
+
+class StorageError( Exception ):
+    pass
+
+
+# tee, elbow, and the two continuations that sit under them, each the same width.
+GLYPHS = ( "\u251c\u2500\u2500 ", "\u2514\u2500\u2500 ", "\u2502   ", "    " )
+ASCII_GLYPHS = ( "+-- ", "`-- ", "|   ", "    " )
+
+# Affirmative mark for a selected build row; ASCII where the console cannot encode it.
+SELECTED_MARK = "\u2713"
+ASCII_SELECTED_MARK = "*"
+
+DirectoryStats = namedtuple( 'DirectoryStats', [ 'bytes', 'mtime' ] )
+
+
+def human_size( nbytes ):
+    """Human-readable size using 1024-based units, matching common ``du -h`` output."""
+    if nbytes is None:
+        return '-'
+    value = float( nbytes )
+    for unit in ( 'B', 'K', 'M', 'G', 'T', 'P' ):
+        if value < 1024.0 or unit == 'P':
+            if unit == 'B':
+                return "{}B".format( int( value ) )
+            formatted = "{:.1f}".format( value )
+            if formatted.endswith( '.0' ):
+                formatted = formatted[:-2]
+            return formatted + unit
+        value /= 1024.0
+    return "{}P".format( int( value ) )
+
+
+def relative_age( mtime, now=None ):
+    """How long ago ``mtime`` was, in words suited to a listing column."""
+    if mtime is None:
+        return '-'
+    now = time.time() if now is None else now
+    seconds = max( 0, int( now - mtime ) )
+    days = seconds // 86400
+    if days < 1:
+        return 'today'
+    if days == 1:
+        return 'yesterday'
+    if days < 14:
+        return "{} days ago".format( days )
+    weeks = days // 7
+    if days < 60:
+        return "{} weeks ago".format( weeks )
+    months = days // 30
+    if days < 730:
+        return "{} month ago".format( months ) if months == 1 else "{} months ago".format( months )
+    years = days // 365
+    return "{} year ago".format( years ) if years == 1 else "{} years ago".format( years )
+
+
+def display_path( path ):
+    """A path with the home directory replaced by ``~``, normalised for a report."""
+    if not path:
+        return path
+    path = os.path.normpath( path )
+    home = os.path.expanduser( '~' )
+    if path == home:
+        return '~'
+    prefix = home + os.sep
+    if path.startswith( prefix ):
+        return '~' + path[len( home ):]
+    return path
+
+
+def _console_encoding( encoding=None ):
+    return ( encoding
+             or getattr( sys.stdout, 'encoding', None )
+             or locale.getpreferredencoding()
+             or 'ascii' )
+
+
+def glyphs( encoding=None ):
+    """Box drawing where the console can encode it, ASCII where it cannot."""
+    try:
+        "".join( GLYPHS ).encode( _console_encoding( encoding ) )
+    except ( UnicodeError, LookupError ):
+        return ASCII_GLYPHS
+    return GLYPHS
+
+
+def selected_mark( encoding=None ):
+    """Check mark where the console can encode it, ``*`` where it cannot."""
+    try:
+        SELECTED_MARK.encode( _console_encoding( encoding ) )
+    except ( UnicodeError, LookupError ):
+        return ASCII_SELECTED_MARK
+    return SELECTED_MARK
+
+
+def selection_triple( status, encoding=None ):
+    """Three-character selection: full ``✓✓✓``, partial ``-✓-``, none ``---`` (ASCII ``*``)."""
+    mark = selected_mark( encoding )
+    if status == 'full':
+        return mark * 3
+    if status == 'partial':
+        return '-' + mark + '-'
+    return '---'
+
+
+def directory_stats( path ):
+    """Total size and newest modification time under ``path``. Symlinks are not followed."""
+    total = 0
+    newest = None
+    if not os.path.exists( path ):
+        return DirectoryStats( 0, None )
+    if os.path.islink( path ) or os.path.isfile( path ):
+        info = os.lstat( path )
+        return DirectoryStats( info.st_size, info.st_mtime )
+
+    for root, dirnames, filenames in os.walk( path, followlinks=False ):
+        dirnames[:] = [
+            name for name in dirnames
+            if not os.path.islink( os.path.join( root, name ) )
+        ]
+        try:
+            root_mtime = os.lstat( root ).st_mtime
+            newest = root_mtime if newest is None else max( newest, root_mtime )
+        except OSError:
+            pass
+        for name in filenames:
+            filepath = os.path.join( root, name )
+            try:
+                info = os.lstat( filepath )
+            except OSError:
+                continue
+            if stat.S_ISREG( info.st_mode ) or stat.S_ISLNK( info.st_mode ):
+                total += info.st_size
+                newest = info.st_mtime if newest is None else max( newest, info.st_mtime )
+    return DirectoryStats( total, newest )
+
+
+def directory_size( path ):
+    """Total size of regular files under ``path``. Symlinks are not followed."""
+    return directory_stats( path ).bytes
+
+
+def real_path( path ):
+    return os.path.realpath( os.path.expanduser( path ) )
+
+
+def is_contained( path, root ):
+    """True when ``path`` resolves inside ``root`` (both realpath'd)."""
+    if not path or not root:
+        return False
+    real = real_path( path )
+    base = real_path( root )
+    try:
+        common = os.path.commonpath( [ real, base ] )
+    except ValueError:
+        return False
+    return common == base
+
+
+def is_suspicious_root( path ):
+    """Roots that must never be removed wholesale, regardless of configuration."""
+    if not path:
+        return True
+    real = real_path( path )
+    home = real_path( os.path.expanduser( '~' ) )
+    if real in ( os.sep, home ):
+        return True
+    # Drive roots on Windows look like ``C:\``.
+    parent, name = os.path.split( real.rstrip( os.sep ) )
+    if name == '' or parent == real:
+        return True
+    return False
+
+
+def ensure_contained( path, root, what="path" ):
+    if not is_contained( path, root ):
+        raise StorageError(
+            "{} [{}] is outside managed root [{}]".format( what, path, root )
+        )
+
+
+def remove_path( path, dry_run=False ):
+    """Remove a file, symlink, or directory tree. Refuses to follow a symlink directory."""
+    if not os.path.lexists( path ):
+        return False
+
+    if os.path.islink( path ) or os.path.isfile( path ):
+        if not dry_run:
+            os.unlink( path )
+        return True
+
+    if os.path.isdir( path ):
+        if not dry_run:
+            shutil.rmtree( path )
+        return True
+
+    return False
+
+
+def prune_empty_parents( path, stop_at ):
+    """Remove empty directories from ``path`` up to, but not including, ``stop_at``."""
+    stop_at = real_path( stop_at )
+    current = real_path( path ) if os.path.isdir( path ) else real_path( os.path.dirname( path ) )
+
+    while current and current != stop_at and is_contained( current, stop_at ):
+        try:
+            os.rmdir( current )
+        except OSError:
+            break
+        parent = os.path.dirname( current )
+        if parent == current:
+            break
+        current = parent
+
+
+def render_table( columns, rows ):
+    """Padded plain-text table: header, one row per entry. Columns are ``(key, heading)``."""
+    keys = [ key for key, _heading in columns ]
+    headings = [ heading for _key, heading in columns ]
+    cells = [ headings ]
+    for row in rows:
+        cells.append( [ str( row.get( key, '' ) ) for key in keys ] )
+
+    widths = [ max( len( cell[i] ) for cell in cells ) for i in range( len( keys ) ) ]
+    lines = []
+    for cell in cells:
+        lines.append( "  ".join(
+            value.ljust( widths[i] ) for i, value in enumerate( cell )
+        ).rstrip() )
+    return lines
+
+
+def render_json( columns, rows, total_bytes=None, extra=None ):
+    keys = [ key for key, _heading in columns ]
+    entries = []
+    for row in rows:
+        entry = { key: row.get( key ) for key in keys }
+        if 'size_bytes' in row:
+            entry['size_bytes'] = row['size_bytes']
+        entries.append( entry )
+    payload = { 'entries': entries }
+    if total_bytes is not None:
+        payload['total_bytes'] = total_bytes
+        payload['total'] = human_size( total_bytes )
+    if extra:
+        payload.update( extra )
+    return render_json_payload( payload )
+
+
+def render_json_payload( payload ):
+    """Pretty-print a JSON object for ``--list-format=json``."""
+    return json.dumps( payload, indent=2, sort_keys=True )

--- a/cuppa/utility/storage.py
+++ b/cuppa/utility/storage.py
@@ -16,9 +16,11 @@ sizing for dependencies and downloads so the reports never disagree about how a 
 import json
 import locale
 import os
+import re
 import shutil
 import stat
 import sys
+import textwrap
 import time
 from collections import namedtuple
 
@@ -31,9 +33,17 @@ class StorageError( Exception ):
 GLYPHS = ( "\u251c\u2500\u2500 ", "\u2514\u2500\u2500 ", "\u2502   ", "    " )
 ASCII_GLYPHS = ( "+-- ", "`-- ", "|   ", "    " )
 
-# Affirmative mark for a selected build row; ASCII where the console cannot encode it.
+# Affirmative mark for a selected / removed build row; ASCII where the console cannot encode it.
 SELECTED_MARK = "\u2713"
 ASCII_SELECTED_MARK = "*"
+# Heavier form used when a fully matched name-row mark is emphasised.
+HEAVY_SELECTED_MARK = "\u2714"
+
+# Ballot for a removal that failed; ASCII where the console cannot encode it.
+FAILED_MARK = "\u2717"
+ASCII_FAILED_MARK = "x"
+# Heavier form used when a fully matched name-row mark is emphasised.
+HEAVY_FAILED_MARK = "\u2718"
 
 DirectoryStats = namedtuple( 'DirectoryStats', [ 'bytes', 'mtime' ] )
 
@@ -117,6 +127,28 @@ def selected_mark( encoding=None ):
     return SELECTED_MARK
 
 
+def failed_mark( encoding=None ):
+    """Ballot mark where the console can encode it, ``x`` where it cannot."""
+    try:
+        FAILED_MARK.encode( _console_encoding( encoding ) )
+    except ( UnicodeError, LookupError ):
+        return ASCII_FAILED_MARK
+    return FAILED_MARK
+
+
+def with_heavy_marks( text, encoding=None ):
+    """Upgrade light ``✓`` / ``✗`` to heavy ``✔`` / ``✘`` when the console can encode them."""
+    if not text:
+        return text
+    try:
+        ( HEAVY_SELECTED_MARK + HEAVY_FAILED_MARK ).encode( _console_encoding( encoding ) )
+    except ( UnicodeError, LookupError ):
+        return text
+    return text.replace( SELECTED_MARK, HEAVY_SELECTED_MARK ).replace(
+        FAILED_MARK, HEAVY_FAILED_MARK
+    )
+
+
 def selection_triple( status, encoding=None ):
     """Three-character selection: full ``✓✓✓``, partial ``-✓-``, none ``---`` (ASCII ``*``)."""
     mark = selected_mark( encoding )
@@ -125,6 +157,87 @@ def selection_triple( status, encoding=None ):
     if status == 'partial':
         return '-' + mark + '-'
     return '---'
+
+
+def outcome_triple( selection, result, encoding=None ):
+    """Rollup mark for a removal report: checks for success, ballots for failure.
+
+    ``result`` is ``removed``, ``failed``, ``mixed``, or ``none``.
+    All-failed rollups are ``✗✗✗``; mixed success and failure is ``✓-✗``; all-removed follows
+    the usual full / partial check pattern.
+    """
+    if result == 'none' or selection == 'none':
+        return '---' if selection != 'none' else ''
+    ok = selected_mark( encoding )
+    bad = failed_mark( encoding )
+    if result == 'removed':
+        if selection == 'full':
+            return ok * 3
+        return '-' + ok + '-'
+    if result == 'failed':
+        return bad * 3
+    # mixed: some removed, some failed
+    return ok + '-' + bad
+
+
+def short_path( path, project_dir=None ):
+    """Prefer a project-relative path, otherwise ``~``, for report text."""
+    if not path:
+        return path
+    path = os.path.normpath( path )
+    if project_dir:
+        project = real_path( project_dir )
+        real = real_path( path )
+        try:
+            common = os.path.commonpath( [ real, project ] )
+        except ValueError:
+            common = None
+        if common == project:
+            relative = os.path.relpath( real, project )
+            return relative if relative != '.' else os.path.basename( project ) or '.'
+    return display_path( path )
+
+
+def shorten_paths_in_text( text, project_dir=None ):
+    """Replace absolute / home paths in ``text`` with :func:`short_path` forms."""
+    if not text:
+        return text
+
+    def replace( match ):
+        quote = match.group( 1 ) or ''
+        raw = match.group( 2 ) or match.group( 3 )
+        shortened = short_path( raw, project_dir=project_dir )
+        if quote:
+            return quote + shortened + quote
+        return shortened
+
+    # Quoted paths first, then bare absolute / home paths.
+    pattern = re.compile(
+        r"(['\"])([^'\"]+)\1|(?<![\w./])(~?/[^\s\"']+)"
+    )
+    return pattern.sub( replace, text )
+
+
+# Bracketed placeholders in report prose — colour these, leave the surrounding text plain
+# (same convention as ``--list-develop``).
+_VALUES = re.compile( r'\[([^\[\]]+)\]' )
+WIDEST_PROSE = 110
+NARROWEST_PROSE = 40
+
+
+def highlight_values( text, colour ):
+    """Colour only ``[placeholder]`` spans in otherwise plain report prose."""
+    return _VALUES.sub( lambda match: "[" + colour( match.group( 1 ) ) + "]", text )
+
+
+def wrapped( text, width ):
+    """Wrap prose, keeping bracketed values whole so they can still be coloured."""
+    if not width:
+        return [ text ]
+    return textwrap.wrap(
+        text, max( width, NARROWEST_PROSE ),
+        break_long_words=False, break_on_hyphens=False
+    ) or [ text ]
 
 
 def directory_stats( path ):

--- a/design/README.md
+++ b/design/README.md
@@ -20,7 +20,7 @@ alternatives behind one of those roadmap entries.
 |----------|--------|---------|
 | [`plans/coverage-performance.md`](plans/coverage-performance.md) | proposal | Where `--cov --test` time actually goes, what the A/B measurement ruled out, and the remaining suspects |
 | [`plans/modules-activation.md`](plans/modules-activation.md) | proposal | Whether C++ modules should stay opt-in behind `--modules` or become opt-out, and what must land first |
-| [`plans/removal-options.md`](plans/removal-options.md) | in progress | `--remove-build` / `--remove-dependencies` / `--purge-*`, listing with sizes, renaming the storage roots; `--list-develop` / `--update-develop` are done ([#132](https://github.com/ja11sop/cuppa/issues/132)) |
+| [`plans/removal-options.md`](plans/removal-options.md) | in progress | `--remove-build` / `--list-builds` next (Phase 2); storage rename done ([#133](https://github.com/ja11sop/cuppa/issues/133)); `--list-develop` / `--update-develop` done ([#132](https://github.com/ja11sop/cuppa/issues/132)) |
 | [`plans/scons-tool-wrapper.md`](plans/scons-tool-wrapper.md) | proposal | Wrapping an SCons Tool as a cuppa dependency instead of hand-writing a dependency class |
 | [`archive/conan-consumer-plan.md`](archive/conan-consumer-plan.md) | shipped | Design of `conan_deps` / `conan_dependency` consumer support |
 | [`archive/conan-publish-plan.md`](archive/conan-publish-plan.md) | shipped | Design of `ConanPackagePublisher` and `--publish-package` |

--- a/design/README.md
+++ b/design/README.md
@@ -21,7 +21,7 @@ alternatives behind one of those roadmap entries.
 | [`plans/colourised-doc-samples.md`](plans/colourised-doc-samples.md) | proposal | Capture cuppa report output as semantic HTML for Antora samples and local preview |
 | [`plans/coverage-performance.md`](plans/coverage-performance.md) | proposal | Where `--cov --test` time actually goes, what the A/B measurement ruled out, and the remaining suspects |
 | [`plans/modules-activation.md`](plans/modules-activation.md) | proposal | Whether C++ modules should stay opt-in behind `--modules` or become opt-out, and what must land first |
-| [`plans/removal-options.md`](plans/removal-options.md) | in progress | Phase 2 is in progress for [#134](https://github.com/ja11sop/cuppa/issues/134); storage rename done ([#133](https://github.com/ja11sop/cuppa/issues/133)); `--list-develop` / `--update-develop` done ([#132](https://github.com/ja11sop/cuppa/issues/132)) |
+| [`plans/removal-options.md`](plans/removal-options.md) | in progress | Phases 1, 2, and 5 done (#133, #140, #132); dependency/download listing and removal ([#134](https://github.com/ja11sop/cuppa/issues/134)) and artefact removal ([#135](https://github.com/ja11sop/cuppa/issues/135)) remain |
 | [`plans/scons-tool-wrapper.md`](plans/scons-tool-wrapper.md) | proposal | Wrapping an SCons Tool as a cuppa dependency instead of hand-writing a dependency class |
 | [`archive/conan-consumer-plan.md`](archive/conan-consumer-plan.md) | shipped | Design of `conan_deps` / `conan_dependency` consumer support |
 | [`archive/conan-publish-plan.md`](archive/conan-publish-plan.md) | shipped | Design of `ConanPackagePublisher` and `--publish-package` |

--- a/design/README.md
+++ b/design/README.md
@@ -20,7 +20,7 @@ alternatives behind one of those roadmap entries.
 |----------|--------|---------|
 | [`plans/coverage-performance.md`](plans/coverage-performance.md) | proposal | Where `--cov --test` time actually goes, what the A/B measurement ruled out, and the remaining suspects |
 | [`plans/modules-activation.md`](plans/modules-activation.md) | proposal | Whether C++ modules should stay opt-in behind `--modules` or become opt-out, and what must land first |
-| [`plans/removal-options.md`](plans/removal-options.md) | in progress | `--remove-build` / `--list-builds` next (Phase 2); storage rename done ([#133](https://github.com/ja11sop/cuppa/issues/133)); `--list-develop` / `--update-develop` done ([#132](https://github.com/ja11sop/cuppa/issues/132)) |
+| [`plans/removal-options.md`](plans/removal-options.md) | in progress | Phase 2 is in progress for [#134](https://github.com/ja11sop/cuppa/issues/134); storage rename done ([#133](https://github.com/ja11sop/cuppa/issues/133)); `--list-develop` / `--update-develop` done ([#132](https://github.com/ja11sop/cuppa/issues/132)) |
 | [`plans/scons-tool-wrapper.md`](plans/scons-tool-wrapper.md) | proposal | Wrapping an SCons Tool as a cuppa dependency instead of hand-writing a dependency class |
 | [`archive/conan-consumer-plan.md`](archive/conan-consumer-plan.md) | shipped | Design of `conan_deps` / `conan_dependency` consumer support |
 | [`archive/conan-publish-plan.md`](archive/conan-publish-plan.md) | shipped | Design of `ConanPackagePublisher` and `--publish-package` |

--- a/design/README.md
+++ b/design/README.md
@@ -18,6 +18,7 @@ alternatives behind one of those roadmap entries.
 
 | Document | Status | Subject |
 |----------|--------|---------|
+| [`plans/colourised-doc-samples.md`](plans/colourised-doc-samples.md) | proposal | Capture cuppa report output as semantic HTML for Antora samples and local preview |
 | [`plans/coverage-performance.md`](plans/coverage-performance.md) | proposal | Where `--cov --test` time actually goes, what the A/B measurement ruled out, and the remaining suspects |
 | [`plans/modules-activation.md`](plans/modules-activation.md) | proposal | Whether C++ modules should stay opt-in behind `--modules` or become opt-out, and what must land first |
 | [`plans/removal-options.md`](plans/removal-options.md) | in progress | Phase 2 is in progress for [#134](https://github.com/ja11sop/cuppa/issues/134); storage rename done ([#133](https://github.com/ja11sop/cuppa/issues/133)); `--list-develop` / `--update-develop` done ([#132](https://github.com/ja11sop/cuppa/issues/132)) |

--- a/design/plans/colourised-doc-samples.md
+++ b/design/plans/colourised-doc-samples.md
@@ -1,0 +1,267 @@
+# Plan: colourised sample output for documentation and preview
+
+- **Status:** proposal
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Documentation tooling (`doc-output-samples`); follows build-report work in [`removal-options.md`](removal-options.md) Phase 2
+- **Updated:** 2026-08-02
+
+Cuppa already produces rich, colour-coded reports (`--list-builds`, `--list-develop`,
+`--remove-builds`, coverage summaries, and more). The Antora docs currently show those reports as
+plain `[source,text]` blocks and describe colour in prose. That works, but readers never see the
+hierarchy that colour and emphasis are meant to convey.
+
+This plan proposes a **general facility** to capture cuppa report output and render it as stable,
+colourised HTML suitable for:
+
+1. Inclusion in Antora pages (annotated examples next to commands).
+2. Local **preview** of what a report looks like without reading a terminal transcript.
+3. Optional CI checks that sample pages still build.
+
+It is deliberately separate from the storage/removal phases: those land reports first; this makes
+the reports teachable in the docs.
+
+---
+
+## 1. Goals and non-goals
+
+**Goals**
+
+- Turn real cuppa report output into something the documentation site can show in colour.
+- Prefer **semantic** markup driven by cuppa's existing meaning vocabulary (`error`, `warning`,
+  `info`, `notice`, `emphasised`, `subdued`, labels, …) over scraping terminal-dependent ANSI.
+- Provide a small capture/preview CLI so authors can regenerate samples without hand-editing HTML.
+- Keep samples free of private project names and absolute home paths (same rule as the rest of
+  this repository).
+- Style samples so they remain readable on the Antora UI's light page background.
+
+**Non-goals**
+
+- Replacing the live terminal colouriser or changing default build log colours.
+- Pixel-perfect terminal screenshots or animated demos.
+- Colourising arbitrary compiler/tool stdout that cuppa does not own.
+- Requiring a network fetch (Kroki, etc.) at Antora build time — same constraint as Mermaid today
+  (client-side or checked-in artefacts only).
+
+---
+
+## 2. Why not only “capture ANSI and convert”?
+
+Cuppa already depends on **colorama** and enables colour when not under `--raw-output`. Capturing
+ANSI and feeding it to `ansi2html` (or similar) is attractive for “what the terminal showed”, but:
+
+| Issue | Effect on docs |
+|-------|----------------|
+| `CUPPA_CONSOLE_BACKGROUND` / `COLORFGBG` | Subdued text uses DIM vs grey-256; samples drift by machine |
+| Nested emphasise + colour | Reset sequences are easy to mis-parse |
+| Docs site is light-themed | Raw dark-terminal palettes can be illegible |
+| `--raw-output` / pipes | Easy to accidentally capture uncoloured text in CI |
+
+ANSI conversion remains useful as an **optional preview mode** (“show me exactly this run”). The
+**canonical docs path** should be semantic HTML from the same `as_*` meanings the terminal uses.
+
+---
+
+## 3. Design sketch
+
+```text
+  report code
+      │
+      ├─ Colouriser (ANSI)     → terminal / CI logs
+      │
+      └─ HtmlColouriser (new)  → spans with cuppa-* classes
+                │
+                v
+        capture runner (script)
+                │
+                ├─ stdout HTML fragment
+                ├─ optional full preview page
+                └─ checked-in sample under docs/…/samples/  (or generated at doc build)
+                │
+                v
+        Antora page include + supplemental-ui CSS
+```
+
+### 3.1 HtmlColouriser
+
+Add a parallel implementation (name illustrative) that implements the same operations the report
+code already calls through `cuppa.colourise` helpers:
+
+| Helper today | Docs class (illustrative) |
+|--------------|---------------------------|
+| `as_error` / `as_error_label` | `cuppa-error` / `cuppa-error-label` |
+| `as_warning` / `as_warning_label` | `cuppa-warning` / `cuppa-warning-label` |
+| `as_info` / `as_info_label` | `cuppa-info` / `cuppa-info-label` |
+| `as_notice` | `cuppa-notice` |
+| `as_emphasised` | `cuppa-emphasised` (bold / stronger weight) |
+| `as_subdued` | `cuppa-subdued` (grey, not DIM-on-white) |
+
+Implementation options (pick one in the first PR):
+
+1. **Injectable colouriser** — `colourise` gains `set_colouriser(...)` / context manager used only
+   by the capture runner; production builds keep today's ANSI colouriser.
+2. **Dual emit** — helpers append to a side channel (fragile; avoid).
+3. **Post-process a tagged stream** — reports emit `\0meaning\0text\0` (invasive; avoid).
+
+Option 1 matches how tests already stub behaviour and keeps report code unchanged aside from
+going through the shared helpers (which they already do).
+
+Escape HTML in text nodes; preserve spaces/newlines inside a `<pre class="cuppa-output">`.
+
+### 3.2 Capture runner
+
+A module under `scripts/` (illustrative: `python -m scripts.sample_output`) that:
+
+1. Builds a **fixture project** under a temp dir (reuse integration helpers / dummy project), or
+   accepts `--project=` for local preview against a real tree (never commit that capture).
+2. Forces colour / HTML mode and a fixed console background for any ANSI fallback.
+3. Invokes specific reports in-process where possible (`storage_actions.list_builds`,
+   `develop.list_develop`, …) so samples do not need a full compiler — or shells out to
+   `python -m cuppa` when the report only exists as a CLI mode.
+4. Rewrites paths through the existing `short_path` / display helpers so samples show `_build`,
+   `~/.cuppa/…`, not `/home/<user>/…`.
+5. Writes:
+
+   - `*.html` fragment (body inner HTML only), and/or
+   - `*.adoc` wrapper with a passthrough block, and/or
+   - a standalone preview page with the CSS inlined for `file://` viewing.
+
+Suggested first recipes (names illustrative):
+
+| Recipe | Source |
+|--------|--------|
+| `list-builds` | Planted variant trees + `list_builds` |
+| `remove-builds-dry` | Same + `remove_builds` with dry-run |
+| `remove-all-builds-dry` | Same + `remove_all_builds` with dry-run |
+| `list-develop` | Fake develop copies / existing unit fakes |
+
+### 3.3 Antora integration
+
+**CSS:** add `docs/supplemental-ui/css/cuppa-output.css` (or partial + `ui.yml` edit) defining the
+`cuppa-*` classes against the default Antora light background. Keep contrast accessible; do not
+rely on terminal bright-on-black.
+
+**Pages:** replace or supplement plain listings with an include, for example:
+
+```asciidoc
+.Example `--list-builds` output (colours approximate the terminal meanings)
+++++
+include::partial$samples/list-builds.html[]
+++++
+```
+
+Exact include path depends on whether fragments live as Antora partials or as generated files
+copied in a docs npm script before `antora generate`.
+
+**Optional AsciiDoc role:** `[cuppa-output]` on a listing that contains only escaped plain text is
+*not* enough for spans; passthrough HTML (or a tiny Antora extension that expands a custom block)
+is required for colour. Prefer checked-in or pre-build fragments over a Ruby/Asciidoctor extension
+(Antora 3 uses Asciidoctor.js — same constraint that blocked `asciidoctor-diagram`).
+
+### 3.4 Preview facility
+
+```sh
+python -m scripts.sample_output list-builds --preview
+# → opens or prints path to _docs_build/samples/list-builds.preview.html
+```
+
+Authors use this while iterating on report layout, without running a full Antora build. The same
+artefact can be copied into `docs/` when the sample should ship.
+
+### 3.5 Optional ANSI path
+
+```sh
+python -m scripts.sample_output list-builds --format=ansi-html
+```
+
+Force `TERM=xterm-256color`, `CUPPA_CONSOLE_BACKGROUND=dark` (or `light`), enable colour, capture
+stdout, convert with a pinned dependency or a minimal SGR→span mapper. Document that this mode is
+for preview parity checks, not for committed docs samples, unless the env is fully pinned in the
+recipe.
+
+---
+
+## 4. Path and privacy rules
+
+Samples committed under `docs/` are public. The capture runner must:
+
+- Run under a temp project root with generic names (`widget`, `_build`, …).
+- Apply `short_path` / `display_path` so home directories become `~`.
+- Fail the recipe if output matches `/home/` or other absolute user paths (guard test).
+
+Private consumer project names must not appear — same policy as `AGENTS.md`.
+
+---
+
+## 5. Testing
+
+| Layer | What |
+|-------|------|
+| Unit | `HtmlColouriser` escapes HTML; nested emphasise+info produces expected class nesting or ordered spans; subdued never emits raw DIM alone without a docs-safe class |
+| Unit | Path guard rejects absolute home paths in fragments |
+| Unit | Design-index / recipe registry stays consistent if recipes are listed in a table |
+| Optional integration | One Antora build job or local `npm run build` asserts a sample page contains `cuppa-output` and `cuppa-info` |
+
+Do not require a C++ toolchain for the HTML colouriser unit tests; plant directories like the
+storage-action unit tests already do.
+
+---
+
+## 6. Documentation impact
+
+Once the facility exists:
+
+- Update `build-layout.adoc` (and later `dependencies.adoc` develop section) to include colourised
+  samples beside the existing plain listings, or replace plain listings where colour is the point.
+- Document the capture command for contributors in `docs/modules/ROOT/pages/extending.adoc` or a
+  short “Writing docs” note — only if we want contributors to regenerate samples; otherwise keep
+  the runner as a maintainer tool referenced from this plan and `AGENTS.md`.
+
+Release impact: **none** for the facility alone (docs/tooling); **patch** if shipped samples are
+considered doc fixes in an open release cycle.
+
+---
+
+## 7. Phased delivery
+
+| Phase | Delivers | Notes |
+|-------|----------|-------|
+| A | `HtmlColouriser` + unit tests + preview CSS | No Antora page changes required yet |
+| B | `scripts.sample_output` with `list-builds` / `remove-builds-dry` recipes | Unblocks authoring |
+| C | Wire samples into `build-layout.adoc`; supplemental-ui CSS in the site | Reader-visible |
+| D | Add `list-develop` and other high-value recipes; optional `ansi-html` format | Expand coverage |
+
+Phase A+B can land without waiting on removal Phase 2 merge; Phase C should use the final report
+shapes from `#134` so samples do not churn.
+
+---
+
+## 8. Alternatives considered
+
+| Approach | Why not first |
+|----------|----------------|
+| Manual HTML in AsciiDoc | Rotates out of date the first time marks or columns change |
+| Screenshots / SVG exports | Heavy to regenerate; inaccessible to search; poor for copy-paste |
+| Kroki / server-side render | Network at doc build; avoided for Mermaid already |
+| Only ANSI→HTML | Environment-dependent; weak on light doc backgrounds |
+| Asciidoctor syntax highlighter themes | Highlights “language”, not cuppa meanings |
+
+---
+
+## 9. Open questions
+
+1. **Checked-in vs generate-at-doc-build** — Checked-in fragments are reviewable in PRs; generate
+   during `npm run build` always matches code but needs Python on the docs CI path.
+2. **Emphasise + colour nesting** — Emit outer `<span class="cuppa-emphasised"><span class="cuppa-info">` or a single combined class? Combined classes are simpler for CSS.
+3. **Dark-mode docs** — Antora UI default is light; if the site later gains a dark theme, samples
+   need paired CSS variables.
+4. **GitHub issue** — File when Phase A starts; no issue number yet.
+
+---
+
+## 10. Success criteria
+
+- A maintainer can regenerate a colourised `--list-builds` sample with one command and open a
+  preview HTML file locally.
+- The published build-layout page shows that sample in colour without describing “red” and “blue”
+  as the only way to understand marks.
+- No committed sample contains a personal absolute path or private project name.
+- Unit tests cover the HTML colouriser without a compiler.

--- a/design/plans/removal-options.md
+++ b/design/plans/removal-options.md
@@ -14,9 +14,8 @@ easy to aim at the wrong path, and cuppa already knows exactly which folders bel
 variant and which dependency.
 
 This plan proposes a way to list what is in the storage roots, a family of explicit removal
-options, a report on the state of the local working copies `--develop` substitutes together with
-conservative ways to bring them up to date and to create the ones that are missing, and the
-safety model that governs all of it.
+options (Phase 2 next), conservative ways to create develop copies that are missing (§3.7), and
+the safety model that governs deletion.
 
 The storage rename came **first** (§6, Phase 1) so every later phase talks about one vocabulary.
 Throughout this document the new names are used: `dependencies_root` (was `download_root`) and
@@ -69,9 +68,9 @@ which defaults to `~/.cuppa` and can be moved with one option.
 | Remove a variant folder | manual `rm -rf _build/...` |
 | Remove all build output | manual `rm -rf _build` |
 | See what dependencies are on disk and how big they are | manual `du -sh` |
-| Remove one stale dependency | manual `rm -rf` under the download root |
+| Remove one stale dependency | manual `rm -rf` under the dependencies root |
 | Remove all dependencies | manual |
-| Remove cached archives | manual, under `cache_root` |
+| Remove cached archives | manual, under the downloads root |
 
 The listing gap matters as much as the removal gap. Working across branches leaves
 branch-qualified trees (`…@feature_x`) behind indefinitely, and nothing ever reports them, so
@@ -79,20 +78,23 @@ they accumulate unnoticed until a disk fills.
 
 ### 2.2 Storage roots
 
-From `cuppa/core/storage_options.py`:
+From `cuppa/core/storage_options.py` **after Phase 1**:
 
 | Key | Default | Set by |
 |-----|---------|--------|
 | `build_root` / `abs_build_root` | `_build` | `--build-root` |
-| `download_root` | `_cuppa` (project-relative) | `--download-root` |
-| `cache_root` | `~/_cuppa/_cache` | `--cache-root` |
+| `storage_root` | `~/.cuppa` | `--storage-root` |
+| `dependencies_root` | `<storage_root>/dependencies` | `--dependencies-root` |
+| `downloads_root` | `<storage_root>/downloads` | `--downloads-root` |
 
-Many users point `download_root` at a shared location (for example `~/_cuppa/_download` via
-`~/.cuppaconfig`), which is what makes stale dependency trees shared across projects and
-therefore worth a managed removal command.
+`download_root` and `cache_root` remain as aliases of the resolved `dependencies_root` and
+`downloads_root` (and `--download-root` / `--cache-root` as deprecated CLI aliases) so plugins and
+`~/.cuppaconfig` entries keep working. Where an older tree already exists — project-local `_cuppa`,
+or `~/_cuppa/_download` / `~/_cuppa/_cache` — and no root is named, that tree is kept in use so an
+upgrade does not re-fetch; see §8.5.
 
-This table describes today. Phase 1 renames these to `dependencies_root` and `downloads_root`,
-changes where they default to, and adds the `storage_root` they derive from; see §8.
+Shared dependency trees are now the default, which is what makes stale trees across projects
+worth a managed removal command in later phases.
 
 ### 2.3 Build root layout
 
@@ -117,30 +119,31 @@ Two consequences matter for removal:
    the location folder name, and are exactly the leftovers the current `--clean` warning
    points at.
 
-### 2.4 Download root layout
+### 2.4 Dependencies root layout
 
-Written by several subsystems, all under `download_root`:
+Written by several subsystems, all under `dependencies_root`:
 
 | Producer | Path shape |
 |----------|-----------|
-| `cuppa/location.py` (VCS) | `<download_root>/<folder_name_from_path(url)>[@<branch or tag>]` |
-| `cuppa/location.py` (archives) | `<download_root>/<folder_name_from_path(url)>` (extracted) |
-| `cuppa/package_managers/gitlab.py` | `<download_root>/<tool_variant>/<package>/<version>/` |
-| `cuppa/build_with_conan.py` | `<download_root>/conan/<dependency name>/` |
+| `cuppa/location.py` (VCS) | `<dependencies_root>/<folder_name_from_path(url)>[@<branch or tag>]` |
+| `cuppa/location.py` (archives) | `<dependencies_root>/<folder_name_from_path(url)>` (extracted) |
+| `cuppa/package_managers/gitlab.py` | `<dependencies_root>/<tool_variant>/<package>/<version>/` |
+| `cuppa/build_with_conan.py` | `<dependencies_root>/conan/<dependency name>/` |
 
 The `@<branch>` suffix is decided by relative versioning plus `--location-match-current-branch`
 / `--location-match-branch` / `--location-match-tag`, so the *same* dependency can legitimately
 have several sibling folders. Removal has to be explicit about which of those it is deleting.
 
-### 2.5 Cache root layout
+### 2.5 Downloads root layout
 
 | Producer | Path shape |
 |----------|-----------|
-| `cuppa/location.py` | `<cache_root>/<local folder name>` — the raw downloaded archive |
-| `cuppa/package_managers/gitlab.py` | `<cache_root>/packages/<package>/<version>/<package file>.tar.gz` |
+| `cuppa/location.py` | `<downloads_root>/<local folder name>` — the raw downloaded archive |
+| `cuppa/package_managers/gitlab.py` | `<downloads_root>/packages/<package>/<version>/<package file>.tar.gz` |
 
-Note the asymmetry that motivates §8: the folder called `_download` holds *extracted, ready to
-use* trees, and the folder called `_cache` holds the *actual downloaded files*.
+The names after Phase 1 match the contents: `dependencies` holds extracted, ready-to-use trees;
+`downloads` holds the archives they came from. Older layouts used `_download` / `_cache` under
+`_cuppa` for the same split (§8.5).
 
 ---
 
@@ -809,14 +812,14 @@ discussion uses one set of names. Phases 1 to 4 form one chain: each needs the v
 machinery of the one before it. Phases 5 and 6 do not — Phase 5 touches no storage at all and
 could land at any point, and Phase 6 needs a design pass this plan does not attempt.
 
-| Phase | Delivers | Depends on |
-|-------|----------|-----------|
-| 1 | `--storage-root` and the renamed roots | — |
-| 2 | `--remove-build`, `--remove-all-builds`, `--list-builds` | 1 |
-| 3 | Inventory, `--list-dependencies`, `--remove-dependencies` / `--remove-all-dependencies` | 1, 2 |
-| 4 | `--list-downloads`, `--purge-*` | 3 |
-| 5 | `--list-develop`, `--update-develop` | nothing in this plan |
-| 6 | `--remove-artefacts` | its own design pass first |
+| Phase | Delivers | Depends on | Status |
+|-------|----------|-----------|--------|
+| 1 | `--storage-root` and the renamed roots | — | **done** ([#133](https://github.com/ja11sop/cuppa/issues/133)) |
+| 2 | `--remove-build`, `--remove-all-builds`, `--list-builds` | 1 | next |
+| 3 | Inventory, `--list-dependencies`, `--remove-dependencies` / `--remove-all-dependencies` | 1, 2 | |
+| 4 | `--list-downloads`, `--purge-*` | 3 | |
+| 5 | `--list-develop`, `--update-develop` | nothing in this plan | **done** ([#132](https://github.com/ja11sop/cuppa/issues/132)) |
+| 6 | `--remove-artefacts` | its own design pass first | |
 
 **Phase 1 — storage naming** (§8, §3.1) — **done**
 
@@ -864,21 +867,16 @@ could land at any point, and Phase 6 needs a design pass this plan does not atte
 - Extend the protocol results with download entries, add `--list-downloads` and the `--purge-*`
   variants.
 
-**Phase 5 — develop copies** (§3.5, §3.6 — independent of Phases 1 to 4)
+**Phase 5 — develop copies** (§3.5, §3.6 — independent of Phases 1 to 4) — **done**
 
-- Touches no storage root, needs no inventory, and removes nothing, so it can land at any point,
-  including before Phase 1. It is numbered last of the buildable phases only because the storage
-  chain is the reason this plan exists.
-- Extract the develop-path resolution from `Location.__init__` into a shared helper — `~`
-  expansion and the `#` anchor to `sconstruct_dir` — so the report and the swap cannot disagree.
-- Add `Git.get_working_copy_state()` (`git status --porcelain`,
-  `git rev-list --left-right --count @{upstream}...HEAD`) and the classification of §3.5, then
-  `--list-develop` on top of the report-and-exit wiring Phase 2 established.
-- Then `--update-develop`: fetch, fast-forward the copies that are clean and strictly behind,
-  skip and report everything else. One decision per copy, no new state, and an error rather than
-  a silent no-op under `--offline`.
-- The `=fetch-only` / `=allow-rebase` / `=allow-merge` values are **not** in this phase. They
-  wait for evidence from using the two options above (§3.6).
+- Landed ahead of Phase 2 ([#132](https://github.com/ja11sop/cuppa/issues/132) / #137): touches no
+  storage root, needs no inventory, and removes nothing.
+- Develop-path resolution is shared (`develop_location`); `Git.get_working_copy_state()` feeds
+  the classification; `--list-develop` reports to stdout and exits; `--update-develop` fetches and
+  fast-forwards only clean, strictly-behind copies.
+- `--clone-develop` (§3.7) remains a proposal ([#138](https://github.com/ja11sop/cuppa/issues/138)).
+- The `=fetch-only` / `=allow-rebase` / `=allow-merge` values are still out of scope until there
+  is evidence from using the two shipped options (§3.6).
 
 **Phase 6 — artefacts outside the build root** (§4.6)
 
@@ -1029,14 +1027,14 @@ unless set individually (§3.1). This is what makes the hidden default in §8.4 
 person who wants their dependency trees somewhere visible, or on another volume, says
 `--storage-root=~/cuppa-storage` once, in `~/.cuppaconfig`, and never thinks about it again.
 
-**The default moves from project-relative to shared.** `download_root` currently defaults to
-`_cuppa` *inside the project*. Defaulting to `~/.cuppa/dependencies` matches what people
-configure in practice, and means a second checkout of the same project reuses trees instead of
-re-cloning them. The cost is coupling: one bad tree now affects every project on the machine,
-and branch-qualified trees from every project pile up in one place. That cost is precisely what
-the listing options in §3.2 are there to make visible, which is another reason they belong in
-this plan rather than a later one. A project that wants isolation still says
-`--storage-root=_cuppa` and gets both roots inside the project, or
+**The default moved from project-relative to shared (Phase 1).** Before the rename,
+`download_root` defaulted to `_cuppa` *inside the project*. Defaulting to
+`~/.cuppa/dependencies` matches what people configured in practice, and means a second checkout
+of the same project reuses trees instead of re-cloning them. The cost is coupling: one bad tree
+now affects every project on the machine, and branch-qualified trees from every project pile up
+in one place. That cost is precisely what the listing options in §3.2 are there to make visible,
+which is another reason they belong in this plan rather than a later one. A project that wants
+isolation still says `--storage-root=_cuppa` and gets both roots inside the project, or
 `--dependencies-root=_cuppa/dependencies` to keep only the trees local while still sharing
 downloaded archives.
 
@@ -1131,32 +1129,35 @@ against their will; the change is to what a new installation chooses for itself.
 
 ### 8.5 Migration
 
-Renaming storage silently would strand existing trees and force re-downloads, so:
+Renaming storage silently would strand existing trees and force re-downloads. Phase 1 shipped
+the following; what remains is optional tooling once listing and removal exist.
 
-1. Add `--storage-root`, `--dependencies-root`, and `--downloads-root` as the primary options;
-   keep `--download-root` / `--cache-root` working as documented aliases.
-2. Keep the environment keys (`download_root`, `cache_root`) as aliases of the new keys for at
-   least one minor release so third-party dependency plugins keep working.
-3. On startup, if an old folder exists and the new one does not, use the old one and log once at
-   info level explaining the new name and how to move. This matters more than a pure rename
-   would, because the default location changes too: an existing `~/_cuppa/_download` full of
-   trees must not silently become an empty `~/.cuppa/dependencies` and a machine-wide re-fetch.
+1. **Done.** `--storage-root`, `--dependencies-root`, and `--downloads-root` are the primary
+   options; `--download-root` / `--cache-root` remain documented aliases.
+2. **Done.** The environment keys `download_root` / `cache_root` alias the resolved new keys for
+   at least one minor release so third-party dependency plugins keep working.
+3. **Done.** On startup, if an old folder exists and the new one does not, use the old one and
+   log once at info level explaining the new name and how to move. This matters more than a pure
+   rename would, because the default location changed too: an existing `~/_cuppa/_download` full
+   of trees must not silently become an empty `~/.cuppa/dependencies` and a machine-wide
+   re-fetch.
 
-   The fallback has to consider **two** old dependency locations, not one. `download_root`
-   defaults to `_cuppa` *inside the project* today, so the tree a project has by default is
-   `<project>/_cuppa`, and only a person who configured `download_root` themselves has the shared
-   `~/_cuppa/_download` this section originally named. Checking the shared path alone would leave
-   every unconfigured project re-fetching into `~/.cuppa/dependencies` with a perfectly good tree
-   sitting beside its sconstruct — the exact outcome the fallback exists to prevent. Both are
-   checked, project-local first, because that is what the old default produced.
+   The fallback considers **two** old dependency locations, not one. Before Phase 1,
+   `download_root` defaulted to `_cuppa` *inside the project*, so the tree a project had by
+   default was `<project>/_cuppa`, and only a person who configured `download_root` themselves
+   had the shared `~/_cuppa/_download`. Checking the shared path alone would leave every
+   unconfigured project re-fetching into `~/.cuppa/dependencies` with a perfectly good tree
+   sitting beside its sconstruct. Both are checked, project-local first.
 
    A root kept by the fallback is kept in the form it was written in. A relative `_cuppa` stays
    relative rather than being resolved to an absolute path, because `construct.py` excludes the
    dependencies root from sconscript discovery by folder name and only a relative name matches:
    resolving it would quietly start scanning every retrieved tree for sconscripts.
-4. Document the change in `CHANGELOG.md` under Deprecated, and give the `mv` commands in the docs.
-5. Consider a `--migrate-storage` action that performs the moves, once the machinery in this plan
-   exists, since it needs the same containment and reporting code.
+4. **Done.** `CHANGELOG.md` under Deprecated / Changed, and the docs describe the new defaults
+   and how to keep a project self-contained.
+5. **Still open.** Consider a `--migrate-storage` action that performs the moves, once the
+   listing and removal machinery in this plan exists, since it needs the same containment and
+   reporting code.
 
 ---
 
@@ -1173,7 +1174,7 @@ Settled while reviewing this plan, and folded into the sections above:
 | Shared or project-relative default | Shared, with a documentation obligation rather than a footnote, and one option to make a project self-contained (§8.3) |
 | Whether cloning a missing develop copy is its own option or a mode of `--update-develop` | Its own option, `--clone-develop`, so that updating keeps its narrow promise and the mode slot stays reserved for tolerance levels (§3.7, [#138](https://github.com/ja11sop/cuppa/issues/138)) |
 
-Still open, and none of them block Phase 1:
+Still open, and none of them block Phase 2:
 
 - **How `--remove-artefacts` finds paths.** Graph discovery, project declaration, or both, and
   what it adds over SCons `--clean`. This wants measurement on a real project before an option

--- a/design/plans/removal-options.md
+++ b/design/plans/removal-options.md
@@ -188,7 +188,7 @@ Read-only, and useful on their own:
 |--------|---------|
 | `--list-dependencies` | Every dependency tree under `dependencies_root`, with size, which dependency name owns it, which branch or tag qualifier it carries, and when it was last used |
 | `--list-downloads` | Every archive under `downloads_root`, with size and the dependency it feeds |
-| `--list-builds` | Every variant subtree under `build_root`, with size |
+| `--list-builds` | Three views of `build_root`: folder summary, toolchain → variant tree, and sconscript tree, plus an explicit command for the selected builds |
 
 A fourth listing, `--list-develop`, answers a different question — the state of local working
 copies rather than what storage costs — and is covered separately in §3.5.
@@ -234,15 +234,62 @@ cuppa: storage: [info]   36M    gadget_2.26.0_rel_x86_64.tar.gz    gadget  unref
 cuppa: storage: [info]   3 entries, 216M total, 36M unreferenced
 ```
 
-`--list-builds` follows with `SIZE`, `SCONSCRIPT`, `TOOLCHAIN VARIANT`, and `STATE`, where the
-state distinguishes the variant the current options select from the others present.
+`--list-builds` is three related views of the same walk, not a flat table:
 
-In `--list-format=json` there is no header row: each entry is an object whose keys are the
-lower-cased column names (`size_bytes` alongside the human-readable `size`), so scripts read
-fields by name and people read columns.
+```
+  --------------------------------------------------------------------
+      SIZE  LAST BUILD    BUILD FOLDER
+  --------------------------------------------------------------------
+    229.5M  today         ~/coding/project/_build
+    124.5M  today         └── selected (25 of 39 entries)
+  --------------------------------------------------------------------
 
-Two lines of that output answer the question people currently answer with `du` and guesswork,
-and the last line is the one that prompts a `--remove-dependencies=widget`.
+  --------------------------------------------------------------------
+      SIZE  LAST BUILD    BY TOOLCHAIN VARIANT
+  --------------------------------------------------------------------
+     51.4M  2 years ago   ├── --- clang211
+     51.4M  2 years ago   │       └── --- dbg/x86_64/cxx2c
+     14.6M  today         └── ✓✓✓ gcc153
+     14.6M  today                 └── ✓✓✓ dbg/x86_64/cxx2c
+  --------------------------------------------------------------------
+
+  --------------------------------------------------------------------
+      SIZE  SELECTED      BY SCONSCRIPT
+  --------------------------------------------------------------------
+     41.1M                ├── test
+     20.4M      ✓         │   └── gcc153
+     14.6M      ✓         │       └── dbg/x86_64/cxx2c
+  --------------------------------------------------------------------
+
+  Selected 124.5M of 229.5M (25 of 39 entries)
+
+  Explicit command for the selected builds:
+
+  cuppa -D --dbg --toolchains=gcc153
+
+  Append --remove-build to clear those folders.
+```
+
+The folder section hangs the **selected** subset under the build root with the same branch
+notation (`all N entries selected` when every entry matches). The toolchain section is the prune
+view: age and size without per-sconscript noise, grouped as `toolchain` → `variant/arch/abi`,
+with `✓✓✓` / `-✓-` / `---` for full, partial, and unselected (ASCII `*`). Toolchain names and
+marks use the info colour; fully selected name rows also emphasise size, mark, and name.
+Partial and unselected rows are dimmed. The sconscript section is a rollup tree with the same
+marks; toolchain children are listed before nested folders under a mixed parent. Sconscript
+names (the folder above the toolchain variants) and their marks use the info colour, subdued
+when not fully selected, and emphasised when fully selected. Tree branch glyphs are always
+subdued. A closing summary emphasises the selected size (info-coloured when it is less than the
+total) and prints an explicit `cuppa -D …` command for the selected builds that exist on disk
+(formatted like `--show-conf`), so appending `--remove-build` clears those folders without
+naming absent variants.
+
+In `--list-format=json` the same structures appear as `folder`, `by_toolchain_variant`,
+`by_sconscript`, `summary`, and a flat `entries` list (`size_bytes` alongside human-readable
+`size`), so scripts read fields by name and people read columns.
+
+The summary command is the prompt to reclaim space: the tables show what is selected; the
+command is what you append `--remove-build` to.
 
 ### 3.3 Removal
 
@@ -815,7 +862,7 @@ could land at any point, and Phase 6 needs a design pass this plan does not atte
 | Phase | Delivers | Depends on | Status |
 |-------|----------|-----------|--------|
 | 1 | `--storage-root` and the renamed roots | — | **done** ([#133](https://github.com/ja11sop/cuppa/issues/133)) |
-| 2 | `--remove-build`, `--remove-all-builds`, `--list-builds` | 1 | next |
+| 2 | `--remove-build`, `--remove-all-builds`, `--list-builds` | 1 | in progress |
 | 3 | Inventory, `--list-dependencies`, `--remove-dependencies` / `--remove-all-dependencies` | 1, 2 | |
 | 4 | `--list-downloads`, `--purge-*` | 3 | |
 | 5 | `--list-develop`, `--update-develop` | nothing in this plan | **done** ([#132](https://github.com/ja11sop/cuppa/issues/132)) |
@@ -837,11 +884,12 @@ could land at any point, and Phase 6 needs a design pass this plan does not atte
 
 - `cuppa/core/build_layout.py`: shared `tool_variant_dir` composition, extracted from
   `construct.py` and used by both.
-- `cuppa/core/storage_actions.py`: option registration and scope resolution for listing and
-  removal.
-- `cuppa/utility/storage.py`: directory sizing, human-readable formatting, containment checks,
-  removal, empty-directory pruning, and the table renderer — header row, padded columns, totals,
-  and the `--list-format=json` form (§3.2), which every later listing reuses.
+- `cuppa/core/storage_actions.py`: `--list-builds` / `--remove-build` / `--remove-all-builds`,
+  the three-section report (folder, toolchain tree, sconscript tree), selection marks, and the
+  explicit-command summary.
+- `cuppa/utility/storage.py`: directory sizing and ages, human-readable formatting, containment
+  checks, removal, empty-directory pruning, tree glyphs, and `--list-format=json` helpers that
+  later listings reuse.
 - The safety model (§5) lands here too, since Phase 2 is the first phase that deletes anything:
   containment, symlink and suspicious-root refusal, report-before-acting, `-n`, exit status.
 - Wire into `cuppa/construct.py` after option processing, before `self.build(...)`; report and

--- a/design/plans/removal-options.md
+++ b/design/plans/removal-options.md
@@ -53,7 +53,7 @@ which defaults to `~/.cuppa` and can be moved with one option.
 - Managing storage owned by third-party tools (the Conan home cache, pip caches, system
   package managers). Cuppa only removes what it created.
 - Removing output a project writes outside the build root. That is a real need, but it is a
-  separate option with a separate design pass (§4.6), not a widening of `--remove-build`.
+  separate option with a separate design pass (§4.6), not a widening of `--remove-builds`.
 - Touching `--develop` working copies or anything outside the storage roots (see §5).
 
 ---
@@ -267,7 +267,7 @@ cuppa: storage: [info]   3 entries, 216M total, 36M unreferenced
 
   cuppa -D --dbg --toolchains=gcc153
 
-  Append --remove-build to clear those folders.
+  Append --remove-builds to clear those folders.
 ```
 
 The folder section hangs the **selected** subset under the build root with the same branch
@@ -281,7 +281,7 @@ names (the folder above the toolchain variants) and their marks use the info col
 when not fully selected, and emphasised when fully selected. Tree branch glyphs are always
 subdued. A closing summary emphasises the selected size (info-coloured when it is less than the
 total) and prints an explicit `cuppa -D …` command for the selected builds that exist on disk
-(formatted like `--show-conf`), so appending `--remove-build` clears those folders without
+(formatted like `--show-conf`), so appending `--remove-builds` clears those folders without
 naming absent variants.
 
 In `--list-format=json` the same structures appear as `folder`, `by_toolchain_variant`,
@@ -289,13 +289,13 @@ In `--list-format=json` the same structures appear as `folder`, `by_toolchain_va
 `size`), so scripts read fields by name and people read columns.
 
 The summary command is the prompt to reclaim space: the tables show what is selected; the
-command is what you append `--remove-build` to.
+command is what you append `--remove-builds` to.
 
 ### 3.3 Removal
 
 | Option | Removes |
 |--------|---------|
-| `--remove-build` | Every `<tool_variant_dir>` subtree under `build_root` matching the current toolchain / variant / arch / ABI selection |
+| `--remove-builds` | Every `<tool_variant_dir>` subtree under `build_root` matching the current toolchain / variant / arch / ABI selection |
 | `--remove-all-builds` | The `build_root` folder itself |
 | `--remove-dependencies=dep1,dep2` | The `dependencies_root` folders for the named dependencies, for the current selection |
 | `--remove-all-dependencies` | As above for every dependency the current build knows about |
@@ -305,7 +305,7 @@ command is what you append `--remove-build` to.
 
 The build options are confined to `build_root`. Everything a project writes elsewhere — the
 conventional `_artifacts/` tree that collated coverage indexes and reports land in, generated
-sources, copied runtime files — is `--remove-artefacts`' problem, not `--remove-build`'s. That
+sources, copied runtime files — is `--remove-artefacts`' problem, not `--remove-builds`'s. That
 separation keeps the build options describable in one sentence each and keeps the harder
 discovery question (§4.6) out of their way.
 
@@ -623,7 +623,7 @@ non-empty directory, and one asserting that no token appears in the resulting `.
 
 ## 4. Scope resolution
 
-### 4.1 `--remove-build`
+### 4.1 `--remove-builds`
 
 1. Compute `tool_variant_dir` for each active toolchain / variant / arch / ABI, using the same
    composition as `construct.py` so the two cannot drift. Factor that composition into a shared
@@ -814,7 +814,7 @@ Two candidate mechanisms, not yet chosen:
 
 The likely answer is both: declaration for the coarse trees a project knows it owns, discovery
 for the rest, with removal reporting which mechanism found each path. Until that is worked out,
-`--remove-build` and `--remove-all-builds` stay confined to `build_root`, and the documentation
+`--remove-builds` and `--remove-all-builds` stay confined to `build_root`, and the documentation
 says plainly that artefact trees are not removed.
 
 ---
@@ -862,7 +862,7 @@ could land at any point, and Phase 6 needs a design pass this plan does not atte
 | Phase | Delivers | Depends on | Status |
 |-------|----------|-----------|--------|
 | 1 | `--storage-root` and the renamed roots | — | **done** ([#133](https://github.com/ja11sop/cuppa/issues/133)) |
-| 2 | `--remove-build`, `--remove-all-builds`, `--list-builds` | 1 | in progress |
+| 2 | `--remove-builds`, `--remove-all-builds`, `--list-builds` | 1 | in progress |
 | 3 | Inventory, `--list-dependencies`, `--remove-dependencies` / `--remove-all-dependencies` | 1, 2 | |
 | 4 | `--list-downloads`, `--purge-*` | 3 | |
 | 5 | `--list-develop`, `--update-develop` | nothing in this plan | **done** ([#132](https://github.com/ja11sop/cuppa/issues/132)) |
@@ -884,7 +884,7 @@ could land at any point, and Phase 6 needs a design pass this plan does not atte
 
 - `cuppa/core/build_layout.py`: shared `tool_variant_dir` composition, extracted from
   `construct.py` and used by both.
-- `cuppa/core/storage_actions.py`: `--list-builds` / `--remove-build` / `--remove-all-builds`,
+- `cuppa/core/storage_actions.py`: `--list-builds` / `--remove-builds` / `--remove-all-builds`,
   the three-section report (folder, toolchain tree, sconscript tree), selection marks, and the
   explicit-command summary.
 - `cuppa/utility/storage.py`: directory sizing and ages, human-readable formatting, containment
@@ -983,7 +983,7 @@ could land at any point, and Phase 6 needs a design pass this plan does not atte
   the same project configured with the new options produces identical layout.
 - A project built with `--storage-root=<tmp>` writes both roots underneath it, and adding
   `--downloads-root` moves only the downloads half.
-- Build two variants, `--remove-build` one, assert the other survives.
+- Build two variants, `--remove-builds` one, assert the other survives.
 - Build, `--remove-all-builds`, assert the build root is gone.
 - `--list-builds` / `--list-dependencies` report the expected entries and totals and change
   nothing on disk.
@@ -1215,7 +1215,7 @@ Settled while reviewing this plan, and folded into the sections above:
 
 | Question | Decision |
 |----------|----------|
-| Artefacts written outside the build root | Not the build options' job. A separate `--remove-artefacts` with its own design pass (§4.6, Phase 6); `--remove-build` and `--remove-all-builds` stay inside `build_root` |
+| Artefacts written outside the build root | Not the build options' job. A separate `--remove-artefacts` with its own design pass (§4.6, Phase 6); `--remove-builds` and `--remove-all-builds` stay inside `build_root` |
 | Scope of `--remove-all-dependencies` | Remove what the current selection uses, report what is left for other selections (§4.3) |
 | An inventory under the dependencies root | Yes — per-entry JSON, updated on resolve, advisory only (§4.5) |
 | Exact or sampled sizing | Sampled, cached in the inventory, refreshed lazily, `~` marks an estimate, `--exact-sizes` measures (§4.5) |

--- a/design/plans/removal-options.md
+++ b/design/plans/removal-options.md
@@ -1,6 +1,6 @@
 # Plan: removal options for build folders and dependencies
 
-- **Status:** in progress (Phases 1, 2, and 5 done; 3, 4, and 6 remain)
+- **Status:** in progress
 - **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Storage roots, listing, and removal; GitHub [#132](https://github.com/ja11sop/cuppa/issues/132), [#133](https://github.com/ja11sop/cuppa/issues/133), [#134](https://github.com/ja11sop/cuppa/issues/134), [#135](https://github.com/ja11sop/cuppa/issues/135), [#138](https://github.com/ja11sop/cuppa/issues/138)
 - **Updated:** 2026-08-02
 

--- a/design/plans/removal-options.md
+++ b/design/plans/removal-options.md
@@ -1,21 +1,22 @@
 # Plan: removal options for build folders and dependencies
 
-- **Status:** in progress
+- **Status:** in progress (Phases 1, 2, and 5 done; 3, 4, and 6 remain)
 - **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Storage roots, listing, and removal; GitHub [#132](https://github.com/ja11sop/cuppa/issues/132), [#133](https://github.com/ja11sop/cuppa/issues/133), [#134](https://github.com/ja11sop/cuppa/issues/134), [#135](https://github.com/ja11sop/cuppa/issues/135), [#138](https://github.com/ja11sop/cuppa/issues/138)
-- **Updated:** 2026-08-01
+- **Updated:** 2026-08-02
 
-`--list-develop` and `--update-develop` (§3.5, §3.6) and the storage rename (§3.1, §8, Phase 1)
-are implemented. Cloning a missing develop copy (§3.7) came out of using the develop report and
-is a proposal, as are the listing and removal options. Follow-on from the `--clean` work in
-`cuppa/location.py` and `cuppa/package_managers/gitlab.py`, where a clean could not complete
-because a dependency was missing, and where the advice for leftover artefacts was "remove the
-folder by hand". Telling people to run `rm -rf` is unsatisfying: it is platform-specific, it is
-easy to aim at the wrong path, and cuppa already knows exactly which folders belong to which
-variant and which dependency.
+`--list-develop` and `--update-develop` (§3.5, §3.6), the storage rename (§3.1, §8, Phase 1),
+and build listing/removal (`--list-builds`, `--remove-builds`, `--remove-all-builds`, Phase 2)
+are implemented. Cloning a missing develop copy (§3.7) remains a proposal, as do dependency and
+download listing/removal (Phases 3–4) and artefact removal (Phase 6). Follow-on from the
+`--clean` work in `cuppa/location.py` and `cuppa/package_managers/gitlab.py`, where a clean
+could not complete because a dependency was missing, and where the advice for leftover
+artefacts was "remove the folder by hand". Telling people to run `rm -rf` is unsatisfying: it
+is platform-specific, it is easy to aim at the wrong path, and cuppa already knows exactly which
+folders belong to which variant and which dependency.
 
 This plan proposes a way to list what is in the storage roots, a family of explicit removal
-options (Phase 2 next), conservative ways to create develop copies that are missing (§3.7), and
-the safety model that governs deletion.
+options (Phase 2 done; Phases 3–4 next), conservative ways to create develop copies that are
+missing (§3.7), and the safety model that governs deletion.
 
 The storage rename came **first** (§6, Phase 1) so every later phase talks about one vocabulary.
 Throughout this document the new names are used: `dependencies_root` (was `download_root`) and
@@ -862,7 +863,7 @@ could land at any point, and Phase 6 needs a design pass this plan does not atte
 | Phase | Delivers | Depends on | Status |
 |-------|----------|-----------|--------|
 | 1 | `--storage-root` and the renamed roots | — | **done** ([#133](https://github.com/ja11sop/cuppa/issues/133)) |
-| 2 | `--remove-builds`, `--remove-all-builds`, `--list-builds` | 1 | in progress |
+| 2 | `--remove-builds`, `--remove-all-builds`, `--list-builds` | 1 | **done** ([#134](https://github.com/ja11sop/cuppa/issues/134) / #140) |
 | 3 | Inventory, `--list-dependencies`, `--remove-dependencies` / `--remove-all-dependencies` | 1, 2 | |
 | 4 | `--list-downloads`, `--purge-*` | 3 | |
 | 5 | `--list-develop`, `--update-develop` | nothing in this plan | **done** ([#132](https://github.com/ja11sop/cuppa/issues/132)) |
@@ -880,7 +881,7 @@ could land at any point, and Phase 6 needs a design pass this plan does not atte
 - Roots reported at info level on the first retrieval of a run.
 - Docs and `CHANGELOG.md` updated under Changed and Deprecated.
 
-**Phase 2 — build removal and `--list-builds`** (§3.3, §4.1, §4.2)
+**Phase 2 — build removal and `--list-builds`** (§3.3, §4.1, §4.2) — **done**
 
 - `cuppa/core/build_layout.py`: shared `tool_variant_dir` composition, extracted from
   `construct.py` and used by both.

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -18,6 +18,7 @@
 ** xref:integration/test-configure-conf.adoc[configure.conf]
 ** xref:integration/test-scripts-scoping.adoc[Scripts scoping]
 ** xref:integration/test-storage-roots.adoc[Storage roots]
+** xref:integration/test-list-builds.adoc[List builds]
 ** xref:integration/test-toolchains-matrix.adoc[Toolchains matrix]
 ** xref:integration/test-build.adoc[Build]
 ** xref:integration/test-build-test.adoc[BuildTest and Test]

--- a/docs/modules/ROOT/pages/build-layout.adoc
+++ b/docs/modules/ROOT/pages/build-layout.adoc
@@ -94,7 +94,7 @@ cuppa -D --dbg --modules --stdcpp=c++20 --toolchains=gcc --clean
 ----
 
 That removes objects, binaries, module BMIs (`.gcm` / `.pcm`), and the GCC
-`module-mapper.txt`. Empty directories under `_build` may remain; use `--remove-build` or
+`module-mapper.txt`. Empty directories under `_build` may remain; use `--remove-builds` or
 `--remove-all-builds` (below) when you want the directories gone too.
 
 [#listing-and-removing-builds]
@@ -106,47 +106,247 @@ individual targets, use the storage actions. They run instead of a build.
 [source,sh]
 ----
 cuppa -D --list-builds
-cuppa -D --dbg --toolchains=gcc --remove-build
-cuppa -D --dbg --toolchains=gcc --remove-build -n
+cuppa -D --dbg --toolchains=gcc --remove-builds -n
+cuppa -D --dbg --toolchains=gcc --remove-builds
 cuppa -D --remove-all-builds
 ----
 
-`--list-builds` prints three related views of the build root, then a short selection summary:
+The examples below use a small project that has already built debug and release under `test/`,
+and debug under `lib/`, with `--dbg` (and a matching toolchain) as the active selection. Your
+sizes, ages, and toolchain names will differ; the shape of the report does not. Colour is
+described in the commentary — terminals show info in blue, errors in red, and warnings in
+magenta; emphasised text is bold.
 
-* **BUILD FOLDER** — total size and newest build under the root (info-coloured), with the selected
-  subset hung underneath as `└── selected (N of M entries)` (or `all N entries selected` when
-  every entry matches). When every entry is selected, that hang line's size and label are
-  emphasised.
-* **BY TOOLCHAIN VARIANT** — size and last-build age rolled up across every sconscript, grouped as
-  `toolchain` → `variant/arch/abi`. Each row carries a three-character mark: `✓✓✓` when fully
-  selected, `-✓-` when a toolchain is only partially selected, and `---` when not selected
-  (ASCII uses `*` for the check). Toolchain names and their marks use the info colour (subdued
-  when partial or unselected). When a toolchain is fully selected, its size, mark, and name are
-  also emphasised. Partial and unselected rows are dimmed.
-* **BY SCONSCRIPT** — a directory tree with rolled-up sizes. Each tool-variant leaf is shown as
-  the toolchain name with `variant/arch/abi` underneath. Where a folder both builds and contains
-  nested sconscripts, its toolchain variants are listed before the nested folders. Rollup folders
-  show `✓✓✓` when fully selected and `-✓-` when partially selected (partial and unselected rows
-  are dimmed); leaves show a single centered `✓`. The sconscript name — the folder above the
-  toolchain variants — and its selection mark are drawn in the info colour, subdued when not
-  fully selected, and with size, mark, and name emphasised when fully selected. Tree branch
-  glyphs are always subdued.
+[#list-builds-example]
+=== `--list-builds`
+
+`--list-builds` prints three related views of the build root, then a short selection summary.
+Run it with the same variant and toolchain flags you would use for a build when you want the
+**SELECTED** marks to reflect that selection:
+
+[source,sh]
+----
+cuppa -D --dbg --toolchains=gcc --list-builds
+----
+
+Example output:
+
+[source,text]
+----
+  --------------------------------------------------------
+      SIZE  LAST BUILD    BUILD FOLDER
+  --------------------------------------------------------
+    146.5K  3 days ago    _build
+     68.4K  3 days ago    └── selected (2 of 3 entries)
+  --------------------------------------------------------
+
+  --------------------------------------------------------
+      SIZE  LAST BUILD    BY TOOLCHAIN VARIANT
+  --------------------------------------------------------
+    146.5K  3 days ago    └── -✓- gcc15
+     68.4K  3 days ago            ├── ✓✓✓ dbg/x86_64/cxx2c
+     78.1K  3 days ago            └── --- rel/x86_64/cxx2c
+  --------------------------------------------------------
+
+  --------------------------------------------------------
+      SIZE  SELECTED      BY SCONSCRIPT
+  --------------------------------------------------------
+     19.5K     ✔✔✔        ├── lib
+     19.5K     ✓✓✓        │   └── gcc15
+     19.5K      ✓         │       └── dbg/x86_64/cxx2c
+      127K     -✓-        └── test
+      127K     -✓-            └── gcc15
+     48.8K      ✓                 ├── dbg/x86_64/cxx2c
+     78.1K                        └── rel/x86_64/cxx2c
+  --------------------------------------------------------
+
+Selected 68.4K of 146.5K (2 of 3 entries)
+
+Explicit command for the selected builds:
+
+cuppa -D --dbg --toolchains=gcc15
+
+Append --remove-builds to clear those folders.
+----
+
+Reading the report:
+
+* **BUILD FOLDER** — the root total (info-coloured) with the selected subset hung underneath.
+  Here two of the three on-disk entries match `--dbg`, so the hang reads
+  `selected (2 of 3 entries)`. When every entry matches, that line becomes
+  `all N entries selected` and its size and label are emphasised.
+* **BY TOOLCHAIN VARIANT** — sizes rolled up across every sconscript as
+  `toolchain` → `variant/arch/abi`. Marks are `✓✓✓` (fully selected), `-✓-` (partial), or
+  `---` (not selected); ASCII terminals use `*` for the check. The toolchain name and mark use
+  the info colour; a fully selected toolchain also emphasises size, mark, and name (with a heavy
+  `✔` in the mark). Partial and unselected rows are dimmed.
+* **BY SCONSCRIPT** — the same selection marks on a directory tree. Toolchain folders are listed
+  before nested sconscript folders. Leaves show a single centered `✓`. The sconscript name
+  (the folder above the toolchains) uses the info colour; when fully selected, size, mark, and
+  name are emphasised (`✔✔✔` on that name row). Branch glyphs are always subdued.
 
 The closing summary emphasises the selected and total sizes (the selected size is also
 info-coloured when it is less than the total) and prints an explicit `cuppa -D …` command for
 the selected builds that exist on disk (formatted like `--show-conf`), omitting active variants
-that have no matching trees. Append `--remove-build` to clear those folders.
+that have no matching trees. Append `--remove-builds` to that command to clear those folders.
+
 `--list-format=json` emits the same structures (`folder`, `by_toolchain_variant`,
-`by_sconscript`, `summary`, plus a flat `entries` list).
+`by_sconscript`, `summary`, plus a flat `entries` list) for scripts.
 
-`--remove-build` removes only the variant suffixes the current options would write — the same
+[#remove-builds-example]
+=== `--remove-builds`
+
+`--remove-builds` removes only the variant suffixes the current options would write — the same
 `<toolchain>/<variant>/<arch>/<abi>` composition the build uses — under every sconscript path,
-then prunes empty parents. `--remove-all-builds` removes the build root itself.
+then prunes empty parents. Prefer a dry run first:
 
-Both removals report the paths first, honour SCons `-n` as a dry run, refuse to follow symlinks,
-and refuse a build root that is `/`, your home directory, or the sconstruct directory. They never
-touch trees outside the build root; collated coverage under `_artifacts/` and other project
-artefacts stay put.
+[source,sh]
+----
+cuppa -D --dbg --toolchains=gcc --remove-builds -n
+----
+
+Example dry-run output (tables match a live run; nothing is deleted):
+
+[source,text]
+----
+Would remove 2 entries (68.4K) under _build
+
+  --------------------------------------------------------
+      SIZE  LAST BUILD    BUILD FOLDER
+  --------------------------------------------------------
+    146.5K  3 days ago    _build
+     68.4K  3 days ago    └── removed (2 of 3 entries)
+  --------------------------------------------------------
+
+  --------------------------------------------------------
+      SIZE  LAST BUILD    BY TOOLCHAIN VARIANT
+  --------------------------------------------------------
+    146.5K  3 days ago    └── -✓- gcc15
+     68.4K  3 days ago            ├── ✓✓✓ dbg/x86_64/cxx2c
+     78.1K  3 days ago            └── --- rel/x86_64/cxx2c
+  --------------------------------------------------------
+
+  --------------------------------------------------------
+      SIZE  REMOVED       BY SCONSCRIPT
+  --------------------------------------------------------
+     19.5K     ✔✔✔        ├── lib
+     19.5K     ✓✓✓        │   └── gcc15
+     19.5K      ✓         │       └── dbg/x86_64/cxx2c
+      127K     -✓-        └── test
+      127K     -✓-            └── gcc15
+     48.8K      ✓                 ├── dbg/x86_64/cxx2c
+     78.1K                        └── rel/x86_64/cxx2c
+  --------------------------------------------------------
+
+Would remove 2 entries freeing up 68.4K of disk space.
+dry run (-n); nothing removed
+
+Verify the removal with the same selection by adding --list-builds:
+
+cuppa -D --dbg --toolchains=gcc15 --list-builds
+----
+
+Reading the report:
+
+* The first line announces how many entries and how much space would go (count and size
+  emphasised; the build-root path info-coloured and shortened, for example `_build` or
+  `~/project/_build`).
+* The three tables are the same shape as `--list-builds`, but the middle column is **REMOVED**
+  and the folder hang reads `removed (N of M entries)`. Successful removals use the error
+  (red) colour and checks; a fully cleared sconscript name row emphasises size, mark, and name
+  with heavy `✔` marks. Rows that were never candidates stay dim with a blank mark (here
+  `rel/…`).
+* After a live run the closing line is `Removed N entries freeing up SIZE of disk space.`
+  Dry-run uses `Would remove…` and `dry run (-n); nothing removed`.
+* The final block is a ready-made `--list-builds` command for the same selection so you can
+  confirm that nothing remains selected and that the build-folder size has dropped.
+
+If a path cannot be deleted, the tables mark it with a ballot (`✗`, or heavy `✘` on an
+emphasised name row) in the warning or error colour, and a reason tree follows (same shape as
+`--list-develop`). Already-deleted paths are warnings; other failures are errors. Mixed success
+and failure under one rollup shows `✓-✗`. Only bracketed values in the reason lines are
+coloured — for example `[Errno 13]` and `[_build/lib/…/working]`.
+
+[source,text]
+----
+Not all requested build entries could be removed: 1 error
+
+  1 error
+  │
+  └── lib/gcc15/dbg/x86_64/cxx2c
+      └── [Errno 13] Permission denied: [_build/lib/gcc15/dbg/x86_64/cxx2c/working]
+----
+
+[#remove-all-builds-example]
+=== `--remove-all-builds`
+
+`--remove-all-builds` removes the entire build root. It inventories every variant first, then
+attempts the wipe, then prints the same three **REMOVED** tables so you can review what was
+cleared — or see which rows are still present if something blocked the delete.
+
+[source,sh]
+----
+cuppa -D --remove-all-builds -n
+----
+
+Example dry-run output:
+
+[source,text]
+----
+Would remove build root _build (146.5K)
+
+  --------------------------------------------------------
+      SIZE  LAST BUILD    BUILD FOLDER
+  --------------------------------------------------------
+    146.5K  3 days ago    _build
+    146.5K  3 days ago    └── removed all 3 entries
+  --------------------------------------------------------
+
+  --------------------------------------------------------
+      SIZE  LAST BUILD    BY TOOLCHAIN VARIANT
+  --------------------------------------------------------
+    146.5K  3 days ago    └── ✔✔✔ gcc15
+     68.4K  3 days ago            ├── ✓✓✓ dbg/x86_64/cxx2c
+     78.1K  3 days ago            └── ✓✓✓ rel/x86_64/cxx2c
+  --------------------------------------------------------
+
+  --------------------------------------------------------
+      SIZE  REMOVED       BY SCONSCRIPT
+  --------------------------------------------------------
+     19.5K     ✔✔✔        ├── lib
+     19.5K     ✓✓✓        │   └── gcc15
+     19.5K      ✓         │       └── dbg/x86_64/cxx2c
+      127K     ✔✔✔        └── test
+      127K     ✓✓✓            └── gcc15
+     48.8K      ✓                 ├── dbg/x86_64/cxx2c
+     78.1K      ✓                 └── rel/x86_64/cxx2c
+  --------------------------------------------------------
+
+Would remove build root _build freeing up 146.5K of disk space.
+dry run (-n); nothing removed
+
+Verify with --list-builds:
+
+cuppa -D --list-builds
+----
+
+Reading the report:
+
+* Every on-disk variant is a removal candidate, so the hang reads `removed all N entries` and
+  toolchain / sconscript rollups show full checks when the plan (or live wipe) succeeds.
+* On failure, variants that remain on disk are marked with ballots; paths already deleted before
+  the failure show as removed. The reason tree uses the intro
+  `The build root could not be removed` and labels the obstructing path (often a file under a
+  specific variant), so you can match the tree entry to a failed row in the tables.
+* A live success ends with `Removed build root … freeing up SIZE of disk space.` Verify with
+  `--list-builds` as suggested — an empty or much smaller build root is the expected result.
+
+[#removal-safety]
+=== Safety and scope
+
+Both removals honour SCons `-n` as a dry run, refuse to follow symlinks, and refuse a build root
+that is `/`, your home directory, or the sconstruct directory. They never touch trees outside the
+build root; collated coverage under `_artifacts/` and other project artefacts stay put.
 
 Cleaning never retrieves or updates dependencies. If a location or package dependency
 is not present in the dependencies root, cuppa reports that at info level and treats it as

--- a/docs/modules/ROOT/pages/build-layout.adoc
+++ b/docs/modules/ROOT/pages/build-layout.adoc
@@ -94,8 +94,59 @@ cuppa -D --dbg --modules --stdcpp=c++20 --toolchains=gcc --clean
 ----
 
 That removes objects, binaries, module BMIs (`.gcm` / `.pcm`), and the GCC
-`module-mapper.txt`. Empty directories under `_build` may remain; delete `_build`
-for a fully cold tree.
+`module-mapper.txt`. Empty directories under `_build` may remain; use `--remove-build` or
+`--remove-all-builds` (below) when you want the directories gone too.
+
+[#listing-and-removing-builds]
+== Listing and removing builds
+
+When you want to see what is under the build root, or remove whole variant trees rather than
+individual targets, use the storage actions. They run instead of a build.
+
+[source,sh]
+----
+cuppa -D --list-builds
+cuppa -D --dbg --toolchains=gcc --remove-build
+cuppa -D --dbg --toolchains=gcc --remove-build -n
+cuppa -D --remove-all-builds
+----
+
+`--list-builds` prints three related views of the build root, then a short selection summary:
+
+* **BUILD FOLDER** — total size and newest build under the root (info-coloured), with the selected
+  subset hung underneath as `└── selected (N of M entries)` (or `all N entries selected` when
+  every entry matches). When every entry is selected, that hang line's size and label are
+  emphasised.
+* **BY TOOLCHAIN VARIANT** — size and last-build age rolled up across every sconscript, grouped as
+  `toolchain` → `variant/arch/abi`. Each row carries a three-character mark: `✓✓✓` when fully
+  selected, `-✓-` when a toolchain is only partially selected, and `---` when not selected
+  (ASCII uses `*` for the check). Toolchain names and their marks use the info colour (subdued
+  when partial or unselected). When a toolchain is fully selected, its size, mark, and name are
+  also emphasised. Partial and unselected rows are dimmed.
+* **BY SCONSCRIPT** — a directory tree with rolled-up sizes. Each tool-variant leaf is shown as
+  the toolchain name with `variant/arch/abi` underneath. Where a folder both builds and contains
+  nested sconscripts, its toolchain variants are listed before the nested folders. Rollup folders
+  show `✓✓✓` when fully selected and `-✓-` when partially selected (partial and unselected rows
+  are dimmed); leaves show a single centered `✓`. The sconscript name — the folder above the
+  toolchain variants — and its selection mark are drawn in the info colour, subdued when not
+  fully selected, and with size, mark, and name emphasised when fully selected. Tree branch
+  glyphs are always subdued.
+
+The closing summary emphasises the selected and total sizes (the selected size is also
+info-coloured when it is less than the total) and prints an explicit `cuppa -D …` command for
+the selected builds that exist on disk (formatted like `--show-conf`), omitting active variants
+that have no matching trees. Append `--remove-build` to clear those folders.
+`--list-format=json` emits the same structures (`folder`, `by_toolchain_variant`,
+`by_sconscript`, `summary`, plus a flat `entries` list).
+
+`--remove-build` removes only the variant suffixes the current options would write — the same
+`<toolchain>/<variant>/<arch>/<abi>` composition the build uses — under every sconscript path,
+then prunes empty parents. `--remove-all-builds` removes the build root itself.
+
+Both removals report the paths first, honour SCons `-n` as a dry run, refuse to follow symlinks,
+and refuse a build root that is `/`, your home directory, or the sconstruct directory. They never
+touch trees outside the build root; collated coverage under `_artifacts/` and other project
+artefacts stay put.
 
 Cleaning never retrieves or updates dependencies. If a location or package dependency
 is not present in the dependencies root, cuppa reports that at info level and treats it as

--- a/docs/modules/ROOT/pages/cli-reference.adoc
+++ b/docs/modules/ROOT/pages/cli-reference.adoc
@@ -60,6 +60,25 @@ The dependencies and downloads roots are shared between projects. Set `--storage
 both, or name one of them to move only that half. See xref:build-layout.adoc[Build layout] for
 what goes where and for how cuppa treats storage left by an earlier version.
 
+== Build listing and removal
+
+These run instead of a build: cuppa resolves the same toolchain and variant selection the build
+would use, reports or removes, and exits.
+
+|===
+| Option | Effect
+
+| `--list-builds` | List the build root as folder summary, toolchain → variant tree, and sconscript tree; print an explicit command for the selected builds
+| `--remove-build` | Remove variant subtrees matching the current `--toolchains` / `--dbg` / `--rel` / `--cov` selection
+| `--remove-all-builds` | Remove the entire build root
+| `--list-format=text\|json` | Format for `--list-*` output (default `text`)
+|===
+
+SCons `-n` / `--no-exec` turns either removal into a dry run: the same report, nothing deleted.
+Containment, symlink refusal, and refusal of home / filesystem / sconstruct-directory roots are
+described in xref:build-layout.adoc#listing-and-removing-builds[Listing and removing builds].
+Artefact trees outside the build root (for example `_artifacts/`) are not removed.
+
 == Configuration persistence
 
 See xref:configuration.adoc[Configuration] for `--show-conf`, `--save-conf`, `--update-conf`, `--clear-conf`, `--remove-settings`, global variants, and `--use-conf`.

--- a/docs/modules/ROOT/pages/cli-reference.adoc
+++ b/docs/modules/ROOT/pages/cli-reference.adoc
@@ -63,20 +63,24 @@ what goes where and for how cuppa treats storage left by an earlier version.
 == Build listing and removal
 
 These run instead of a build: cuppa resolves the same toolchain and variant selection the build
-would use, reports or removes, and exits.
+would use, reports or removes, and exits. Annotated example output for each command is in
+xref:build-layout.adoc#listing-and-removing-builds[Listing and removing builds]
+(xref:build-layout.adoc#list-builds-example[`--list-builds`],
+xref:build-layout.adoc#remove-builds-example[`--remove-builds`],
+xref:build-layout.adoc#remove-all-builds-example[`--remove-all-builds`]).
 
 |===
 | Option | Effect
 
 | `--list-builds` | List the build root as folder summary, toolchain → variant tree, and sconscript tree; print an explicit command for the selected builds
-| `--remove-build` | Remove variant subtrees matching the current `--toolchains` / `--dbg` / `--rel` / `--cov` selection
+| `--remove-builds` | Remove variant subtrees matching the current `--toolchains` / `--dbg` / `--rel` / `--cov` selection
 | `--remove-all-builds` | Remove the entire build root
 | `--list-format=text\|json` | Format for `--list-*` output (default `text`)
 |===
 
 SCons `-n` / `--no-exec` turns either removal into a dry run: the same report, nothing deleted.
 Containment, symlink refusal, and refusal of home / filesystem / sconstruct-directory roots are
-described in xref:build-layout.adoc#listing-and-removing-builds[Listing and removing builds].
+described in xref:build-layout.adoc#removal-safety[Safety and scope].
 Artefact trees outside the build root (for example `_artifacts/`) are not removed.
 
 == Configuration persistence

--- a/docs/modules/ROOT/pages/integration-tests.adoc
+++ b/docs/modules/ROOT/pages/integration-tests.adoc
@@ -43,6 +43,7 @@ cuppa.run(default_variants=['dbg'])
 * xref:integration/test-configure-conf.adoc[`configure.conf` save / show]
 * xref:integration/test-scripts-scoping.adoc[`--scripts=` scoping]
 * xref:integration/test-storage-roots.adoc[Storage root resolution]
+* xref:integration/test-list-builds.adoc[List and remove builds]
 * xref:integration/test-toolchains-matrix.adoc[gcc / clang toolchains]
 
 == Method tests

--- a/docs/modules/ROOT/pages/integration/test-list-builds.adoc
+++ b/docs/modules/ROOT/pages/integration/test-list-builds.adoc
@@ -1,0 +1,36 @@
+= `test_list_builds` — list and remove build trees
+:description: Cuppa integration test documentation for test_list_builds
+
+
+== What is tested
+
+After a debug build, `--list-builds` reports the variant trees under `_build`, `--remove-build -n`
+shows the plan without deleting, `--remove-build` removes the matching trees, and
+`--list-format=json` emits parseable objects.
+
+== Generated files
+
+The dummy project with the default `sconstruct`.
+
+== Commands
+
+[source,sh]
+----
+cuppa -D --offline --dbg
+cuppa -D --offline --dbg --list-builds
+cuppa -D --offline --dbg --remove-build -n
+cuppa -D --offline --dbg --remove-build
+cuppa -D --offline --dbg --list-builds --list-format=json
+----
+
+== Expectations
+
+The listing includes `BUILD FOLDER`, `BY TOOLCHAIN VARIANT`, and `BY SCONSCRIPT` sections, a
+selected hang under the build folder, and a closing `Explicit command for the selected builds`
+block with a `cuppa -D …` line. The dry run keeps `_build`. The real removal leaves no `working`
+directories under `_build`. JSON output parses and includes `folder`, `by_toolchain_variant`,
+`by_sconscript`, `summary`, and `size_bytes` on each entry.
+
+'''
+
+Related test module: `tests/integration/test_list_builds.py`.

--- a/docs/modules/ROOT/pages/integration/test-list-builds.adoc
+++ b/docs/modules/ROOT/pages/integration/test-list-builds.adoc
@@ -4,9 +4,11 @@
 
 == What is tested
 
-After a debug build, `--list-builds` reports the variant trees under `_build`, `--remove-builds -n`
-shows the plan without deleting, `--remove-builds` removes the matching trees, and
-`--list-format=json` emits parseable objects.
+After a debug build, `--list-builds` reports the variant trees under `_build`,
+`--remove-builds -n` shows the plan without deleting, `--remove-builds` removes the matching
+trees and a follow-up `--list-builds` shows nothing selected, `--remove-all-builds -n` / live
+clear the whole build root with the same REMOVED tables, and `--list-format=json` emits
+parseable objects.
 
 == Generated files
 
@@ -20,6 +22,10 @@ cuppa -D --offline --dbg
 cuppa -D --offline --dbg --list-builds
 cuppa -D --offline --dbg --remove-builds -n
 cuppa -D --offline --dbg --remove-builds
+cuppa -D --offline --dbg --list-builds
+cuppa -D --offline --dbg
+cuppa -D --offline --remove-all-builds -n
+cuppa -D --offline --remove-all-builds
 cuppa -D --offline --dbg --list-builds --list-format=json
 ----
 
@@ -27,10 +33,12 @@ cuppa -D --offline --dbg --list-builds --list-format=json
 
 The listing includes `BUILD FOLDER`, `BY TOOLCHAIN VARIANT`, and `BY SCONSCRIPT` sections, a
 selected hang under the build folder, and a closing `Explicit command for the selected builds`
-block with a `cuppa -D …` line. The dry run announces what would be removed, prints the three build views with a `REMOVED`
-column, and keeps `_build`. The real removal leaves no `working` directories under `_build`.
-JSON output parses and includes `folder`, `by_toolchain_variant`, `by_sconscript`, `summary`, and
-`size_bytes` on each entry.
+block with a `cuppa -D …` line. The `--remove-builds` dry run announces what would be removed,
+prints the three build views with a `REMOVED` column, and keeps `_build`. The real
+`--remove-builds` leaves no `working` directories under `_build` and a follow-up listing shows
+zero selected entries. `--remove-all-builds` dry run keeps the root; the live run removes
+`_build` entirely and both print the REMOVED tables. JSON output parses and includes `folder`,
+`by_toolchain_variant`, `by_sconscript`, `summary`, and `size_bytes` on each entry.
 
 '''
 

--- a/docs/modules/ROOT/pages/integration/test-list-builds.adoc
+++ b/docs/modules/ROOT/pages/integration/test-list-builds.adoc
@@ -4,8 +4,8 @@
 
 == What is tested
 
-After a debug build, `--list-builds` reports the variant trees under `_build`, `--remove-build -n`
-shows the plan without deleting, `--remove-build` removes the matching trees, and
+After a debug build, `--list-builds` reports the variant trees under `_build`, `--remove-builds -n`
+shows the plan without deleting, `--remove-builds` removes the matching trees, and
 `--list-format=json` emits parseable objects.
 
 == Generated files
@@ -18,8 +18,8 @@ The dummy project with the default `sconstruct`.
 ----
 cuppa -D --offline --dbg
 cuppa -D --offline --dbg --list-builds
-cuppa -D --offline --dbg --remove-build -n
-cuppa -D --offline --dbg --remove-build
+cuppa -D --offline --dbg --remove-builds -n
+cuppa -D --offline --dbg --remove-builds
 cuppa -D --offline --dbg --list-builds --list-format=json
 ----
 
@@ -27,9 +27,10 @@ cuppa -D --offline --dbg --list-builds --list-format=json
 
 The listing includes `BUILD FOLDER`, `BY TOOLCHAIN VARIANT`, and `BY SCONSCRIPT` sections, a
 selected hang under the build folder, and a closing `Explicit command for the selected builds`
-block with a `cuppa -D …` line. The dry run keeps `_build`. The real removal leaves no `working`
-directories under `_build`. JSON output parses and includes `folder`, `by_toolchain_variant`,
-`by_sconscript`, `summary`, and `size_bytes` on each entry.
+block with a `cuppa -D …` line. The dry run announces what would be removed, prints the three build views with a `REMOVED`
+column, and keeps `_build`. The real removal leaves no `working` directories under `_build`.
+JSON output parses and includes `folder`, `by_toolchain_variant`, `by_sconscript`, `summary`, and
+`size_bytes` on each entry.
 
 '''
 

--- a/scripts/github_api.py
+++ b/scripts/github_api.py
@@ -10,19 +10,22 @@ Seal or rotate a token:
 
     python -m scripts.github_api seal
 
-Use it:
+Reads on a public repository use the anonymous API by default (GET / HEAD do not unseal):
 
     python -m scripts.github_api GET /repos/ja11sop/cuppa/issues/132
+    python -m scripts.github_api GET /repos/ja11sop/cuppa/pulls/140 --auth   # sealed, if needed
 
     from scripts.github_api import GitHub
-    github = GitHub()
-    github.request( 'POST', '/repos/ja11sop/cuppa/issues/132/labels', { 'labels': [ 'bug' ] } )
-
-    # Public repository reads — no sealed token:
     GitHub.public().request( 'GET', '/repos/ja11sop/cuppa/pulls/139' )
 
-Every run reports how long the token has left, so rotation is prompted by use rather than by a
-checklist nobody reads.
+Writes always use the sealed credential:
+
+    from scripts.github_api import GitHub
+    GitHub().request( 'POST', '/repos/ja11sop/cuppa/issues/132/labels', { 'labels': [ 'bug' ] } )
+    python -m scripts.github_api PATCH /repos/ja11sop/cuppa/pulls/140 --data '{"title":"…"}'
+
+Authenticated runs report how long the token has left, so rotation is prompted by use rather
+than by a checklist nobody reads.
 """
 
 import argparse
@@ -215,11 +218,19 @@ def seal_command():
     return 0 if status == 200 else 1
 
 
+# Safe methods default to the anonymous client so a casual GET does not unseal the token.
+PUBLIC_METHODS = frozenset( { 'GET', 'HEAD' } )
+
+
 def main( argv=None ):
     parser = argparse.ArgumentParser( description=__doc__ )
     parser.add_argument( 'method', help="an HTTP method, or 'seal' to store a token" )
     parser.add_argument( 'path', nargs='?', help="an API path, for example /repos/owner/name" )
     parser.add_argument( '--data', help="a JSON request body" )
+    parser.add_argument(
+        '--auth', action='store_true',
+        help="unseal the credential (default for writes; optional for GET/HEAD)",
+    )
     arguments = parser.parse_args( argv )
 
     try:
@@ -230,8 +241,11 @@ def main( argv=None ):
             print( "Give an API path" )
             return 1
 
+        method = arguments.method.upper()
         payload = json.loads( arguments.data ) if arguments.data else None
-        status, body = GitHub().request( arguments.method.upper(), arguments.path, payload )
+        use_public = method in PUBLIC_METHODS and not arguments.auth
+        client = GitHub.public() if use_public else GitHub()
+        status, body = client.request( method, arguments.path, payload )
     except CredentialError as error:
         print( "Credential error: {}".format( error ) )
         return 1

--- a/tests/integration/test_list_builds.md
+++ b/tests/integration/test_list_builds.md
@@ -1,0 +1,9 @@
+# test_list_builds
+
+Canonical documentation for this integration test is on the Cuppa docs site:
+
+**[test_list_builds](https://ja11sop.github.io/cuppa/cuppa/integration/test-list-builds.html)**
+
+Source: [`docs/modules/ROOT/pages/integration/test-list-builds.adoc`](../../../docs/modules/ROOT/pages/integration/test-list-builds.adoc)
+
+Related test module: `test_list_builds.py`

--- a/tests/integration/test_list_builds.py
+++ b/tests/integration/test_list_builds.py
@@ -28,25 +28,29 @@ def test_list_builds_after_a_debug_build(tmp_path):
     assert "BY SCONSCRIPT" in listed.stdout
     assert "selected" in listed.stdout
     assert "cuppa -D" in listed.stdout
-    assert "--remove-build" in listed.stdout
+    assert "--remove-builds" in listed.stdout
 
 
-def test_remove_build_dry_run_keeps_the_tree(tmp_path):
+def test_remove_builds_dry_run_keeps_the_tree(tmp_path):
     project = a_project(tmp_path)
     assert_success(run_cuppa(project, "--dbg"))
 
-    dry = run_cuppa(project, "--dbg", "--remove-build", "-n")
+    dry = run_cuppa(project, "--dbg", "--remove-builds", "-n")
     assert_success(dry)
     assert "Would remove" in dry.stdout or "dry run" in dry.stdout
+    assert "BUILD FOLDER" in dry.stdout
+    assert "REMOVED" in dry.stdout or "BY SCONSCRIPT" in dry.stdout
+    assert "Verify the removal" in dry.stdout
+    assert "--list-builds" in dry.stdout
     assert (project / "_build").exists()
 
 
-def test_remove_build_removes_matching_trees(tmp_path):
+def test_remove_builds_removes_matching_trees(tmp_path):
     project = a_project(tmp_path)
     assert_success(run_cuppa(project, "--dbg"))
     assert (project / "_build").exists()
 
-    removed = run_cuppa(project, "--dbg", "--remove-build")
+    removed = run_cuppa(project, "--dbg", "--remove-builds")
     assert_success(removed)
     # The selected variant trees are gone; the build root may remain as an empty shell
     # or be fully pruned depending on what else was under it.

--- a/tests/integration/test_list_builds.py
+++ b/tests/integration/test_list_builds.py
@@ -1,0 +1,72 @@
+import json
+import re
+
+import pytest
+
+from tests.helpers.cuppa_runner import assert_success, run_cuppa
+from tests.helpers.project import copy_dummy_project, write_sconstruct
+
+
+pytestmark = pytest.mark.integration
+
+
+def a_project(tmp_path):
+    project = copy_dummy_project(tmp_path)
+    write_sconstruct(project)
+    return project
+
+
+def test_list_builds_after_a_debug_build(tmp_path):
+    project = a_project(tmp_path)
+    built = run_cuppa(project, "--dbg")
+    assert_success(built)
+
+    listed = run_cuppa(project, "--dbg", "--list-builds")
+    assert_success(listed)
+    assert "BUILD FOLDER" in listed.stdout
+    assert "BY TOOLCHAIN VARIANT" in listed.stdout
+    assert "BY SCONSCRIPT" in listed.stdout
+    assert "selected" in listed.stdout
+    assert "cuppa -D" in listed.stdout
+    assert "--remove-build" in listed.stdout
+
+
+def test_remove_build_dry_run_keeps_the_tree(tmp_path):
+    project = a_project(tmp_path)
+    assert_success(run_cuppa(project, "--dbg"))
+
+    dry = run_cuppa(project, "--dbg", "--remove-build", "-n")
+    assert_success(dry)
+    assert "Would remove" in dry.stdout or "dry run" in dry.stdout
+    assert (project / "_build").exists()
+
+
+def test_remove_build_removes_matching_trees(tmp_path):
+    project = a_project(tmp_path)
+    assert_success(run_cuppa(project, "--dbg"))
+    assert (project / "_build").exists()
+
+    removed = run_cuppa(project, "--dbg", "--remove-build")
+    assert_success(removed)
+    # The selected variant trees are gone; the build root may remain as an empty shell
+    # or be fully pruned depending on what else was under it.
+    assert "removed" in removed.stdout
+    remaining = list((project / "_build").rglob("working")) if (project / "_build").exists() else []
+    assert remaining == []
+
+
+def test_list_builds_json(tmp_path):
+    project = a_project(tmp_path)
+    assert_success(run_cuppa(project, "--dbg"))
+
+    listed = run_cuppa(project, "--dbg", "--list-builds", "--list-format=json")
+    assert_success(listed)
+    match = re.search(r"\{.*\}", listed.stdout, re.DOTALL)
+    assert match, listed.stdout
+    payload = json.loads(match.group(0))
+    assert payload["entries"]
+    assert "size_bytes" in payload["entries"][0]
+    assert "folder" in payload
+    assert "by_toolchain_variant" in payload
+    assert "by_sconscript" in payload
+    assert "summary" in payload

--- a/tests/integration/test_list_builds.py
+++ b/tests/integration/test_list_builds.py
@@ -54,9 +54,47 @@ def test_remove_builds_removes_matching_trees(tmp_path):
     assert_success(removed)
     # The selected variant trees are gone; the build root may remain as an empty shell
     # or be fully pruned depending on what else was under it.
-    assert "removed" in removed.stdout
+    assert "BUILD FOLDER" in removed.stdout
+    assert "REMOVED" in removed.stdout
+    assert "Removed" in removed.stdout and "freeing up" in removed.stdout
+    assert "Verify the removal" in removed.stdout
     remaining = list((project / "_build").rglob("working")) if (project / "_build").exists() else []
     assert remaining == []
+
+    listed = run_cuppa(project, "--dbg", "--list-builds")
+    assert_success(listed)
+    assert "selected (0 of" in listed.stdout or "Selected 0" in listed.stdout or (
+        "0 of 0" in listed.stdout
+    )
+
+
+def test_remove_all_builds_dry_run_keeps_the_root(tmp_path):
+    project = a_project(tmp_path)
+    assert_success(run_cuppa(project, "--dbg"))
+
+    dry = run_cuppa(project, "--remove-all-builds", "-n")
+    assert_success(dry)
+    assert "Would remove build root" in dry.stdout
+    assert "BUILD FOLDER" in dry.stdout
+    assert "REMOVED" in dry.stdout
+    assert "dry run" in dry.stdout
+    assert "--list-builds" in dry.stdout
+    assert (project / "_build").exists()
+    assert list((project / "_build").rglob("working"))
+
+
+def test_remove_all_builds_removes_the_build_root(tmp_path):
+    project = a_project(tmp_path)
+    assert_success(run_cuppa(project, "--dbg"))
+    assert (project / "_build").exists()
+
+    removed = run_cuppa(project, "--remove-all-builds")
+    assert_success(removed)
+    assert "BUILD FOLDER" in removed.stdout
+    assert "REMOVED" in removed.stdout
+    assert "Removed build root" in removed.stdout
+    assert "freeing up" in removed.stdout
+    assert not (project / "_build").exists()
 
 
 def test_list_builds_json(tmp_path):

--- a/tests/unit/test_build_layout.py
+++ b/tests/unit/test_build_layout.py
@@ -1,0 +1,57 @@
+import os
+
+import pytest
+
+from cuppa.core import build_layout
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_sanitise_abi_makes_plus_path_safe():
+    assert build_layout.sanitise_abi( 'c++2c' ) == 'cxx2c'
+    assert build_layout.sanitise_abi( 'c++20' ) == 'cxx20'
+
+
+def test_tool_variant_dir_joins_the_four_segments():
+    assert build_layout.tool_variant_dir( 'gcc15', 'dbg', 'x86_64', 'cxx2c' ) == os.path.join(
+        'gcc15', 'dbg', 'x86_64', 'cxx2c'
+    )
+
+
+def test_discover_build_variants_finds_nested_and_root_layouts( tmp_path ):
+    root = tmp_path / '_build'
+    nested = root / 'test' / 'orders' / 'gcc15' / 'dbg' / 'x86_64' / 'cxx2c'
+    ( nested / 'working' ).mkdir( parents=True )
+    ( nested / 'final' ).mkdir()
+    top = root / 'clang21' / 'rel' / 'x86_64' / 'cxx20'
+    ( top / 'working' ).mkdir( parents=True )
+
+    selected = [ os.path.join( 'gcc15', 'dbg', 'x86_64', 'cxx2c' ) ]
+    found = build_layout.discover_build_variants( str( root ), selected )
+
+    assert len( found ) == 2
+    by_variant = { entry.tool_variant: entry for entry in found }
+
+    nested_entry = by_variant[ os.path.join( 'gcc15', 'dbg', 'x86_64', 'cxx2c' ) ]
+    assert nested_entry.sconscript == os.path.join( 'test', 'orders' )
+    assert nested_entry.selected is True
+
+    top_entry = by_variant[ os.path.join( 'clang21', 'rel', 'x86_64', 'cxx20' ) ]
+    assert top_entry.sconscript == '.'
+    assert top_entry.selected is False
+
+
+def test_paths_ending_with_finds_every_matching_suffix( tmp_path ):
+    root = tmp_path / '_build'
+    first = root / 'a' / 'gcc' / 'dbg' / 'x86_64' / 'cxx2c'
+    second = root / 'b' / 'gcc' / 'dbg' / 'x86_64' / 'cxx2c'
+    other = root / 'a' / 'gcc' / 'rel' / 'x86_64' / 'cxx2c'
+    first.mkdir( parents=True )
+    second.mkdir( parents=True )
+    other.mkdir( parents=True )
+
+    matches = build_layout.paths_ending_with(
+        str( root ), os.path.join( 'gcc', 'dbg', 'x86_64', 'cxx2c' )
+    )
+    assert sorted( matches ) == sorted( [ str( first ), str( second ) ] )

--- a/tests/unit/test_storage_actions.py
+++ b/tests/unit/test_storage_actions.py
@@ -1,0 +1,256 @@
+import io
+import json
+import re
+
+import pytest
+
+from cuppa.core import storage_actions
+from cuppa.utility import storage
+from tests.helpers.fakes import FakeEnv
+
+
+pytestmark = pytest.mark.unit
+
+
+class FakeToolchain( object ):
+    def __init__( self, name ):
+        self._name = name
+
+    def name( self ):
+        return self._name
+
+
+class FakeConstruct( object ):
+    def __init__( self, selections ):
+        # selections: list of (toolchain_name, variant, arch, abi)
+        self.selections = selections
+
+    def create_build_envs( self, toolchain, cuppa_env ):
+        return [
+            {
+                'variant': variant,
+                'target_arch': arch,
+                'abi': abi,
+            }
+            for name, variant, arch, abi in self.selections
+            if name == toolchain.name()
+        ]
+
+
+def env_for( tmp_path, **options ):
+    build = tmp_path / '_build'
+    build.mkdir()
+    env = FakeEnv( options )
+    env['build_root'] = '_build'
+    env['abs_build_root'] = str( build )
+    env['sconstruct_dir'] = str( tmp_path )
+    env['list_format'] = options.get( 'list_format', 'text' )
+    env['active_toolchains'] = [ FakeToolchain( 'gcc15' ) ]
+    return env, build
+
+
+def plant_variant( build_root, *parts, content=b'hello' ):
+    path = build_root.joinpath( *parts )
+    working = path / 'working'
+    working.mkdir( parents=True )
+    ( working / 'obj.o' ).write_bytes( content )
+    return path
+
+
+def test_list_builds_marks_selected_variants_and_totals( tmp_path ):
+    env, build = env_for( tmp_path, list_builds=True )
+    plant_variant( build, 'test', 'gcc15', 'dbg', 'x86_64', 'cxx2c', content=b'1234' )
+    plant_variant( build, 'test', 'gcc15', 'rel', 'x86_64', 'cxx2c', content=b'12345678' )
+
+    construct = FakeConstruct( [
+        ( 'gcc15', 'dbg', 'x86_64', 'cxx2c' ),
+    ] )
+    out = io.StringIO()
+    status = storage_actions.list_builds( construct, env, out=out )
+    text = out.getvalue()
+
+    assert status == 0
+    assert 'BUILD FOLDER' in text
+    assert 'BY TOOLCHAIN VARIANT' in text
+    assert 'BY SCONSCRIPT' in text
+    assert 'SELECTED' in text
+    assert re.search( r'(──|\+--|`--)\s*selected \(1 of 2 entries\)', text )
+    assert re.search( r'(──|\+--|`--)\s*(-[✓*]-|[✓*]{3}|---)\s*gcc15\b', text )
+    assert 'dbg/x86_64/cxx2c' in text
+    assert 'rel/x86_64/cxx2c' in text
+    # Mixed toolchain selection: parent partial; selected leaf full; other leaf none.
+    assert re.search( r'(-[✓*]-)\s*gcc15\b', text )
+    assert re.search( r'([✓*]{3})\s*dbg/x86_64/cxx2c', text )
+    assert re.search( r'(---)\s*rel/x86_64/cxx2c', text )
+    # Sconscript rollups are partial; the selected leaf keeps a single check.
+    assert re.search( r'(-[✓*]-).*(──|\+--|`--)\s*test\b', text )
+    assert re.search( r'(-[✓*]-).*(──|\+--|`--)\s*gcc15\b', text )
+    assert re.search( r'[✓*].*(──|\+--|`--)\s*dbg/x86_64/cxx2c', text )
+    assert 'Selected ' in text
+    assert 'Explicit command for the selected builds:' in text
+    assert 'cuppa -D' in text
+    assert '--dbg' in text
+    assert '--toolchains=' in text
+    assert '--remove-build' in text
+
+
+def test_list_builds_summary_omits_variants_absent_from_the_build_root( tmp_path ):
+    env, build = env_for( tmp_path, list_builds=True )
+    plant_variant( build, 'test', 'gcc15', 'dbg', 'x86_64', 'cxx2c', content=b'1234' )
+    # Active selection includes rel, but no rel tree exists on disk.
+    construct = FakeConstruct( [
+        ( 'gcc15', 'dbg', 'x86_64', 'cxx2c' ),
+        ( 'gcc15', 'rel', 'x86_64', 'cxx2c' ),
+    ] )
+    out = io.StringIO()
+    storage_actions.list_builds( construct, env, out=out )
+    text = out.getvalue()
+    assert '--dbg' in text
+    assert '--rel' not in text
+    payload = io.StringIO()
+    env['list_format'] = 'json'
+    storage_actions.list_builds( construct, env, out=payload )
+    settings = json.loads( payload.getvalue() )['summary']['settings']
+    assert settings.get( 'dbg' ) is True
+    assert 'rel' not in settings
+
+
+def test_list_builds_rolls_up_selected_when_every_leaf_matches( tmp_path ):
+    env, build = env_for( tmp_path, list_builds=True )
+    plant_variant( build, 'test', 'gcc15', 'dbg', 'x86_64', 'cxx2c', content=b'1234' )
+    plant_variant( build, 'test', 'gcc15', 'rel', 'x86_64', 'cxx2c', content=b'12345678' )
+    construct = FakeConstruct( [
+        ( 'gcc15', 'dbg', 'x86_64', 'cxx2c' ),
+        ( 'gcc15', 'rel', 'x86_64', 'cxx2c' ),
+    ] )
+    out = io.StringIO()
+    storage_actions.list_builds( construct, env, out=out )
+    text = out.getvalue()
+    assert re.search( r'([✓*]{3})\s*gcc15\b', text )
+    assert re.search( r'([✓*]{3})\s*dbg/x86_64/cxx2c', text )
+    assert re.search( r'([✓*]{3})\s*rel/x86_64/cxx2c', text )
+    assert re.search( r'([✓*]{3}).*(──|\+--|`--)\s*test\b', text )
+    assert re.search( r'(──|\+--|`--)\s*all 2 entries selected', text )
+
+
+def test_list_builds_marks_sconscript_name_above_toolchains( tmp_path ):
+    env, build = env_for( tmp_path, list_builds=True )
+    plant_variant( build, 'test', 'algorithms', 'gcc15', 'dbg', 'x86_64', 'cxx2c' )
+    construct = FakeConstruct( [ ( 'gcc15', 'dbg', 'x86_64', 'cxx2c' ) ] )
+    payload_out = io.StringIO()
+    env['list_format'] = 'json'
+    storage_actions.list_builds( construct, env, out=payload_out )
+    tree = json.loads( payload_out.getvalue() )['by_sconscript']
+    assert tree[0]['name'] == 'test'
+    assert tree[0]['sconscript_name'] is False
+    assert tree[0]['children'][0]['name'] == 'algorithms'
+    assert tree[0]['children'][0]['sconscript_name'] is True
+
+
+def test_list_builds_lists_toolchains_before_sibling_folders( tmp_path ):
+    env, build = env_for( tmp_path, list_builds=True )
+    plant_variant( build, 'test', 'gcc15', 'dbg', 'x86_64', 'cxx2c', content=b'1234' )
+    plant_variant( build, 'test', 'algorithms', 'gcc15', 'dbg', 'x86_64', 'cxx2c', content=b'123456' )
+    plant_variant( build, 'test', 'clang211', 'dbg', 'x86_64', 'cxx2c', content=b'12' )
+    construct = FakeConstruct( [ ( 'gcc15', 'dbg', 'x86_64', 'cxx2c' ) ] )
+    env['list_format'] = 'json'
+    out = io.StringIO()
+    storage_actions.list_builds( construct, env, out=out )
+    children = json.loads( out.getvalue() )['by_sconscript'][0]['children']
+    names = [ child['name'] for child in children ]
+    assert names == [ 'clang211', 'gcc15', 'algorithms' ]
+    assert children[0]['toolchain'] is True
+    assert children[1]['toolchain'] is True
+    assert children[2]['sconscript_name'] is True
+
+
+def test_list_builds_json_is_scriptable( tmp_path ):
+    env, build = env_for( tmp_path, list_builds=True, list_format='json' )
+    plant_variant( build, 'gcc15', 'dbg', 'x86_64', 'cxx2c' )
+    construct = FakeConstruct( [ ( 'gcc15', 'dbg', 'x86_64', 'cxx2c' ) ] )
+    out = io.StringIO()
+    storage_actions.list_builds( construct, env, out=out )
+    payload = json.loads( out.getvalue() )
+    assert payload['entries'][0]['selected'] is True
+    assert 'size_bytes' in payload['entries'][0]
+    assert payload['total_bytes'] >= 5
+    assert payload['folder']['selected_entries'] == 1
+    assert payload['by_toolchain_variant'][0]['name'] == 'gcc15'
+    assert payload['by_toolchain_variant'][0]['selection'] == 'full'
+    assert payload['by_toolchain_variant'][0]['children'][0]['name'] == 'dbg/x86_64/cxx2c'
+    assert payload['by_sconscript'][0]['selected'] is True
+    assert payload['summary']['equivalent_command'].startswith( 'cuppa -D' )
+    assert 'dbg' in payload['summary']['settings']
+    assert payload['summary']['settings']['toolchains'] == [ 'gcc15' ]
+
+
+def test_remove_build_removes_only_the_selected_suffix( tmp_path ):
+    env, build = env_for( tmp_path, remove_build=True )
+    keep = plant_variant( build, 'lib', 'gcc15', 'rel', 'x86_64', 'cxx2c' )
+    remove = plant_variant( build, 'lib', 'gcc15', 'dbg', 'x86_64', 'cxx2c' )
+    construct = FakeConstruct( [ ( 'gcc15', 'dbg', 'x86_64', 'cxx2c' ) ] )
+
+    out = io.StringIO()
+    status = storage_actions.remove_build( construct, env, out=out )
+
+    assert status == 0
+    assert not remove.exists()
+    assert keep.exists()
+    assert 'removed' in out.getvalue()
+
+
+def test_remove_build_dry_run_removes_nothing( tmp_path, monkeypatch ):
+    env, build = env_for( tmp_path, remove_build=True )
+    path = plant_variant( build, 'gcc15', 'dbg', 'x86_64', 'cxx2c' )
+    construct = FakeConstruct( [ ( 'gcc15', 'dbg', 'x86_64', 'cxx2c' ) ] )
+    monkeypatch.setattr( storage_actions, 'dry_run', lambda cuppa_env: True )
+
+    out = io.StringIO()
+    status = storage_actions.remove_build( construct, env, out=out )
+
+    assert status == 0
+    assert path.exists()
+    assert 'Would remove' in out.getvalue()
+    assert 'dry run' in out.getvalue()
+
+
+def test_remove_build_refuses_a_symlink( tmp_path ):
+    env, build = env_for( tmp_path, remove_build=True )
+    real = tmp_path / 'elsewhere' / 'gcc15' / 'dbg' / 'x86_64' / 'cxx2c'
+    real.mkdir( parents=True )
+    link = build / 'gcc15' / 'dbg' / 'x86_64' / 'cxx2c'
+    link.parent.mkdir( parents=True )
+    link.symlink_to( real )
+    construct = FakeConstruct( [ ( 'gcc15', 'dbg', 'x86_64', 'cxx2c' ) ] )
+
+    out = io.StringIO()
+    with pytest.raises( storage.StorageError, match='symlink' ):
+        storage_actions.remove_build( construct, env, out=out )
+
+
+def test_remove_all_builds_removes_the_build_root( tmp_path ):
+    env, build = env_for( tmp_path, remove_all_builds=True )
+    plant_variant( build, 'gcc15', 'dbg', 'x86_64', 'cxx2c' )
+
+    out = io.StringIO()
+    status = storage_actions.remove_all_builds( env, out=out )
+
+    assert status == 0
+    assert not build.exists()
+
+
+def test_remove_all_builds_refuses_the_sconstruct_directory( tmp_path ):
+    env, build = env_for( tmp_path, remove_all_builds=True )
+    env['abs_build_root'] = str( tmp_path )
+    out = io.StringIO()
+    with pytest.raises( storage.StorageError, match='sconstruct' ):
+        storage_actions.remove_all_builds( env, out=out )
+
+
+def test_remove_build_reports_nothing_to_remove( tmp_path ):
+    env, build = env_for( tmp_path, remove_build=True )
+    construct = FakeConstruct( [ ( 'gcc15', 'dbg', 'x86_64', 'cxx2c' ) ] )
+    out = io.StringIO()
+    status = storage_actions.remove_build( construct, env, out=out )
+    assert status == 0
+    assert 'nothing to remove' in out.getvalue()

--- a/tests/unit/test_storage_actions.py
+++ b/tests/unit/test_storage_actions.py
@@ -1,9 +1,11 @@
 import io
 import json
+import os
 import re
 
 import pytest
 
+from cuppa.colourise import as_emphasised, as_info
 from cuppa.core import storage_actions
 from cuppa.utility import storage
 from tests.helpers.fakes import FakeEnv
@@ -75,23 +77,23 @@ def test_list_builds_marks_selected_variants_and_totals( tmp_path ):
     assert 'BY SCONSCRIPT' in text
     assert 'SELECTED' in text
     assert re.search( r'(──|\+--|`--)\s*selected \(1 of 2 entries\)', text )
-    assert re.search( r'(──|\+--|`--)\s*(-[✓*]-|[✓*]{3}|---)\s*gcc15\b', text )
+    assert re.search( r'(──|\+--|`--)\s*(-[✓✔*]-|[✓✔*]{3}|---)\s*gcc15\b', text )
     assert 'dbg/x86_64/cxx2c' in text
     assert 'rel/x86_64/cxx2c' in text
     # Mixed toolchain selection: parent partial; selected leaf full; other leaf none.
-    assert re.search( r'(-[✓*]-)\s*gcc15\b', text )
-    assert re.search( r'([✓*]{3})\s*dbg/x86_64/cxx2c', text )
+    assert re.search( r'(-[✓✔*]-)\s*gcc15\b', text )
+    assert re.search( r'([✓✔*]{3})\s*dbg/x86_64/cxx2c', text )
     assert re.search( r'(---)\s*rel/x86_64/cxx2c', text )
     # Sconscript rollups are partial; the selected leaf keeps a single check.
-    assert re.search( r'(-[✓*]-).*(──|\+--|`--)\s*test\b', text )
-    assert re.search( r'(-[✓*]-).*(──|\+--|`--)\s*gcc15\b', text )
-    assert re.search( r'[✓*].*(──|\+--|`--)\s*dbg/x86_64/cxx2c', text )
+    assert re.search( r'(-[✓✔*]-).*(──|\+--|`--)\s*test\b', text )
+    assert re.search( r'(-[✓✔*]-).*(──|\+--|`--)\s*gcc15\b', text )
+    assert re.search( r'[✓✔*].*(──|\+--|`--)\s*dbg/x86_64/cxx2c', text )
     assert 'Selected ' in text
     assert 'Explicit command for the selected builds:' in text
     assert 'cuppa -D' in text
     assert '--dbg' in text
     assert '--toolchains=' in text
-    assert '--remove-build' in text
+    assert '--remove-builds' in text
 
 
 def test_list_builds_summary_omits_variants_absent_from_the_build_root( tmp_path ):
@@ -126,10 +128,10 @@ def test_list_builds_rolls_up_selected_when_every_leaf_matches( tmp_path ):
     out = io.StringIO()
     storage_actions.list_builds( construct, env, out=out )
     text = out.getvalue()
-    assert re.search( r'([✓*]{3})\s*gcc15\b', text )
-    assert re.search( r'([✓*]{3})\s*dbg/x86_64/cxx2c', text )
-    assert re.search( r'([✓*]{3})\s*rel/x86_64/cxx2c', text )
-    assert re.search( r'([✓*]{3}).*(──|\+--|`--)\s*test\b', text )
+    assert re.search( r'([✓✔*]{3})\s*gcc15\b', text )
+    assert re.search( r'([✓✔*]{3})\s*dbg/x86_64/cxx2c', text )
+    assert re.search( r'([✓✔*]{3})\s*rel/x86_64/cxx2c', text )
+    assert re.search( r'([✓✔*]{3}).*(──|\+--|`--)\s*test\b', text )
     assert re.search( r'(──|\+--|`--)\s*all 2 entries selected', text )
 
 
@@ -184,38 +186,192 @@ def test_list_builds_json_is_scriptable( tmp_path ):
     assert payload['summary']['settings']['toolchains'] == [ 'gcc15' ]
 
 
-def test_remove_build_removes_only_the_selected_suffix( tmp_path ):
-    env, build = env_for( tmp_path, remove_build=True )
+def test_remove_builds_removes_only_the_selected_suffix( tmp_path ):
+    env, build = env_for( tmp_path, remove_builds=True )
     keep = plant_variant( build, 'lib', 'gcc15', 'rel', 'x86_64', 'cxx2c' )
     remove = plant_variant( build, 'lib', 'gcc15', 'dbg', 'x86_64', 'cxx2c' )
     construct = FakeConstruct( [ ( 'gcc15', 'dbg', 'x86_64', 'cxx2c' ) ] )
 
     out = io.StringIO()
-    status = storage_actions.remove_build( construct, env, out=out )
+    status = storage_actions.remove_builds( construct, env, out=out )
+    text = out.getvalue()
 
     assert status == 0
     assert not remove.exists()
     assert keep.exists()
-    assert 'removed' in out.getvalue()
+    assert 'Removing' in text
+    assert text.index( 'Removing' ) < text.index( 'BUILD FOLDER' )
+    assert '_build' in text.split( 'BUILD FOLDER' )[0]
+    assert 'BUILD FOLDER' in text
+    assert 'BY TOOLCHAIN VARIANT' in text
+    assert 'BY SCONSCRIPT' in text
+    assert 'REMOVED' in text
+    assert re.search( r'removed \(1 of 2 entries\)', text )
+    assert re.search( r'[✓✔*].*(──|\+--|`--)\s*dbg/x86_64/cxx2c', text )
+    assert re.search( r'(──|\+--|`--)\s*rel/x86_64/cxx2c', text )
+    assert 'Removed 1 entry freeing up' in text
+    assert 'Verify the removal' in text
+    assert '--list-builds' in text
 
 
-def test_remove_build_dry_run_removes_nothing( tmp_path, monkeypatch ):
-    env, build = env_for( tmp_path, remove_build=True )
+def test_remove_builds_dry_run_removes_nothing( tmp_path, monkeypatch ):
+    env, build = env_for( tmp_path, remove_builds=True )
     path = plant_variant( build, 'gcc15', 'dbg', 'x86_64', 'cxx2c' )
     construct = FakeConstruct( [ ( 'gcc15', 'dbg', 'x86_64', 'cxx2c' ) ] )
     monkeypatch.setattr( storage_actions, 'dry_run', lambda cuppa_env: True )
 
     out = io.StringIO()
-    status = storage_actions.remove_build( construct, env, out=out )
+    status = storage_actions.remove_builds( construct, env, out=out )
+    text = out.getvalue()
 
     assert status == 0
     assert path.exists()
-    assert 'Would remove' in out.getvalue()
-    assert 'dry run' in out.getvalue()
+    assert 'Would remove' in text
+    assert text.index( 'Would remove' ) < text.index( 'BUILD FOLDER' )
+    assert 'REMOVED' in text
+    assert 'Would remove 1 entry freeing up' in text
+    assert 'dry run' in text
+    assert 'Verify the removal' in text
+    assert '--list-builds' in text
 
 
-def test_remove_build_refuses_a_symlink( tmp_path ):
-    env, build = env_for( tmp_path, remove_build=True )
+def test_removal_announce_line_emphasises_count_size_and_short_path( tmp_path ):
+    line = storage_actions._removal_announce_line(
+        False, 13, 1024 * 210, str( tmp_path / '_build' ),
+        project_dir=str( tmp_path ),
+    )
+    assert 'Removing' in line
+    assert '13' in line
+    assert '_build' in line
+    assert str( tmp_path ) not in line
+    # Emphasised / info spans are present (ANSI or plain depending on colouriser).
+    assert as_emphasised( '13' ) in line or '13' in line
+    assert as_info( '_build' ) in line or line.endswith( '_build' ) or '_build' in line
+
+
+def test_remove_builds_reports_failures_with_ballot( tmp_path, monkeypatch ):
+    env, build = env_for( tmp_path, remove_builds=True )
+    path = plant_variant( build, 'lib', 'gcc15', 'dbg', 'x86_64', 'cxx2c' )
+    construct = FakeConstruct( [ ( 'gcc15', 'dbg', 'x86_64', 'cxx2c' ) ] )
+
+    def boom( target, dry_run=False ):
+        raise OSError( 13, "Permission denied", os.path.join( target, 'working' ) )
+
+    monkeypatch.setattr( storage, 'remove_path', boom )
+
+    out = io.StringIO()
+    status = storage_actions.remove_builds( construct, env, out=out )
+    text = out.getvalue()
+
+    assert status == 1
+    assert path.exists()
+    assert re.search( r'[✗✘x]{3}', text )
+    assert 'Permission denied' in text
+    assert 'Not all requested build entries could be removed' in text
+    assert '1 error' in text
+    assert re.search( r'(^|\n)\s*1 error\s*\n', text )
+    assert 'lib/gcc15/dbg/x86_64/cxx2c' in text
+    assert '[Errno 13]' in text or 'Errno 13' in text
+    assert '_build/' in text
+    assert 'Removed 0 entries freeing up' in text
+    assert 'Verify the removal' in text
+
+
+def test_removal_reason_highlights_only_bracketed_values():
+    reason = storage_actions._format_removal_reason(
+        OSError( 13, "Permission denied", "/tmp/project/_build/lib/working" ),
+        project_dir="/tmp/project",
+    )
+    assert reason.startswith( '[Errno 13]' )
+    assert '[_build/' in reason or '[lib/' in reason
+    coloured = storage.highlight_values( reason, lambda text: 'X' + text + 'X' )
+    assert 'Permission denied' in coloured
+    assert 'XErrno 13X' in coloured or coloured.count( 'X' ) >= 2
+
+
+def test_removal_error_lines_wrap_long_reasons():
+    long_path = '_build/' + '/'.join( [ 'seg' ] * 40 )
+    failures = [ {
+        'label': 'lib/gcc15/dbg/x86_64/cxx2c',
+        'reason': "[Errno 13] Permission denied: [{}]".format( long_path ),
+        'path': '/tmp/x',
+        'severity': 'error',
+    } ]
+    lines = storage_actions._removal_error_lines( failures, width=60 )
+    # Stem carried across wrapped reason lines.
+    reason_lines = [ line for line in lines if 'Permission denied' in line or 'seg/' in line ]
+    assert len( reason_lines ) >= 2
+
+
+def test_remove_builds_already_deleted_is_a_warning( tmp_path, monkeypatch ):
+    env, build = env_for( tmp_path, remove_builds=True )
+    path = plant_variant( build, 'lib', 'gcc15', 'dbg', 'x86_64', 'cxx2c' )
+    construct = FakeConstruct( [ ( 'gcc15', 'dbg', 'x86_64', 'cxx2c' ) ] )
+    real_lexists = os.path.lexists
+
+    def fake_lexists( target ):
+        if os.path.realpath( str( target ) ) == os.path.realpath( str( path ) ):
+            return False
+        return real_lexists( target )
+
+    monkeypatch.setattr( os.path, 'lexists', fake_lexists )
+
+    out = io.StringIO()
+    status = storage_actions.remove_builds( construct, env, out=out )
+    text = out.getvalue()
+
+    assert status == 0
+    assert '1 warning' in text
+    assert 'already deleted' in text
+    assert 'Not all requested build entries could be removed' in text
+
+
+def test_outcome_triple_marks_mixed_as_check_dash_ballot():
+    assert storage.outcome_triple( 'full', 'failed' ) in ( '✗✗✗', 'xxx' )
+    mixed = storage.outcome_triple( 'full', 'mixed' )
+    assert mixed[0] in ( '✓', '*' )
+    assert mixed[1] == '-'
+    assert mixed[2] in ( '✗', 'x' )
+
+
+def test_with_heavy_marks_upgrades_light_check_and_ballot():
+    light = storage.selected_mark() * 3
+    heavy = storage.with_heavy_marks( light )
+    if light.startswith( '*' ):
+        assert heavy == light
+    else:
+        assert heavy == storage.HEAVY_SELECTED_MARK * 3
+    mixed = storage.selected_mark() + '-' + storage.failed_mark()
+    upgraded = storage.with_heavy_marks( mixed )
+    if mixed[0] == '*':
+        assert upgraded == mixed
+    else:
+        assert upgraded == storage.HEAVY_SELECTED_MARK + '-' + storage.HEAVY_FAILED_MARK
+
+
+def test_emphasised_name_row_mark_uses_heavy_check():
+    mark = storage.selection_triple( 'full' )
+    painted = storage_actions._paint_sconscript_mark(
+        mark, is_sconscript_name=True, dim=False, accent='info'
+    )
+    if mark.startswith( '*' ):
+        assert storage.selected_mark() in painted or '*' in painted
+    else:
+        assert storage.HEAVY_SELECTED_MARK in painted
+        assert storage.SELECTED_MARK not in painted
+
+
+def test_short_path_prefers_project_relative( tmp_path ):
+    project = tmp_path
+    nested = project / '_build' / 'lib' / 'gcc15'
+    nested.mkdir( parents=True )
+    assert storage.short_path( str( nested ), project_dir=str( project ) ) == os.path.join(
+        '_build', 'lib', 'gcc15'
+    )
+
+
+def test_remove_builds_refuses_a_symlink( tmp_path ):
+    env, build = env_for( tmp_path, remove_builds=True )
     real = tmp_path / 'elsewhere' / 'gcc15' / 'dbg' / 'x86_64' / 'cxx2c'
     real.mkdir( parents=True )
     link = build / 'gcc15' / 'dbg' / 'x86_64' / 'cxx2c'
@@ -225,7 +381,7 @@ def test_remove_build_refuses_a_symlink( tmp_path ):
 
     out = io.StringIO()
     with pytest.raises( storage.StorageError, match='symlink' ):
-        storage_actions.remove_build( construct, env, out=out )
+        storage_actions.remove_builds( construct, env, out=out )
 
 
 def test_remove_all_builds_removes_the_build_root( tmp_path ):
@@ -234,9 +390,43 @@ def test_remove_all_builds_removes_the_build_root( tmp_path ):
 
     out = io.StringIO()
     status = storage_actions.remove_all_builds( env, out=out )
+    text = out.getvalue()
 
     assert status == 0
     assert not build.exists()
+    assert 'Removing' in text
+    assert 'BUILD FOLDER' in text
+    assert 'BY SCONSCRIPT' in text
+    assert 'REMOVED' in text
+    assert 'Removed build root' in text
+    assert 'freeing up' in text
+    assert '--list-builds' in text
+
+
+def test_remove_all_builds_reports_failures_with_error_tree( tmp_path, monkeypatch ):
+    env, build = env_for( tmp_path, remove_all_builds=True )
+    blocked = plant_variant( build, 'lib', 'gcc15', 'dbg', 'x86_64', 'cxx2c' )
+    plant_variant( build, 'app', 'gcc15', 'dbg', 'x86_64', 'cxx2c' )
+
+    def boom( target, dry_run=False ):
+        raise OSError( 13, "Permission denied", str( blocked / 'working' ) )
+
+    monkeypatch.setattr( storage, 'remove_path', boom )
+
+    out = io.StringIO()
+    status = storage_actions.remove_all_builds( env, out=out )
+    text = out.getvalue()
+
+    assert status == 1
+    assert build.exists()
+    assert 'BUILD FOLDER' in text
+    assert 'REMOVED' in text
+    assert 'The build root could not be removed' in text
+    assert '1 error' in text
+    assert 'Permission denied' in text
+    assert 'lib/gcc15/dbg/x86_64/cxx2c' in text or 'working' in text
+    assert 'Build root was not removed.' in text
+    assert re.search( r'[✗✘x]', text )
 
 
 def test_remove_all_builds_refuses_the_sconstruct_directory( tmp_path ):
@@ -247,10 +437,10 @@ def test_remove_all_builds_refuses_the_sconstruct_directory( tmp_path ):
         storage_actions.remove_all_builds( env, out=out )
 
 
-def test_remove_build_reports_nothing_to_remove( tmp_path ):
-    env, build = env_for( tmp_path, remove_build=True )
+def test_remove_builds_reports_nothing_to_remove( tmp_path ):
+    env, build = env_for( tmp_path, remove_builds=True )
     construct = FakeConstruct( [ ( 'gcc15', 'dbg', 'x86_64', 'cxx2c' ) ] )
     out = io.StringIO()
-    status = storage_actions.remove_build( construct, env, out=out )
+    status = storage_actions.remove_builds( construct, env, out=out )
     assert status == 0
     assert 'nothing to remove' in out.getvalue()

--- a/tests/unit/test_storage_utility.py
+++ b/tests/unit/test_storage_utility.py
@@ -1,0 +1,118 @@
+import os
+
+import pytest
+
+from cuppa.utility import storage
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_human_size_uses_binary_units():
+    assert storage.human_size( 0 ) == '0B'
+    assert storage.human_size( 512 ) == '512B'
+    assert storage.human_size( 1024 ) == '1K'
+    assert storage.human_size( int( 1.5 * 1024 * 1024 ) ) == '1.5M'
+
+
+def test_relative_age_uses_readable_buckets():
+    now = 1_700_000_000
+    assert storage.relative_age( None ) == '-'
+    assert storage.relative_age( now - 3600, now=now ) == 'today'
+    assert storage.relative_age( now - 86400, now=now ) == 'yesterday'
+    assert storage.relative_age( now - 3 * 86400, now=now ) == '3 days ago'
+    assert storage.relative_age( now - 20 * 86400, now=now ) == '2 weeks ago'
+    assert storage.relative_age( now - 90 * 86400, now=now ) == '3 months ago'
+    assert storage.relative_age( now - 800 * 86400, now=now ) == '2 years ago'
+
+
+def test_directory_size_sums_files_without_following_symlinks( tmp_path ):
+    tree = tmp_path / 'tree'
+    tree.mkdir()
+    ( tree / 'a.txt' ).write_bytes( b'12345' )
+    nested = tree / 'nested'
+    nested.mkdir()
+    ( nested / 'b.txt' ).write_bytes( b'abcdef' )
+
+    outside = tmp_path / 'outside'
+    outside.mkdir()
+    ( outside / 'c.txt' ).write_bytes( b'xxxxx' )
+    ( tree / 'link' ).symlink_to( outside )
+
+    assert storage.directory_size( str( tree ) ) == 5 + 6
+    stats = storage.directory_stats( str( tree ) )
+    assert stats.bytes == 5 + 6
+    assert stats.mtime is not None
+
+
+def test_display_path_uses_tilde_for_home( tmp_path, monkeypatch ):
+    home = tmp_path / 'home'
+    home.mkdir()
+    monkeypatch.setenv( 'HOME', str( home ) )
+    nested = home / 'project' / '_build'
+    nested.mkdir( parents=True )
+    assert storage.display_path( str( nested ) ) == '~/project/_build'
+
+
+def test_selected_mark_falls_back_to_ascii():
+    assert storage.selected_mark( encoding='utf-8' ) == '✓'
+    assert storage.selected_mark( encoding='ascii' ) == '*'
+    assert storage.selection_triple( 'full', encoding='utf-8' ) == '✓✓✓'
+    assert storage.selection_triple( 'partial', encoding='utf-8' ) == '-✓-'
+    assert storage.selection_triple( 'none', encoding='ascii' ) == '---'
+    assert storage.selection_triple( 'partial', encoding='ascii' ) == '-*-'
+
+
+def test_is_contained_requires_a_path_inside_the_root( tmp_path ):
+    root = tmp_path / 'root'
+    inside = root / 'child'
+    outside = tmp_path / 'elsewhere'
+    inside.mkdir( parents=True )
+    outside.mkdir()
+
+    assert storage.is_contained( str( inside ), str( root ) ) is True
+    assert storage.is_contained( str( root ), str( root ) ) is True
+    assert storage.is_contained( str( outside ), str( root ) ) is False
+
+
+def test_is_suspicious_root_rejects_home_and_filesystem_root( tmp_path, monkeypatch ):
+    home = tmp_path / 'home'
+    home.mkdir()
+    monkeypatch.setenv( 'HOME', str( home ) )
+    monkeypatch.setenv( 'USERPROFILE', str( home ) )
+
+    assert storage.is_suspicious_root( str( home ) ) is True
+    assert storage.is_suspicious_root( os.sep ) is True
+    assert storage.is_suspicious_root( str( tmp_path / 'build' ) ) is False
+
+
+def test_remove_path_and_prune_empty_parents( tmp_path ):
+    root = tmp_path / 'build'
+    leaf = root / 'a' / 'b' / 'c'
+    leaf.mkdir( parents=True )
+    ( leaf / 'file' ).write_text( 'x' )
+
+    assert storage.remove_path( str( leaf ) ) is True
+    storage.prune_empty_parents( str( leaf ), str( root ) )
+    assert root.exists()
+    assert not ( root / 'a' ).exists()
+
+
+def test_remove_path_dry_run_leaves_the_tree( tmp_path ):
+    path = tmp_path / 'keep'
+    path.mkdir()
+    ( path / 'file' ).write_text( 'x' )
+    assert storage.remove_path( str( path ), dry_run=True ) is True
+    assert path.exists()
+
+
+def test_render_table_pads_columns():
+    columns = ( ( 'size', 'SIZE' ), ( 'name', 'NAME' ) )
+    rows = [ { 'size': '1K', 'name': 'short' }, { 'size': '10M', 'name': 'longer_name' } ]
+    lines = storage.render_table( columns, rows )
+    assert lines[0].startswith( 'SIZE' )
+    assert 'longer_name' in lines[2]
+    # Header NAME and values share a common left edge after SIZE padding.
+    name_col = lines[0].index( 'NAME' )
+    assert lines[1][name_col:].startswith( 'short' )
+    assert lines[2][name_col:].startswith( 'longer_name' )


### PR DESCRIPTION
## Summary
- Add `--list-builds` with three views of the build root (folder, toolchain → variant tree, sconscript tree), selection marks, and an explicit `cuppa -D …` command for the selected builds present on disk.
- Add `--remove-builds` and `--remove-all-builds` with containment, symlink refusal, suspicious-root checks, report-then-act tables (REMOVED column, error tree), and SCons `-n` dry-run. Removals stay inside `build_root` and do not touch `_artifacts/`.
- Cover with unit and integration tests (including `--remove-all-builds` and post-remove `--list-builds` verification); update docs, CHANGELOG, ROADMAP, and the removal plan for Phase 2 of #134.
- Also lands a follow-on design proposal for colourised Antora sample output (`doc-output-samples`).

## Test plan
- [x] `pytest -m unit` (CI)
- [x] `pytest -m integration` including `tests/integration/test_list_builds.py` (CI)
- [x] On a real project with mixed toolchains/variants: `cuppa -D --list-builds -Q` and confirm section layout, selection marks, and the summary command omit absent variants
- [x] `cuppa -D --dbg --remove-builds -n` then without `-n`; confirm only selected trees are removed
- [x] `cuppa -D --remove-all-builds -n` refuses home / sconstruct directory if pointed there

Does not close #134 (umbrella for dependency/download halves). Completes the build half of that issue.
