### PR TITLE
Archive shipped toolchains-as-dependencies plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reuse `--toolchains=` flag at sconstruct end. List/downloads classify these as type
   `toolchain`; force-wipe accepts `[toolchain]clang/…`, `[toolchain]gcc/…`, or the session name.
   Project-scoped `--remove-` / `--purge-` / `--wipe-dependencies` do not apply. See
-  `design/plans/toolchains-as-dependencies.md` and [#160](https://github.com/ja11sop/cuppa/issues/160).
+  `design/archive/toolchains-as-dependencies.md` and [#160](https://github.com/ja11sop/cuppa/issues/160).
   ([#127](https://github.com/ja11sop/cuppa/issues/127) `--profiles` remains a follow-on.)
 - `--list-scope=compact` is a refinement of `referenced`: resolve-selected leaves only (no
   unused siblings, no unreferenced section).
@@ -288,6 +288,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Archive the shipped toolchains-as-dependencies design plan under `design/archive/` (umbrella
+  [#160](https://github.com/ja11sop/cuppa/issues/160)); update ROADMAP, toolchains docs, and code
+  citations to the new path.
 - The `release` workflow builds sdist and wheel, creates the GitHub Release from the CHANGELOG
   section, and publishes to PyPI via Trusted Publishing after approval on the `pypi` environment.
   Tag push and `workflow_dispatch` (existing tag) both drive it; see `release.txt`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -312,9 +312,10 @@ Goal: fetched compilers behave like other cuppa dependencies — download once, 
 storage roots, register a stable non-colliding name for `--toolchains=` / `_build`, and list /
 force-wipe with the same grammar as location and package trees.
 
-Design: [`design/plans/toolchains-as-dependencies.md`](design/plans/toolchains-as-dependencies.md).
-Umbrella: [#160](https://github.com/ja11sop/cuppa/issues/160). Opt-in C++ Profiles (`-fprofiles`)
-remains [#127](https://github.com/ja11sop/cuppa/issues/127) and is not this section.
+Design (shipped): [`design/archive/toolchains-as-dependencies.md`](design/archive/toolchains-as-dependencies.md).
+Umbrella: [#160](https://github.com/ja11sop/cuppa/issues/160) (Clang [#159](https://github.com/ja11sop/cuppa/pull/159), GCC [#164](https://github.com/ja11sop/cuppa/pull/164)).
+Opt-in C++ Profiles (`-fprofiles`) remains [#127](https://github.com/ja11sop/cuppa/issues/127) and is not
+this section.
 
 ### Today
 
@@ -333,7 +334,7 @@ remains [#127](https://github.com/ja11sop/cuppa/issues/127) and is not this sect
 | ID | Work | Priority | Notes |
 |----|------|----------|-------|
 | `tc-dep-url-sugar` | Optional URL token in `--toolchains=` | Low | Keep `--toolchain-archive=` as explicit supply |
-| `tc-dep-profiles` | [#127](https://github.com/ja11sop/cuppa/issues/127) `--profiles` / `-fprofiles` | Medium | Needs a Profiles-capable Clang via [#160](https://github.com/ja11sop/cuppa/issues/160) |
+| `tc-dep-profiles` | [#127](https://github.com/ja11sop/cuppa/issues/127) `--profiles` / `-fprofiles` | Medium | Needs a Profiles-capable Clang (supply path from [#160](https://github.com/ja11sop/cuppa/issues/160) is done) |
 | `tc-dep-actions` | Authenticated Actions artifact URLs | Low | After public HTTPS / file path is solid |
 | `tc-dep-msvc` | MSVC archive / layout as toolchain dep | Low | Separate driver; not gcc-snapshot |
 

--- a/cuppa/toolchains/toolchain_archive.py
+++ b/cuppa/toolchains/toolchain_archive.py
@@ -7,7 +7,7 @@
 
 Public HTTPS / file archives (Clang tarballs, Debian ``gcc-snapshot`` ``.deb`` files)
 and local ``--clang-root`` / ``--gcc-root`` prefixes. See
-``design/plans/toolchains-as-dependencies.md``.
+``design/archive/toolchains-as-dependencies.md``.
 """
 
 from __future__ import print_function

--- a/design/README.md
+++ b/design/README.md
@@ -27,9 +27,9 @@ maintainer workflow evolved.
 | [`plans/modules-activation.md`](plans/modules-activation.md) | proposal | Whether C++ modules should stay opt-in behind `--modules` or become opt-out, and what must land first |
 | [`plans/removal-options.md`](plans/removal-options.md) | in progress | Phases 1–5 + wipe + §3.7/§3.8 shipped ([#154](https://github.com/ja11sop/cuppa/pull/154)); Phase 6 artefacts [#135](https://github.com/ja11sop/cuppa/issues/135) open; next focus artefacts when that design starts |
 | [`plans/scons-tool-wrapper.md`](plans/scons-tool-wrapper.md) | proposal | Wrapping an SCons Tool as a cuppa dependency instead of hand-writing a dependency class |
-| [`plans/toolchains-as-dependencies.md`](plans/toolchains-as-dependencies.md) | in progress | Fetched compilers as toolchain deps (Clang archives, GCC `.deb` / `--gcc-root=`, multi-select compare; list/force-wipe) — umbrella [#160](https://github.com/ja11sop/cuppa/issues/160) |
 | [`process/agent-workflow-journey.md`](process/agent-workflow-journey.md) | living | How cuppa’s maintainer workflow was hardened for humans and agents (blueprint + case studies) |
 | [`archive/console-report-patterns.md`](archive/console-report-patterns.md) | shipped | Judgement-tree shape, severity timing (warn before / note after), shared helpers for console reports ([#161](https://github.com/ja11sop/cuppa/issues/161)); Antora Report patterns page |
+| [`archive/toolchains-as-dependencies.md`](archive/toolchains-as-dependencies.md) | shipped | Fetched compilers as toolchain deps (Clang archives, GCC `.deb` / `--gcc-root=`, multi-select compare; list/force-wipe) — umbrella [#160](https://github.com/ja11sop/cuppa/issues/160); Clang [#159](https://github.com/ja11sop/cuppa/pull/159), GCC [#164](https://github.com/ja11sop/cuppa/pull/164) |
 | [`archive/conan-consumer-plan.md`](archive/conan-consumer-plan.md) | shipped | Design of `conan_deps` / `conan_dependency` consumer support |
 | [`archive/conan-publish-plan.md`](archive/conan-publish-plan.md) | shipped | Design of `ConanPackagePublisher` and `--publish-package` |
 

--- a/design/archive/toolchains-as-dependencies.md
+++ b/design/archive/toolchains-as-dependencies.md
@@ -1,14 +1,14 @@
 # Plan: Toolchains as dependencies
 
-- **Status:** in progress
-- **Related:** [`ROADMAP.md`](../../ROADMAP.md); umbrella [#160](https://github.com/ja11sop/cuppa/issues/160); Profiles follow-on [#127](https://github.com/ja11sop/cuppa/issues/127); type-selector note in [`boost-updates.md`](boost-updates.md); report polish [#161](https://github.com/ja11sop/cuppa/issues/161)
-- **Updated:** 2026-08-08
+- **Status:** shipped
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md); umbrella [#160](https://github.com/ja11sop/cuppa/issues/160) (Clang [#159](https://github.com/ja11sop/cuppa/pull/159) / GCC [#164](https://github.com/ja11sop/cuppa/pull/164)); Profiles follow-on [#127](https://github.com/ja11sop/cuppa/issues/127); type-selector note in [`boost-updates.md`](../plans/boost-updates.md); report polish [#161](https://github.com/ja11sop/cuppa/issues/161); download progress [#165](https://github.com/ja11sop/cuppa/pull/165)
+- **Updated:** 2026-08-09
 
-Fetched compilers should behave like other cuppa dependencies: download once, extract under
+Fetched compilers behave like other cuppa dependencies: download once, extract under
 storage roots, list / remove / wipe later, and register a **stable toolchain name** for
 `--toolchains=` and `_build` folders. **Clang** (public archive URLs) and **GCC**
 (`gcc-snapshot` `.deb` + `--gcc-root=`) are the shipped families. MSVC and authenticated
-Actions artifacts come later.
+Actions artifacts remain follow-ons (see ROADMAP).
 
 **Product goal — multiple concurrent copies:** users must be able to keep several Clang and
 several GCC installs registered at once and **select more than one in a single cuppa run**
@@ -108,16 +108,16 @@ cuppa -D --dbg --toolchains=gcc15,gcc16_gcc_snapshot_20260725_1_amd64,clang24_pr
 | `tc-dep-list` | list/downloads type `toolchain` | done |
 | `tc-dep-remove` | force-wipe `[toolchain]…` | done |
 | `tc-dep-pr` | First Clang slice land | done |
-| `tc-dep-gcc-root` | `--gcc-root=` + persist external + discover gcc | done (this PR) |
-| `tc-dep-gcc-deb` | `.deb` as `--toolchain-archive=` for gcc-snapshot | done (this PR) |
-| `tc-dep-external-persist` | Persist `--clang-root=` / `--gcc-root=` registrations | done (this PR) |
-| `tc-dep-url-sugar` | Optional URL token in `--toolchains=` | later |
-| `tc-dep-profiles` | [#127](https://github.com/ja11sop/cuppa/issues/127) `--profiles` | later |
-| `tc-dep-actions` | Authenticated Actions artifact URLs | later |
-| `dl-prog` | Shared HTTP download progress for large archives | later — [`download-progress.md`](../archive/download-progress.md) |
+| `tc-dep-gcc-root` | `--gcc-root=` + persist external + discover gcc | done (#164) |
+| `tc-dep-gcc-deb` | `.deb` as `--toolchain-archive=` for gcc-snapshot | done (#164) |
+| `tc-dep-external-persist` | Persist `--clang-root=` / `--gcc-root=` registrations | done (#164) |
+| `tc-dep-url-sugar` | Optional URL token in `--toolchains=` | later (ROADMAP) |
+| `tc-dep-profiles` | [#127](https://github.com/ja11sop/cuppa/issues/127) `--profiles` | later (separate issue) |
+| `tc-dep-actions` | Authenticated Actions artifact URLs | later (ROADMAP) |
+| `dl-prog` | Shared HTTP download progress for large archives | done (#165) — [`download-progress.md`](download-progress.md) |
 
 ## Related
 
-- Type selectors for cross-type name clashes — see [`boost-updates.md`](boost-updates.md).
+- Type selectors for cross-type name clashes — see [`boost-updates.md`](../plans/boost-updates.md).
 - Report / judgement-tree polish:
-  [`console-report-patterns.md`](../archive/console-report-patterns.md) / [#161](https://github.com/ja11sop/cuppa/issues/161).
+  [`console-report-patterns.md`](console-report-patterns.md) / [#161](https://github.com/ja11sop/cuppa/issues/161).

--- a/docs/modules/ROOT/pages/toolchains.adoc
+++ b/docs/modules/ROOT/pages/toolchains.adoc
@@ -99,7 +99,7 @@ Which management flags apply:
 * `--force-wipe-unreferenced-dependencies` — yes for installs that are not the active selection.
 * `--remove-dependencies` / `--purge-dependencies` / `--wipe-dependencies` (and the `*-all-*` forms) — no; those only target **project-used** dependency names from the current selection (`default_dependencies` / `BuildWith`), not compiler installs.
 
-Design notes: `design/plans/toolchains-as-dependencies.md`.
+Design notes: `design/archive/toolchains-as-dependencies.md`.
 
 [#c-language-level]
 == C++ language level


### PR DESCRIPTION
## Summary
- Mark `toolchains-as-dependencies` **shipped** and move it to `design/archive/`.
- Update ROADMAP, CHANGELOG path citations, `toolchains.adoc`, and `toolchain_archive.py`.
- Record `dl-prog` as done (#165); leave url-sugar / profiles (#127) / actions on ROADMAP.

## Test plan
- [x] `pytest -m unit` (includes `test_design_index`)
- [x] `flake8 cuppa` / `pylint -E cuppa`
- [x] CI green on the matrix
