### PR TITLE
Share develop judgement trees via _judgement_tree_lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Rename `_removal_error_lines` to `_judgement_tree_lines` and route `--list-develop` judgement
+  bodies through it (same stem glyphs, severity headings, wrap, and value highlighting as wipe /
+  remove). No intentional user-visible change; completes Phase C of the console report-patterns
+  work.
 - `--wipe-dependencies` emits inventory `used_by` judgement notices like force-wipe (warning on
   dry-run, past-tense note after a real wipe). Force-wipe “no inventory record” lines move into
   the judgement tree as notes (`no inventory record…` / `had no inventory record…`) instead of

--- a/cuppa/core/dependency_removal.py
+++ b/cuppa/core/dependency_removal.py
@@ -37,7 +37,7 @@ from cuppa.core.storage_actions import (
     dry_run,
     _already_gone_note_reason,
     _is_already_gone_error,
-    _removal_error_lines,
+    _judgement_tree_lines,
 )
 from cuppa.log import logger
 from cuppa.utility import storage
@@ -2843,7 +2843,9 @@ def remove_dependencies( construct, cuppa_env, out=None ):
                 verb,
                 storage.emphasised_count_phrase( tree_count, 'tree' ),
         )
-        for line in _removal_error_lines( items, intro=intro ):
+        for line in _judgement_tree_lines(
+                items, intro=intro, width=storage.WIDEST_PROSE
+        ):
             out.write( line + "\n" )
 
     out.write( "\n" )
@@ -3105,7 +3107,9 @@ def _write_wipe_notice_tree(
             "Wiping" if planning else "Wiped",
             storage.emphasised_count_phrase( tree_count, 'tree' ),
     )
-    for line in _removal_error_lines( items, intro=intro ):
+    for line in _judgement_tree_lines(
+            items, intro=intro, width=storage.WIDEST_PROSE
+    ):
         out.write( line + "\n" )
 
 

--- a/cuppa/core/storage_actions.py
+++ b/cuppa/core/storage_actions.py
@@ -982,38 +982,47 @@ def _severity_counts( failures ):
     return counts
 
 
-def _removal_error_lines(
+def _judgement_tree_lines(
         failures, width=None,
-        intro="Not all requested build entries could be removed"
+        intro="Not all requested build entries could be removed",
+        encoding=None,
+        include_intro=True,
 ):
-    """Judgement tree for removal/wipe notices, matching --list-develop shape.
+    """Judgement tree body (and optional intro) for wipe, remove, builds, and develop.
 
-    Hangs from ``intro: [N errors][N warnings][N notes]`` (zeros muted; non-zeros coloured
-    as error / warning / info). Each item needs ``severity`` (``error``, ``warning``, or
-    ``note``), ``label``, and either ``reason`` (wrapped prose) or ``blocks`` — a list of
-    ``{'kind':'prose','text':...}`` and/or ``{'kind':'list','intro':...,'items':[...]}``.
+    When ``include_intro`` is true, hangs from
+    ``intro: [N errors][N warnings][N notes]`` (zeros muted; non-zeros coloured as error /
+    warning / info). Each item needs ``severity`` (``error``, ``warning``, or ``note``),
+    ``label``, and one of: ``notes`` (sibling prose strings), ``reason`` (single prose), or
+    ``blocks`` — a list of ``{'kind':'prose','text':...}`` and/or
+    ``{'kind':'list','intro':...,'items':[...]}``.
+
+    ``width=None`` leaves prose unwrapped (``--list-develop``). Pass an explicit width
+    (typically ``storage.WIDEST_PROSE``) for wipe/remove/build notices.
     """
     if not failures:
         return []
 
-    tee, elbow, pipe, gap = storage.glyphs()
+    tee, elbow, pipe, gap = storage.glyphs( encoding )
     stub = pipe.rstrip()
     colour_for = { 'error': as_error, 'warning': as_warning, 'note': as_info }
     heading_for = { 'error': 'error', 'warning': 'warning', 'note': 'note' }
-    prose_width = width if width is not None else storage.WIDEST_PROSE
+    prose_width = width
 
     counts = _severity_counts( failures )
-    lines = [
-        "",
-        "{}: {}".format(
-                intro,
-                storage.format_severity_count_brackets(
-                        errors=counts['error'],
-                        warnings=counts['warning'],
-                        notes=counts['note'],
-                ),
-        ),
-    ]
+    lines = []
+    if include_intro:
+        lines.extend( [
+            "",
+            "{}: {}".format(
+                    intro,
+                    storage.format_severity_count_brackets(
+                            errors=counts['error'],
+                            warnings=counts['warning'],
+                            notes=counts['note'],
+                    ),
+            ),
+        ] )
 
     groups = []
     for severity in ( 'error', 'warning', 'note' ):
@@ -1022,7 +1031,10 @@ def _removal_error_lines(
             groups.append( ( severity, group ) )
 
     def append_prose( text, colour, first_branch, carried_branch ):
-        wrap_width = max( prose_width - len( first_branch ), storage.NARROWEST_PROSE )
+        if prose_width is None:
+            wrap_width = None
+        else:
+            wrap_width = max( prose_width - len( first_branch ), storage.NARROWEST_PROSE )
         branch = first_branch
         for piece in storage.wrapped( text, wrap_width ):
             lines.append(
@@ -1050,8 +1062,15 @@ def _removal_error_lines(
             note_under = under_severity + ( gap if last else pipe )
             note_first = note_under + elbow
             note_carried = note_under + gap
+            notes = failure.get( 'notes' )
             blocks = failure.get( 'blocks' )
-            if blocks:
+            if notes is not None:
+                for note_index, note in enumerate( notes ):
+                    last_note = note_index == len( notes ) - 1
+                    first = note_under + ( elbow if last_note else tee )
+                    carried = note_under + ( gap if last_note else pipe )
+                    append_prose( note or '', colour, first, carried )
+            elif blocks:
                 first_detail = True
                 for block in blocks:
                     kind = block.get( 'kind' )
@@ -1293,7 +1312,7 @@ def remove_builds( construct, cuppa_env, out=None ):
         accent=folder_accent, middle_heading='REMOVED', hang='removed', mode='outcome',
     )
 
-    for line in _removal_error_lines( failures ):
+    for line in _judgement_tree_lines( failures, width=storage.WIDEST_PROSE ):
         out.write( line + "\n" )
 
     out.write( "\n" )
@@ -1330,10 +1349,10 @@ def _emit_outcome_tables( out, folder, rows, failures=None, intro=None ):
         accent=folder_accent, middle_heading='REMOVED', hang='removed', mode='outcome',
     )
     if failures:
-        kwargs = {}
+        kwargs = { 'width': storage.WIDEST_PROSE }
         if intro:
             kwargs['intro'] = intro
-        for line in _removal_error_lines( failures, **kwargs ):
+        for line in _judgement_tree_lines( failures, **kwargs ):
             out.write( line + "\n" )
     return removed_rows, removed_bytes, has_errors
 

--- a/cuppa/develop.py
+++ b/cuppa/develop.py
@@ -23,11 +23,8 @@ are kept out of them so the rules can be tested without a repository, and so the
 never judge the same copy differently.
 """
 
-import locale
 import os
 import re
-import sys
-import textwrap
 
 from collections import namedtuple
 
@@ -39,13 +36,17 @@ from cuppa.colourise import (
     as_subdued,
     as_warning,
 )
+from cuppa.core.storage_actions import _judgement_tree_lines
 from cuppa.location import develop_location
 from cuppa.log import logger
 from cuppa.scms import scms
 from cuppa.scms.git import Git
 from cuppa.utility.storage import (
+    WIDEST_PROSE,
     emphasised_count_phrase,
     format_severity_count_brackets,
+    highlight_values,
+    wrapped,
 )
 
 
@@ -464,24 +465,8 @@ COLOUR_FOR = { OK: uncoloured, NOTE: as_info, WARNING: as_warning, ERROR: as_err
 # Severity has to survive --raw-output, so it is a column rather than a colour or a log prefix.
 STATUS_FOR = { OK: "ok", NOTE: "note", WARNING: "warn", ERROR: "error" }
 
-# The column abbreviates to keep the table narrow; a heading has the room to say it in full.
-HEADING_FOR = { OK: "ok", NOTE: "note", WARNING: "warning", ERROR: "error" }
-
 INDENT = "  "
 RULE = "-"
-
-# Prose is wrapped to the table's right edge so the report has one, but a wide table comes from a
-# long path rather than from anything worth reading across, so the text stops at a readable width.
-WIDEST_PROSE = 110
-NARROWEST_PROSE = 40
-
-# The values a note is about. Colouring these and leaving the prose plain is what lets a name be
-# found in a page of text; colouring both leaves nothing to find.
-VALUES = re.compile( r'\[([^\[\]]+)\]' )
-
-# tee, elbow, and the two continuations that sit under them, each the same width.
-GLYPHS = ( "\u251c\u2500\u2500 ", "\u2514\u2500\u2500 ", "\u2502   ", "    " )
-ASCII_GLYPHS = ( "+-- ", "`-- ", "|   ", "    " )
 
 
 Entry = namedtuple( 'Entry', [ 'copy', 'severity', 'notes' ] )
@@ -489,10 +474,6 @@ Entry = namedtuple( 'Entry', [ 'copy', 'severity', 'notes' ] )
 
 def write( text="" ):
     print( text )
-
-
-def highlight_values( text, colour ):
-    return VALUES.sub( lambda match: "[" + colour( match.group(1) ) + "]", text )
 
 
 def action_line( text, colour=as_info ):
@@ -558,27 +539,6 @@ def render_table( entries ):
     return lines
 
 
-def glyphs( encoding=None ):
-    """Box drawing where the console can encode it, ASCII where it cannot."""
-    encoding = ( encoding
-                 or getattr( sys.stdout, 'encoding', None )
-                 or locale.getpreferredencoding()
-                 or 'ascii' )
-    try:
-        "".join( GLYPHS ).encode( encoding )
-    except ( UnicodeError, LookupError ):
-        return ASCII_GLYPHS
-    return GLYPHS
-
-
-def wrapped( text, width ):
-    """The text as lines that fit, keeping bracketed values whole so they can still be coloured."""
-    if not width:
-        return [ text ]
-    return textwrap.wrap( text, max( width, NARROWEST_PROSE ),
-                          break_long_words=False, break_on_hyphens=False ) or [ text ]
-
-
 def render_judgements( entries, width=None, encoding=None ):
     """Every judgement in one tree that hangs from the summary line: severity, then dependency,
     then reason, worst first.
@@ -587,43 +547,24 @@ def render_judgements( entries, width=None, encoding=None ):
     at the top, and what is only worth knowing is at the bottom, each dependency named once.
 
     A reason long enough to run past `width` is wrapped and the stem is carried down through the
-    wrapped lines, so the tree stays a tree and the report keeps one right edge.
+    wrapped lines, so the tree stays a tree and the report keeps one right edge. Body rendering
+    is shared with wipe/remove via ``_judgement_tree_lines`` (intro stays in ``summary``).
     """
-    tee, elbow, pipe, gap = glyphs( encoding )
-    stub = pipe.rstrip()
-    lines = []
-
-    groups = [ ( severity, [ entry for entry in entries
-                             if entry.severity == severity and entry.notes ] )
-               for severity in ( ERROR, WARNING, NOTE ) ]
-    groups = [ group for group in groups if group[1] ]
-
-    for index, ( severity, group ) in enumerate( groups ):
-        last_group = index == len( groups ) - 1
-        colour = COLOUR_FOR[severity]
-        # A gap on the stem above each name, so a dependency and its reasons read as one block
-        # rather than as a wall of branches.
-        lines.append( as_subdued( stub ) )
-        lines.append( as_subdued( last_group and elbow or tee )
-                      + colour( plural( len( group ), HEADING_FOR[severity] ) ) )
-
-        under_severity = last_group and gap or pipe
-        for position, entry in enumerate( group ):
-            last_entry = position == len( group ) - 1
-            lines.append( as_subdued( under_severity + stub ) )
-            lines.append( as_subdued( under_severity + ( last_entry and elbow or tee ) )
-                          + colour( entry.copy.name ) )
-
-            under_entry = under_severity + ( last_entry and gap or pipe )
-            for note_index, note in enumerate( entry.notes ):
-                last_note = note_index == len( entry.notes ) - 1
-                branch = under_entry + ( last_note and elbow or tee )
-                carried = under_entry + ( last_note and gap or pipe )
-                for piece in wrapped( note, width and width - len( branch ) ):
-                    lines.append( as_subdued( branch ) + highlight_values( piece, colour ) )
-                    branch = carried
-
-    return lines
+    items = [
+            {
+                'severity': entry.severity,
+                'label': entry.copy.name,
+                'notes': list( entry.notes ),
+            }
+            for entry in entries
+            if entry.severity in ( ERROR, WARNING, NOTE ) and entry.notes
+    ]
+    return _judgement_tree_lines(
+            items,
+            width=width,
+            encoding=encoding,
+            include_intro=False,
+    )
 
 
 def summary( entries, without_develop ):

--- a/design/archive/console-report-patterns.md
+++ b/design/archive/console-report-patterns.md
@@ -43,7 +43,7 @@ topic pages (`build-layout.adoc`, `dependencies-managing.adoc`) as well.
 |--------|--------|---------|
 | `format_severity_count_brackets` | `cuppa.utility.storage` | Intro suffix |
 | `emphasised_count_phrase` | `cuppa.utility.storage` | `N trees` / `N develop locations` |
-| `_removal_error_lines` | `cuppa.core.storage_actions` | Judgement tree body (builds, deps, wipe) |
+| `_judgement_tree_lines` | `cuppa.core.storage_actions` | Judgement tree body (builds, deps, wipe, develop) |
 | `_write_wipe_notice_tree` | `cuppa.core.dependency_removal` | Wipe failures, `used_by`, inventory-missing notes |
 | `_collect_used_by_wipe_notices` | `cuppa.core.dependency_removal` | Shared wipe / force-wipe `used_by` collection |
 | `_is_already_gone_error` / `_already_gone_note_reason` | `cuppa.core.storage_actions` | Benign miss classification |
@@ -71,11 +71,11 @@ If the same fact appears on dry-run and on live run, write **two wordings** (or 
 |-------|------|---------|
 | A | Keep this file updated as new report notices ship | Agents have one place for severity timing |
 | B | Extract a short “Report patterns” subsection into Antora Contributing (link here for depth) | Human contributors see the rules without reading the whole removal plan |
-| C | Optional: fold develop `summary()` further toward shared helpers only (already uses brackets) | Less drift |
+| C | Fold develop `render_judgements()` through `_judgement_tree_lines` (summary already uses brackets) | Less drift |
 | D | Promote force-wipe subdued `no inventory record` lines into judgement notes with past tense after wipe | Consistency |
 | E | Regular `--wipe-dependencies` emitting `used_by` notices like force-wipe | Product parity |
 
-Phase C remains optional polish; B / D / E shipped with [#161](https://github.com/ja11sop/cuppa/issues/161).
+Phases B / D / E shipped with [#161](https://github.com/ja11sop/cuppa/issues/161); Phase C shares the tree body renderer with `--list-develop`.
 
 ---
 
@@ -86,12 +86,13 @@ Phase C remains optional polish; B / D / E shipped with [#161](https://github.co
 | Shared severity brackets + emphasised counts | Done (1.5.0.dev) |
 | Force-wipe `used_by` warn→note | Done |
 | Already-gone → note (builds + deps + force-wipe) | Done |
-| `remove_dependencies` failures → `_removal_error_lines` | Done |
+| `remove_dependencies` failures → `_judgement_tree_lines` | Done |
 | `--list-scope=compact` / `referenced` sibling fix / unqualified stem wipe UX | Done |
 | Design plan + issue [#161](https://github.com/ja11sop/cuppa/issues/161) | Done |
 | Antora Contributing “Report patterns” page | Done (Phase B) |
 | Force-wipe inventory-missing → judgement notes | Done (Phase D) |
 | `--wipe-dependencies` `used_by` parity with force-wipe | Done (Phase E) |
+| `--list-develop` tree body → `_judgement_tree_lines` | Done (Phase C) |
 
 ---
 

--- a/docs/modules/ROOT/pages/contributing-report-patterns.adoc
+++ b/docs/modules/ROOT/pages/contributing-report-patterns.adoc
@@ -93,9 +93,9 @@ Prefer these instead of inventing a second flat warning list:
 | `cuppa.utility.storage`
 | `N trees` / `N develop locations`
 
-| `_removal_error_lines`
+| `_judgement_tree_lines`
 | `cuppa.core.storage_actions`
-| Judgement tree body (builds, deps, wipe)
+| Judgement tree body (builds, deps, wipe, `--list-develop`)
 
 | `_write_wipe_notice_tree`
 | `cuppa.core.dependency_removal`

--- a/tests/unit/test_dependency_removal.py
+++ b/tests/unit/test_dependency_removal.py
@@ -447,7 +447,7 @@ def test_safe_unqualified_duplicate_wipe_requires_canonical_sibling( tmp_path ):
 def test_write_used_by_wipe_warning_colours_paths_and_explains_safe( tmp_path ):
     import io
     from cuppa.colourise import as_emphasised
-    from cuppa.core.storage_actions import _removal_error_lines
+    from cuppa.core.storage_actions import _judgement_tree_lines
 
     stem = tmp_path / 'git_https_example.com__org_widget.git'
     canonical = tmp_path / 'git_https_example.com__org_widget.git@master'
@@ -523,7 +523,7 @@ def test_write_used_by_wipe_warning_colours_paths_and_explains_safe( tmp_path ):
     assert 'by 2 projects:' in text
     assert storage.display_path( '/other/project' ) in text
     assert storage.display_path( '/second/project' ) in text
-    assert _removal_error_lines( items, intro='probe' )
+    assert _judgement_tree_lines( items, intro='probe', width=storage.WIDEST_PROSE )
 
     done_out = io.StringIO()
     dependency_removal._write_wipe_notice_tree(
@@ -724,7 +724,7 @@ def test_dependency_already_gone_is_a_note_in_judgement_tree():
     """Benign misses after a real remove use notes + shared judgement intro, not flat warnings."""
     from cuppa.core.storage_actions import (
         _already_gone_note_reason,
-        _removal_error_lines,
+        _judgement_tree_lines,
     )
 
     items = [
@@ -743,7 +743,7 @@ def test_dependency_already_gone_is_a_note_in_judgement_tree():
     ]
     # Simulate remove_dependencies failure reporting.
     intro = "Removed " + storage.emphasised_count_phrase( 2, 'tree' )
-    lines = _removal_error_lines( items, intro=intro )
+    lines = _judgement_tree_lines( items, intro=intro, width=storage.WIDEST_PROSE )
     text = "\n".join( lines )
     assert 'Removed ' in text
     assert '[1 error]' in text

--- a/tests/unit/test_storage_actions.py
+++ b/tests/unit/test_storage_actions.py
@@ -291,7 +291,7 @@ def test_removal_reason_highlights_only_bracketed_values():
     assert 'XErrno 13X' in coloured or coloured.count( 'X' ) >= 2
 
 
-def test_removal_error_lines_wrap_long_reasons():
+def test_judgement_tree_lines_wrap_long_reasons():
     long_path = '_build/' + '/'.join( [ 'seg' ] * 40 )
     failures = [ {
         'label': 'lib/gcc15/dbg/x86_64/cxx2c',
@@ -299,13 +299,13 @@ def test_removal_error_lines_wrap_long_reasons():
         'path': '/tmp/x',
         'severity': 'error',
     } ]
-    lines = storage_actions._removal_error_lines( failures, width=60 )
+    lines = storage_actions._judgement_tree_lines( failures, width=60 )
     # Stem carried across wrapped reason lines.
     reason_lines = [ line for line in lines if 'Permission denied' in line or 'seg/' in line ]
     assert len( reason_lines ) >= 2
 
 
-def test_removal_error_lines_summary_brackets_and_notes():
+def test_judgement_tree_lines_summary_brackets_and_notes():
     from cuppa.colourise import as_error, as_info, as_subdued, as_warning
 
     failures = [
@@ -326,16 +326,17 @@ def test_removal_error_lines_summary_brackets_and_notes():
             },
     ]
     intro = 'Wiping ' + storage.emphasised_count_phrase( 3, 'tree' )
-    lines = storage_actions._removal_error_lines( failures, intro=intro )
+    lines = storage_actions._judgement_tree_lines( failures, intro=intro, width=110 )
     assert lines[1].startswith( 'Wiping ' )
     assert storage.emphasised_count_phrase( 3, 'tree' ) in lines[1]
     assert as_error( '[1 error]' ) in lines[1]
     assert as_warning( '[1 warning]' ) in lines[1]
     assert as_info( '[1 note]' ) in lines[1]
 
-    zeroed = storage_actions._removal_error_lines(
+    zeroed = storage_actions._judgement_tree_lines(
             [ failures[1] ],
             intro='Wiping ' + storage.emphasised_count_phrase( 1, 'tree' ),
+            width=110,
     )
     assert as_subdued( '[0 errors]' ) in zeroed[1]
     assert as_warning( '[1 warning]' ) in zeroed[1]


### PR DESCRIPTION
## Summary
- Rename `_removal_error_lines` → `_judgement_tree_lines` and extend it for body-only mode, encoding, multi-note siblings, and `width=None` (no wrap).
- Route `--list-develop` `render_judgements()` through that helper; drop develop’s duplicate glyph/wrap/highlight helpers in favour of `cuppa.utility.storage`.
- Update Antora Report patterns, archive plan Phase C, and CHANGELOG (no intentional UX change).

## Test plan
- [x] `flake8 cuppa` / `pylint -E cuppa`
- [x] `pytest -m unit`
- [x] `pytest -m integration`
- [x] CI green on the matrix
