### PR TITLE
Add show-pr helper for public pull request metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,10 +343,14 @@ checks complete, then report the outcome and be ready to decide next steps — m
 green, diagnosis and a fix if red.
 
 ```sh
-python -m scripts.github_helpers watch-pr          # current branch's open PR
+python -m scripts.github_helpers watch-pr          # pins current branch's open PR at start
 python -m scripts.github_helpers watch-pr --pr 139
 python -m scripts.github_helpers pr-status --pr 139   # one snapshot; no wait
 ```
+
+`watch-pr` without `--pr` resolves the open PR once, then keeps that number for every poll — so
+checking out another branch while it runs will not silently switch targets. Prefer `--pr` after
+`create-pr` when the number is already known.
 
 These status helpers read the public API anonymously by default — they do **not** unseal the token
 unless you pass `--auth` or the public API rate-limits (then they fall back to the sealed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ anonymous reads use the public GitHub HTTP API, `curl`, or `urllib` — still no
 
 Cuppa is a public repository, so anything that only reads *metadata* — issue lists, issue bodies,
 pull request state, check-run conclusions — needs no credential at all. Use the public API
-anonymously (`GitHub.public()` / `pr-status` / `watch-pr`) and do not ask for a token.
+anonymously (`GitHub.public()` / `show-pr` / `pr-status` / `watch-pr`) and do not ask for a token.
 
 **Exception — Actions log archives:** even on a public repository, GitHub's
 `/actions/runs/{id}/logs` and `/actions/jobs/{id}/logs` endpoints return **403** to anonymous
@@ -214,20 +214,27 @@ work on a machine with no TPM.
 ### Using it
 
 **Reads** go through the public API — no sealed token. Prefer `scripts.github_helpers`
-(`pr-status` / `watch-pr`) for pull-request CI, or an anonymous client for ad-hoc GETs:
+(`show-pr` / `pr-status` / `watch-pr`) for pull-request metadata and CI, or an anonymous client
+for other ad-hoc GETs:
 
 ```sh
-python -m scripts.github_api GET /repos/ja11sop/cuppa/issues/132
+python -m scripts.github_helpers show-pr --pr 165          # title, labels, body (alias: fetch-pr)
+python -m scripts.github_helpers show-pr --pr 165 --json
 python -m scripts.github_helpers pr-status --pr 140
+python -m scripts.github_api GET /repos/ja11sop/cuppa/issues/132
 ```
 
 ```python
+from scripts.github_helpers import show_pull_request
+show_pull_request( number=165 )
+
 from scripts.github_api import GitHub
 GitHub.public().request( 'GET', '/repos/ja11sop/cuppa/pulls/140' )
 ```
 
 The CLI uses the anonymous client for `GET` / `HEAD` by default. Pass `--auth` only when a read
-truly needs the sealed credential (private resources). Do not unseal just to poll CI.
+truly needs the sealed credential (private resources). Do not unseal just to poll CI or to read
+a public pull request's title and body.
 
 **Writes** use the sealed credential. `scripts.github_api` reads the token into the calling
 process only — never into the environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `scripts.github_helpers show-pr` (alias `fetch-pr`) prints an open pull request's title, labels,
+  head/base, and body via the public GitHub API (`--json` for a stable summary). Prefer this over
+  hand-rolled `GET /pulls/{n}` when agents need PR metadata.
 - `--toolchain-archive=` and `--clang-root=` / `--gcc-root=` fetch or point at Clang and GCC
   installs, cache them under the downloads / dependencies roots as toolchain dependencies, and
   register non-colliding names (`clang{major}_{tag}`, `gcc{major}_{stem}`, or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `scripts.github_helpers show-pr` (alias `fetch-pr`) prints an open pull request's title, labels,
   head/base, and body via the public GitHub API (`--json` for a stable summary). Prefer this over
-  hand-rolled `GET /pulls/{n}` when agents need PR metadata.
+  hand-rolled `GET /pulls/{n}` when agents need PR metadata. `watch-pr` pins the resolved PR
+  number at start so a later checkout of another branch cannot retarget an in-flight watch.
 - `--toolchain-archive=` and `--clang-root=` / `--gcc-root=` fetch or point at Clang and GCC
   installs, cache them under the downloads / dependencies roots as toolchain dependencies, and
   register non-colliding names (`clang{major}_{tag}`, `gcc{major}_{stem}`, or

--- a/design/process/agent-workflow-journey.md
+++ b/design/process/agent-workflow-journey.md
@@ -2,7 +2,7 @@
 
 - **Status:** living
 - **Related:** [`AGENTS.md`](../../AGENTS.md) (agent ops); Antora Contributing (human versioning/release)
-- **Updated:** 2026-08-07
+- **Updated:** 2026-08-09
 - **Maintainer:** primary author of this journey; others append only (see `AGENTS.md`)
 - **Privacy:** obey the private-projects rule; never copy names from `INTERNAL_PROJECTS.local.md`
 - **Source:** Cursor sessions spanning roughly mid-July → 2026-08-07 on cuppa
@@ -88,6 +88,7 @@ yourself repeating a correction in chat*.
 Whenever an agent mistook `GitHub.request`’s `(status, body)` tuple, or reinvented PR polling,
 we added a helper:
 
+- `show-pr` / `fetch-pr` (title, labels, body via the public API — not `gh`, not sealed token)
 - `pr-status` / `watch-pr` (sparse poll schedule to spare the API)
 - `fetch-ci-logs` (Actions logs need auth even on public repos; pass `--pr` or `--run-id`)
 - `create-pr` / `update-pr` (title/body/labels without hand-rolled PATCH)
@@ -292,6 +293,7 @@ These are recommendations for the next project, not self-flagellation.
 | `--list-format=json` for agent consumption | Text is for eyes; JSON is for scripts |
 | Housekeeping ritual before merge | Prevents “green CI, stale ROADMAP” |
 | Sealed token + public reads by default | Safer defaults for agents |
+| `show-pr` / `fetch-pr` for PR metadata | Prefer helpers over ad-hoc `GET /pulls/{n}` (and never `gh`) |
 | `*.local.md` for secrets of context | Public repo stays clean |
 | `check_release` before build/publish | Catches `.dev` / unreleased before PyPI |
 | prepare / publish `workflow_dispatch` | Removes hand-tag ordering mistakes |

--- a/scripts/github_helpers.py
+++ b/scripts/github_helpers.py
@@ -532,11 +532,35 @@ def watch_pull_request(
     Sleeps *before* each poll. Default schedule: 2 minutes, then 8 minutes, then every
     2 minutes. Pass ``interval`` for a fixed delay instead. On public rate limits, falls back
     to the sealed credential and keeps that client for later polls.
+
+    When ``number`` is omitted, the open PR for ``head`` (or the current branch) is resolved
+    **once** up front. Later polls keep that number so a concurrent checkout of another branch
+    cannot retarget the watch.
     """
     out = out or sys.stdout
+    owner, repo = repository( owner, repo )
+    client = public_github( github )
+    if number is None:
+        try:
+            pull = resolve_pull_request(
+                number=None, head=head, owner=owner, repo=repo, github=client
+            )
+        except RateLimited:
+            if not is_anonymous_client( client ):
+                raise
+            out.write(
+                "public API rate-limited; retrying with sealed credential "
+                "(same poll schedule)\n"
+            )
+            out.flush()
+            client = GitHub()
+            pull = resolve_pull_request(
+                number=None, head=head, owner=owner, repo=repo, github=client
+            )
+        number = pull['number']
+
     deadline = clock() + timeout
     last = None
-    client = github
     delays = iter_poll_delays( schedule=schedule, interval=interval )
 
     while True:

--- a/scripts/github_helpers.py
+++ b/scripts/github_helpers.py
@@ -9,11 +9,16 @@ Owner and repository always come from the local ``origin`` remote (or explicit `
 ``--repo``). There is no baked-in default, so a checkout of a fork cannot silently talk to the
 wrong repository.
 
-Reads on a public repository use the anonymous API. ``pr-status`` and ``watch-pr`` do not unseal
-the token. Writes (``create-pr``, ``update-pr``, labelling) and CI log downloads (``fetch-ci-logs``) still go
-through the sealed credential.
+Reads on a public repository use the anonymous API. ``show-pr`` (alias ``fetch-pr``),
+``pr-status``, and ``watch-pr`` do not unseal the token. Writes (``create-pr``, ``update-pr``,
+labelling) and CI log downloads (``fetch-ci-logs``) still go through the sealed credential.
 
 Pushing a branch is still ``git push -u origin HEAD``.
+
+Show pull request metadata (title, labels, body) without unsealing:
+
+    python -m scripts.github_helpers show-pr --pr 165
+    python -m scripts.github_helpers fetch-pr --pr 165 --json
 
 Create a pull request from the current branch:
 
@@ -43,8 +48,11 @@ public even on a public repository):
 
     Or from Python:
 
-    from scripts.github_helpers import create_pull_request, update_pull_request, watch_pull_request
+    from scripts.github_helpers import (
+        create_pull_request, show_pull_request, update_pull_request, watch_pull_request,
+    )
     create_pull_request( title='…', body='…', labels=['impact:minor'] )
+    show_pull_request( number=165 )
     update_pull_request( number=154, title='…', body='…' )
     watch_pull_request( number=139 )
 """
@@ -341,6 +349,92 @@ def resolve_pull_request( number=None, head=None, owner=None, repo=None, github=
             "no open pull request for branch [{}]; pass --pr".format( head or current_branch() )
         )
     return pull
+
+
+def summarize_pull_request( pull ):
+    """Stable fields agents need from a GitHub pull-request payload."""
+    labels = [
+        label.get( 'name' )
+        for label in ( pull.get( 'labels' ) or [] )
+        if label.get( 'name' )
+    ]
+    head = pull.get( 'head' ) or {}
+    base = pull.get( 'base' ) or {}
+    return {
+        'number': pull.get( 'number' ),
+        'url': pull.get( 'html_url' ) or '',
+        'title': pull.get( 'title' ) or '',
+        'state': pull.get( 'state' ) or '',
+        'draft': bool( pull.get( 'draft' ) ),
+        'mergeable_state': pull.get( 'mergeable_state' ) or '',
+        'labels': labels,
+        'head': {
+            'ref': head.get( 'ref' ) or '',
+            'sha': head.get( 'sha' ) or '',
+        },
+        'base': {
+            'ref': base.get( 'ref' ) or '',
+        },
+        'body': pull.get( 'body' ) or '',
+    }
+
+
+def format_pull_request( summary ):
+    """Human-readable ``show-pr`` output from :func:`summarize_pull_request`."""
+    head = summary.get( 'head' ) or {}
+    base = summary.get( 'base' ) or {}
+    sha = head.get( 'sha' ) or ''
+    short_sha = sha[:8] if sha else '-'
+    labels = summary.get( 'labels' ) or []
+    label_text = ', '.join( labels ) if labels else '-'
+    lines = [
+        "PR #{} {}".format( summary.get( 'number' ), summary.get( 'url' ) or '' ).rstrip(),
+        "title: {}".format( summary.get( 'title' ) or '' ),
+        "state={}  draft={}  mergeable_state={}".format(
+            summary.get( 'state' ) or '-',
+            'true' if summary.get( 'draft' ) else 'false',
+            summary.get( 'mergeable_state' ) or '-',
+        ),
+        "labels: {}".format( label_text ),
+        "head: {} @ {}".format( head.get( 'ref' ) or '-', short_sha ),
+        "base: {}".format( base.get( 'ref' ) or '-' ),
+    ]
+    body = summary.get( 'body' ) or ''
+    if body:
+        lines.append( '---' )
+        lines.append( body.rstrip( '\n' ) )
+    return "\n".join( lines )
+
+
+def show_pull_request( number=None, head=None, owner=None, repo=None, github=None ):
+    """Pull request metadata (public API by default). Returns a summary dict."""
+    owner, repo = repository( owner, repo )
+    client = public_github( github )
+    pull = resolve_pull_request(
+        number=number, head=head, owner=owner, repo=repo, github=client
+    )
+    return summarize_pull_request( pull )
+
+
+def _pull_with_auth_fallback( number=None, head=None, owner=None, repo=None, github=None, out=None ):
+    """Return ``(summary, client)``, switching to the sealed token on rate limit."""
+    out = out or sys.stdout
+    client = public_github( github )
+    try:
+        return show_pull_request(
+            number=number, head=head, owner=owner, repo=repo, github=client
+        ), client
+    except RateLimited:
+        if not is_anonymous_client( client ):
+            raise
+        out.write(
+            "public API rate-limited; retrying with sealed credential\n"
+        )
+        out.flush()
+        client = GitHub()
+        return show_pull_request(
+            number=number, head=head, owner=owner, repo=repo, github=client
+        ), client
 
 
 def _check_runs_for( sha, owner, repo, github ):
@@ -721,6 +815,22 @@ def pr_status_command( arguments ):
     return exit_code_for( status.outcome )
 
 
+def show_pr_command( arguments ):
+    github = GitHub() if arguments.auth else None
+    summary, _client = _pull_with_auth_fallback(
+        number = arguments.pr,
+        head = arguments.head,
+        owner = arguments.owner,
+        repo = arguments.repo,
+        github = github,
+    )
+    if arguments.json:
+        print( json.dumps( summary, indent=2, sort_keys=True ) )
+    else:
+        print( format_pull_request( summary ) )
+    return 0
+
+
 def watch_pr_command( arguments ):
     github = GitHub() if arguments.auth else None
     code, _ = watch_pull_request(
@@ -796,6 +906,17 @@ def main( argv=None ):
     status = commands.add_parser( 'pr-status', help="show check status once and exit" )
     _add_pr_selection_arguments( status )
 
+    show = commands.add_parser(
+        'show-pr',
+        aliases=[ 'fetch-pr' ],
+        help="show pull request title, labels, and body (public API)",
+    )
+    _add_pr_selection_arguments( show )
+    show.add_argument(
+        '--json', action='store_true',
+        help="print a JSON summary instead of the human-readable form",
+    )
+
     watch = commands.add_parser(
         'watch-pr',
         help="poll check status until the pull request finishes (or times out)",
@@ -841,6 +962,8 @@ def main( argv=None ):
             return update_pr_command( arguments )
         if arguments.command == 'pr-status':
             return pr_status_command( arguments )
+        if arguments.command in ( 'show-pr', 'fetch-pr' ):
+            return show_pr_command( arguments )
         if arguments.command == 'watch-pr':
             return watch_pr_command( arguments )
         if arguments.command == 'fetch-ci-logs':

--- a/tests/unit/test_github_helpers.py
+++ b/tests/unit/test_github_helpers.py
@@ -81,6 +81,95 @@ def test_pull_request_status_uses_a_public_client_by_default( monkeypatch ):
     assert created, "status helpers must use GitHub.public(), not the sealed client"
 
 
+def test_show_pull_request_uses_public_api_and_summarises( monkeypatch ):
+    created = []
+
+    class CapturingPublic( object ):
+        @classmethod
+        def public( cls ):
+            client = FakeGitHub( responses=[
+                ( 200, {
+                    'number': 165,
+                    'html_url': 'https://example.com/pr/165',
+                    'title': 'Share download progress',
+                    'body': '## Summary\n\nProgress bars.\n',
+                    'state': 'open',
+                    'draft': False,
+                    'mergeable_state': 'unstable',
+                    'labels': [ { 'name': 'impact:patch' } ],
+                    'head': { 'ref': 'download_progress', 'sha': 'f8a68cb8deadbeef' },
+                    'base': { 'ref': 'master' },
+                } ),
+            ] )
+            created.append( client )
+            return client
+
+    monkeypatch.setattr( github_helpers, 'GitHub', CapturingPublic )
+    monkeypatch.setattr(
+        github_helpers, 'repository',
+        lambda owner=None, repo=None: ( 'ja11sop', 'cuppa' ),
+    )
+
+    summary = github_helpers.show_pull_request( number=165 )
+    assert created, "show-pr must use GitHub.public(), not the sealed client"
+    assert summary['number'] == 165
+    assert summary['labels'] == [ 'impact:patch' ]
+    assert summary['head']['ref'] == 'download_progress'
+    assert summary['head']['sha'].startswith( 'f8a68cb8' )
+    assert 'Progress bars' in summary['body']
+
+    rendered = github_helpers.format_pull_request( summary )
+    assert 'PR #165' in rendered
+    assert 'title: Share download progress' in rendered
+    assert 'labels: impact:patch' in rendered
+    assert 'head: download_progress @ f8a68cb8' in rendered
+    assert 'Progress bars' in rendered
+
+
+def test_show_pr_command_json( monkeypatch, capsys ):
+    monkeypatch.setattr(
+        github_helpers, 'show_pull_request',
+        lambda **kwargs: {
+            'number': 165,
+            'url': 'https://example.com/pr/165',
+            'title': 'Share download progress',
+            'state': 'open',
+            'draft': False,
+            'mergeable_state': 'clean',
+            'labels': [ 'impact:patch' ],
+            'head': { 'ref': 'download_progress', 'sha': 'abc12345' },
+            'base': { 'ref': 'master' },
+            'body': 'body text',
+        },
+    )
+    code = github_helpers.main( [ 'show-pr', '--pr', '165', '--json' ] )
+    assert code == 0
+    payload = __import__( 'json' ).loads( capsys.readouterr().out )
+    assert payload['number'] == 165
+    assert payload['labels'] == [ 'impact:patch' ]
+
+
+def test_fetch_pr_alias_dispatches( monkeypatch, capsys ):
+    monkeypatch.setattr(
+        github_helpers, '_pull_with_auth_fallback',
+        lambda **kwargs: ( {
+            'number': 1,
+            'url': 'https://example.com/pr/1',
+            'title': 'T',
+            'state': 'open',
+            'draft': False,
+            'mergeable_state': 'clean',
+            'labels': [],
+            'head': { 'ref': 'b', 'sha': 'deadbeef' },
+            'base': { 'ref': 'master' },
+            'body': '',
+        }, object() ),
+    )
+    code = github_helpers.main( [ 'fetch-pr', '--pr', '1' ] )
+    assert code == 0
+    assert 'PR #1' in capsys.readouterr().out
+
+
 def test_create_pull_request_opens_and_labels( monkeypatch ):
     monkeypatch.setattr( github_helpers, 'current_branch', lambda: 'feature' )
     client = FakeGitHub()

--- a/tests/unit/test_github_helpers.py
+++ b/tests/unit/test_github_helpers.py
@@ -317,6 +317,10 @@ def test_pull_request_status_summarises_checks( monkeypatch ):
 
 def test_watch_pull_request_returns_when_checks_finish( monkeypatch ):
     monkeypatch.setattr( github_helpers, 'current_branch', lambda: 'feature' )
+    monkeypatch.setattr(
+        github_helpers, 'repository',
+        lambda owner=None, repo=None: ( 'ja11sop', 'cuppa' ),
+    )
     pending = github_helpers.PullRequestStatus(
         number=139,
         url='https://example.com/pr/139',
@@ -332,9 +336,16 @@ def test_watch_pull_request_returns_when_checks_finish( monkeypatch ):
         mergeable_state='clean',
     )
     states = [ pending, success ]
+    seen_numbers = []
+
+    def fake_status( **kwargs ):
+        seen_numbers.append( kwargs.get( 'number' ) )
+        return states.pop( 0 )
+
+    monkeypatch.setattr( github_helpers, 'pull_request_status', fake_status )
     monkeypatch.setattr(
-        github_helpers, 'pull_request_status',
-        lambda **kwargs: states.pop( 0 ),
+        github_helpers, 'resolve_pull_request',
+        lambda **kwargs: { 'number': 139 },
     )
 
     sleeps = []
@@ -351,11 +362,58 @@ def test_watch_pull_request_returns_when_checks_finish( monkeypatch ):
     assert last.outcome == 'success'
     # Sleep before each poll (fixed --interval): pending then success.
     assert sleeps == [ 1, 1 ]
+    assert seen_numbers == [ 139, 139 ]
     assert 'outcome=pending' in out.getvalue()
     assert 'outcome=success' in out.getvalue()
 
 
+def test_watch_pull_request_pins_number_despite_branch_change( monkeypatch ):
+    monkeypatch.setattr(
+        github_helpers, 'repository',
+        lambda owner=None, repo=None: ( 'ja11sop', 'cuppa' ),
+    )
+    branches = [ 'show_pr_helper', 'download_progress' ]
+    monkeypatch.setattr( github_helpers, 'current_branch', lambda: branches[0] )
+    monkeypatch.setattr(
+        github_helpers, 'resolve_pull_request',
+        lambda **kwargs: { 'number': 166 },
+    )
+
+    polls = []
+
+    def fake_status( **kwargs ):
+        polls.append( kwargs.get( 'number' ) )
+        # Simulate another agent checking out a different PR branch mid-watch.
+        branches[0] = 'download_progress'
+        return github_helpers.PullRequestStatus(
+            number=kwargs['number'],
+            url='https://example.com/pr/{}'.format( kwargs['number'] ),
+            head_sha='abcdef01',
+            state='open',
+            mergeable_state='clean',
+            checks=[ github_helpers.CheckRun( 'unit', 'completed', 'success', '' ) ],
+            outcome='success',
+        )
+
+    monkeypatch.setattr( github_helpers, 'pull_request_status', fake_status )
+    out = io.StringIO()
+    code, last = github_helpers.watch_pull_request(
+        interval=1,
+        timeout=60,
+        out=out,
+        sleep=lambda seconds: None,
+        clock=lambda: 0,
+    )
+    assert code == github_helpers.EXIT_SUCCESS
+    assert last.number == 166
+    assert polls == [ 166 ]
+
+
 def test_watch_pull_request_times_out( monkeypatch ):
+    monkeypatch.setattr(
+        github_helpers, 'repository',
+        lambda owner=None, repo=None: ( 'ja11sop', 'cuppa' ),
+    )
     monkeypatch.setattr(
         github_helpers, 'pull_request_status',
         lambda **kwargs: github_helpers.PullRequestStatus(


### PR DESCRIPTION
## Summary
- Add `scripts.github_helpers show-pr` (alias `fetch-pr`) for pull request title, labels, head/base, and body via the **public** GitHub API.
- Support `--json` for a stable agent-friendly summary; keep rate-limit / `--auth` fallback consistent with `pr-status`.
- Document in `AGENTS.md`, CHANGELOG, and the agent workflow journey.

## Test plan
- [x] `flake8 cuppa scripts` / `pylint -E cuppa scripts/github_helpers.py`
- [x] `pytest -m unit`
- [x] `pytest -m integration`
- [x] Manual: `python -m scripts.github_helpers show-pr --pr 165` and `--json`
- [x] CI green on the matrix
