### PR TITLE
Cite #171 and #172 for Boost latest and list-toolchains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,19 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `design/ideas/scratchpad.md` holds pre-plan product ideas (living). Notes graduate into
   `design/plans/` and `ROADMAP.md`, then leave the scratchpad. `*.local.md` remains for private
   project maps only.
-- Design plans: [`boost-latest-persistence.md`](design/plans/boost-latest-persistence.md) and
-  [`list-toolchains.md`](design/plans/list-toolchains.md) (opened under the 1.6.0 cycle).
-- Boost latest persistence: remember `boost_latest_version` in project `configure.conf` or
-  `~/.cuppaconfig` according to whether `--downloads-root` sits under the project. Default Boost
-  resolve prefers that stored value, then the compiled-in default, and does not scrape boost.org
-  unless `--boost-latest` is passed. The key updates only when a higher version’s archive is present
-  under downloads-root.
-- `--list-toolchains`: ruled **discovered** / **registered** tree
-  (family → version → driver → name(s)), with shared-driver grouping, per-family and
-  platform-default marking (platform family `(default)` only when the bare default name is
-  present), inventory-backed registered SIZE/LAST USED, summary line, and dry-run wipe hint.
-  Nested `--list-format=json`. `--list-dependencies` toolchain leaves show the Cuppa session name
-  (`gcc17_gcc_snapshot_…`) aligned with `--toolchains=`.
+- Design plans: [`boost-latest-persistence.md`](design/archive/boost-latest-persistence.md) and
+  [`list-toolchains.md`](design/archive/list-toolchains.md) (1.6.0 cycle; tracked as
+  [#171](https://github.com/ja11sop/cuppa/issues/171) /
+  [#172](https://github.com/ja11sop/cuppa/issues/172)).
+- Boost latest persistence ([#171](https://github.com/ja11sop/cuppa/issues/171)): remember
+  `boost_latest_version` in project `configure.conf` or `~/.cuppaconfig` according to whether
+  `--downloads-root` sits under the project. Default Boost resolve prefers that stored value,
+  then the compiled-in default, and does not scrape boost.org unless `--boost-latest` is passed.
+  The key updates only when a higher version’s archive is present under downloads-root.
+- `--list-toolchains` ([#172](https://github.com/ja11sop/cuppa/issues/172)): ruled
+  **discovered** / **registered** tree (family → version → driver → name(s)), with shared-driver
+  grouping, per-family and platform-default marking (platform family `(default)` only when the
+  bare default name is present), inventory-backed registered SIZE/LAST USED, summary line, and
+  dry-run wipe hint. Nested `--list-format=json`. `--list-dependencies` toolchain leaves show the
+  Cuppa session name (`gcc17_gcc_snapshot_…`) aligned with `--toolchains=`.
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -120,13 +120,13 @@ Design: [`design/plans/boost-updates.md`](design/plans/boost-updates.md).
 | `boost_package.define(..., patched=True)` default | Yes — compile define + `patched_test()` only |
 | Package archive / extract / version distinguish patched vs clean | No — same `boost` + `1.91` + tool variant |
 | Package `use_libs` passes `patched_test=` into library deps | No |
-| Persist Boost latest for offline reuse (`boost_latest_version`, downloads-root–scoped) | Yes — on branch; lazy scrape (`--boost-latest` only); see design plan |
+| Persist Boost latest for offline reuse (`boost_latest_version`, downloads-root–scoped) | Yes — [#171](https://github.com/ja11sop/cuppa/issues/171) / [#170](https://github.com/ja11sop/cuppa/pull/170); design [`boost-latest-persistence.md`](design/archive/boost-latest-persistence.md) |
 
 ### Planned / potential
 
 | ID | Work | Priority | Notes |
 |----|------|----------|-------|
-| `boost-latest-persist` | Persist higher downloaded latest; offline reads stored then compiled-in; scrape only with `--boost-latest` | High | Design: [`boost-latest-persistence.md`](design/plans/boost-latest-persistence.md); shipping in 1.6.0 |
+| `boost-latest-persist` | Persist higher downloaded latest; offline reads stored then compiled-in; scrape only with `--boost-latest` | High | Done — [#171](https://github.com/ja11sop/cuppa/issues/171) / [#170](https://github.com/ja11sop/cuppa/pull/170) |
 | `boost-pkg-version` | Canonical version `{base}-patched` / `{base}-clean`; publisher + resolve + `package_id` | High | Visible qualifier; avoids extract collision |
 | `boost-pkg-compat` | Patched resolve falls back to unadorned `{base}`; clean does not | High | Existing registry tarballs are patched and unnamed |
 | `boost-pkg-use-libs` | Package `use_libs` passes `patched_test=` | High | Parity with source Boost |
@@ -330,15 +330,15 @@ this section.
 | External `--*-root=` persists registration (`cuppa-toolchain.json`) | Yes |
 | List as type `toolchain`; force-wipe `[toolchain]…`; project remove/purge/wipe N/A | Yes |
 | Shared transfer progress (HTTP download, extract, Conan stream, git `--progress`) | Yes ([#165](https://github.com/ja11sop/cuppa/pull/165); plan [`download-progress.md`](design/archive/download-progress.md)) |
-| `--list-toolchains` (Discovered vs Registered, driver paths, JSON) | Yes — on [#170](https://github.com/ja11sop/cuppa/pull/170); design [`list-toolchains.md`](design/plans/list-toolchains.md) |
-| `--list-toolchains --list-format=verbose` + `describe()` | Yes — on [#170](https://github.com/ja11sop/cuppa/pull/170); design [`list-toolchains-verbose.md`](design/plans/list-toolchains-verbose.md) |
-| Toolchains hub + GCC / Clang / MSVC family pages | Yes — on [#170](https://github.com/ja11sop/cuppa/pull/170) |
+| `--list-toolchains` (Discovered vs Registered, driver paths, JSON) | Yes — [#172](https://github.com/ja11sop/cuppa/issues/172) / [#170](https://github.com/ja11sop/cuppa/pull/170); design [`list-toolchains.md`](design/archive/list-toolchains.md) |
+| `--list-toolchains --list-format=verbose` + `describe()` | Yes — [#172](https://github.com/ja11sop/cuppa/issues/172) / [#170](https://github.com/ja11sop/cuppa/pull/170); design [`list-toolchains-verbose.md`](design/plans/list-toolchains-verbose.md) |
+| Toolchains hub + GCC / Clang / MSVC family pages | Yes — [#172](https://github.com/ja11sop/cuppa/issues/172) / [#170](https://github.com/ja11sop/cuppa/pull/170) |
 
 ### Planned / potential
 
 | ID | Work | Priority | Notes |
 |----|------|----------|-------|
-| `list-toolchains` | `--list-toolchains` inventory; Discovered vs Registered; driver + storage paths; JSON; verbose `describe()` | High | Landing in [#170](https://github.com/ja11sop/cuppa/pull/170) / 1.6.0 |
+| `list-toolchains` | `--list-toolchains` inventory; Discovered vs Registered; driver + storage paths; JSON; verbose `describe()` | High | Done — [#172](https://github.com/ja11sop/cuppa/issues/172) / [#170](https://github.com/ja11sop/cuppa/pull/170) |
 | `list-tc-flag-tables` | Table-driven GCC/Clang/Cl init shared with `describe()` | Low | Deferred; see [`list-toolchains-verbose.md`](design/plans/list-toolchains-verbose.md) |
 | `tc-dep-url-sugar` | Optional URL token in `--toolchains=` | Low | Keep `--toolchain-archive=` as explicit supply |
 | `tc-dep-profiles` | [#127](https://github.com/ja11sop/cuppa/issues/127) `--profiles` / `-fprofiles` | Medium | Needs a Profiles-capable Clang (supply path from [#160](https://github.com/ja11sop/cuppa/issues/160) is done) |

--- a/design/README.md
+++ b/design/README.md
@@ -21,12 +21,12 @@ maintainer workflow evolved.
 
 | Document | Status | Subject |
 |----------|--------|---------|
-| [`plans/boost-latest-persistence.md`](plans/boost-latest-persistence.md) | in progress | Persist Boost latest (downloads-root–scoped conf); lazy scrape; offline reuse |
 | [`plans/boost-updates.md`](plans/boost-updates.md) | proposal | Boost source vs GitLab `boost_package` identity: patched default, version suffix, `use_libs` parity |
 | [`plans/colourised-doc-samples.md`](plans/colourised-doc-samples.md) | proposal | Capture cuppa report output as semantic HTML for Antora samples and local preview |
 | [`plans/coverage-performance.md`](plans/coverage-performance.md) | proposal | Where `--cov --test` time actually goes, what the A/B measurement ruled out, and the remaining suspects |
-| [`plans/list-toolchains.md`](plans/list-toolchains.md) | in progress | `--list-toolchains` ruled tree (family→version→driver→names); list-deps leaf = Cuppa session name |
-| [`plans/list-toolchains-verbose.md`](plans/list-toolchains-verbose.md) | in progress | Verbose driver subtree: available dialects / stdlib choices / default invocations via `describe()` |
+| [`plans/list-toolchains-verbose.md`](plans/list-toolchains-verbose.md) | in progress | Verbose `describe()` shipped ([#172](https://github.com/ja11sop/cuppa/issues/172) / [#170](https://github.com/ja11sop/cuppa/pull/170)); deferred table-driven init |
+| [`archive/boost-latest-persistence.md`](archive/boost-latest-persistence.md) | shipped | Persist Boost latest (downloads-root–scoped conf); lazy scrape; offline reuse — [#171](https://github.com/ja11sop/cuppa/issues/171) / [#170](https://github.com/ja11sop/cuppa/pull/170) |
+| [`archive/list-toolchains.md`](archive/list-toolchains.md) | shipped | `--list-toolchains` ruled tree (family→version→driver→names); list-deps leaf = Cuppa session name — [#172](https://github.com/ja11sop/cuppa/issues/172) / [#170](https://github.com/ja11sop/cuppa/pull/170) |
 | [`archive/download-progress.md`](archive/download-progress.md) | shipped | Shared HTTP/transfer progress (download, extract, Conan, git) — [#165](https://github.com/ja11sop/cuppa/pull/165) |
 | [`plans/modules-activation.md`](plans/modules-activation.md) | proposal | Whether C++ modules should stay opt-in behind `--modules` or become opt-out, and what must land first |
 | [`plans/removal-options.md`](plans/removal-options.md) | in progress | Phases 1–5 + wipe + §3.7/§3.8 shipped ([#154](https://github.com/ja11sop/cuppa/pull/154)); Phase 6 artefacts [#135](https://github.com/ja11sop/cuppa/issues/135) open; next focus artefacts when that design starts |

--- a/design/archive/boost-latest-persistence.md
+++ b/design/archive/boost-latest-persistence.md
@@ -1,7 +1,8 @@
 # Plan: Persist resolved Boost “latest” across offline runs
 
-- **Status:** in progress
-- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Boost source and packages; [`boost-updates.md`](boost-updates.md) (patched/clean package identity — separate); [`ideas/scratchpad.md`](../ideas/scratchpad.md) (graduated)
+- **Status:** shipped
+- **Related:** [#171](https://github.com/ja11sop/cuppa/issues/171); [#170](https://github.com/ja11sop/cuppa/pull/170);
+  [`ROADMAP.md`](../../ROADMAP.md) — Boost source and packages; [`boost-updates.md`](../plans/boost-updates.md) (patched/clean package identity — separate); [`ideas/scratchpad.md`](../ideas/scratchpad.md) (graduated)
 - **Updated:** 2026-08-09
 - **Impact:** minor — persisted latest version scoped with downloads-root; lazy network check; existing `--boost-latest` kept as an explicit “force latest” switch
 
@@ -24,7 +25,7 @@ A common CI shape breaks around Boost releases:
 **remembering a higher version that was actually downloaded**, scoped like the download cache,
 and **not** scraping Boost when the project never uses Boost.
 
-This is **not** the patched/clean GitLab package identity work in [`boost-updates.md`](boost-updates.md).
+This is **not** the patched/clean GitLab package identity work in [`boost-updates.md`](../plans/boost-updates.md).
 
 ## Goals
 
@@ -108,4 +109,4 @@ This is **not** the patched/clean GitLab package identity work in [`boost-update
 
 ## Open decisions
 
-None — implementation on the 1.6.0 branch.
+None — shipped in [#171](https://github.com/ja11sop/cuppa/issues/171) / [#170](https://github.com/ja11sop/cuppa/pull/170).

--- a/design/archive/list-toolchains.md
+++ b/design/archive/list-toolchains.md
@@ -1,12 +1,12 @@
 # Plan: `--list-toolchains`
 
-- **Status:** in progress
-- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Toolchains as dependencies; shipped design
-  [`archive/toolchains-as-dependencies.md`](../archive/toolchains-as-dependencies.md); [#160](https://github.com/ja11sop/cuppa/issues/160); [`list-toolchains-verbose.md`](list-toolchains-verbose.md); [`ideas/scratchpad.md`](../ideas/scratchpad.md) (graduated); console patterns
-  [`archive/console-report-patterns.md`](../archive/console-report-patterns.md)
+- **Status:** shipped
+- **Related:** [#172](https://github.com/ja11sop/cuppa/issues/172); [#170](https://github.com/ja11sop/cuppa/pull/170);
+  [`ROADMAP.md`](../../ROADMAP.md) — Toolchains as dependencies; shipped design
+  [`toolchains-as-dependencies.md`](toolchains-as-dependencies.md); [#160](https://github.com/ja11sop/cuppa/issues/160); [`list-toolchains-verbose.md`](../plans/list-toolchains-verbose.md); [`ideas/scratchpad.md`](../ideas/scratchpad.md) (graduated); console patterns
+  [`console-report-patterns.md`](console-report-patterns.md)
 - **Updated:** 2026-08-09
 - **Impact:** minor — inventory CLI + list-deps leaf label alignment for toolchain session names
-  (verbose / family docs land on the same [#170](https://github.com/ja11sop/cuppa/pull/170) branch)
 
 ## Why
 
@@ -91,8 +91,9 @@ ruled hierarchical reports instead.
 
 ## Suggested next PR
 
-`list-tc-tree-model` + `list-tc-tree-render` + `list-tc-json-nested` + `list-tc-deps-leaf` + docs/tests
-on the open 1.6.0 branch (follow-on to #170).
+None for the inventory tree — shipped in [#172](https://github.com/ja11sop/cuppa/issues/172) /
+[#170](https://github.com/ja11sop/cuppa/pull/170). Verbose / deferred flag tables:
+[`list-toolchains-verbose.md`](../plans/list-toolchains-verbose.md).
 
 ## Progress
 
@@ -109,9 +110,10 @@ on the open 1.6.0 branch (follow-on to #170).
 | `list-tc-deps-leaf` | done |
 | `list-tc-docs` (tree) | done |
 | `list-tc-follow-inventory` | deferred |
-| `list-tc-verbose` | See [`list-toolchains-verbose.md`](list-toolchains-verbose.md) |
+| `list-tc-verbose` | See [`list-toolchains-verbose.md`](../plans/list-toolchains-verbose.md) |
 
 ## Open decisions
 
-None for the inventory tree — proceed / polish on #170.
-Verbose dialects/flags: open in [`list-toolchains-verbose.md`](list-toolchains-verbose.md).
+None for the inventory tree.
+Verbose dialects/flags and deferred `list-tc-flag-tables`:
+[`list-toolchains-verbose.md`](../plans/list-toolchains-verbose.md).

--- a/design/ideas/scratchpad.md
+++ b/design/ideas/scratchpad.md
@@ -16,8 +16,8 @@ Do not put private project names here; use anonymised labels and
 
 ### Graduated (removed from this file)
 
-- Boost `latest` persistence → [`plans/boost-latest-persistence.md`](../plans/boost-latest-persistence.md)
-- `--list-toolchains` → [`plans/list-toolchains.md`](../plans/list-toolchains.md)
+- Boost `latest` persistence → [`archive/boost-latest-persistence.md`](../archive/boost-latest-persistence.md)
+- `--list-toolchains` → [`archive/list-toolchains.md`](../archive/list-toolchains.md)
 
 ## Update: plans/boost-updates.md (related — dependency selection)
 

--- a/design/plans/boost-updates.md
+++ b/design/plans/boost-updates.md
@@ -1,7 +1,7 @@
 # Plan: Boost source and package updates
 
 - **Status:** proposal
-- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Boost source and packages; storage listing/removal stays in [`removal-options.md`](removal-options.md); offline “latest” persistence is [`boost-latest-persistence.md`](boost-latest-persistence.md) (separate)
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Boost source and packages; storage listing/removal stays in [`removal-options.md`](removal-options.md); offline “latest” persistence is [`boost-latest-persistence.md`](../archive/boost-latest-persistence.md) (separate)
 - **Updated:** 2026-08-09
 
 Source `boost` (b2 / extract homes) and GitLab `boost_package` share Boost.Test patch semantics

--- a/design/plans/list-toolchains-verbose.md
+++ b/design/plans/list-toolchains-verbose.md
@@ -1,13 +1,15 @@
 # Plan: `--list-toolchains --list-format=verbose`
 
 - **Status:** in progress
-- **Related:** [`list-toolchains.md`](list-toolchains.md) (inventory tree on [#170](https://github.com/ja11sop/cuppa/pull/170));
+- **Related:** [#172](https://github.com/ja11sop/cuppa/issues/172); [#170](https://github.com/ja11sop/cuppa/pull/170);
+  [`list-toolchains.md`](../archive/list-toolchains.md) (inventory tree shipped);
   [`ROADMAP.md`](../../ROADMAP.md) — Toolchains; family pages
   (`toolchain-gcc.adoc` / `toolchain-clang.adoc` / `toolchain-msvc.adoc`);
   GCC link options / GNU ld `-Bstatic`/`-Bdynamic` (language-agnostic driver/linker flags)
 - **Updated:** 2026-08-09
-- **Next focus:** deferred `list-tc-flag-tables` (table-driven init); otherwise verbose + docs
-  are on [#170](https://github.com/ja11sop/cuppa/pull/170)
+- **Next focus:** deferred `list-tc-flag-tables` (table-driven init). Verbose render, `describe()`,
+  and family docs shipped with [#172](https://github.com/ja11sop/cuppa/issues/172) /
+  [#170](https://github.com/ja11sop/cuppa/pull/170).
 - **Impact:** minor — verbose list surface + `describe()` API; dialect defaults owned by
   toolchain classes; no intentional change to build flag behaviour
 


### PR DESCRIPTION
## Summary

- Wire retroactive tracking issues into `ROADMAP.md`, `CHANGELOG.md`, and the design index:
  - [#171](https://github.com/ja11sop/cuppa/issues/171) Boost latest persistence
  - [#172](https://github.com/ja11sop/cuppa/issues/172) `--list-toolchains` (+ verbose `describe()`)
- Move shipped plans to `design/archive/` (`boost-latest-persistence`, `list-toolchains`).
- Keep `list-toolchains-verbose` **in progress** for deferred `list-tc-flag-tables`.

## Test plan

- [x] `pytest -m unit tests/unit/test_design_index.py tests/unit/test_version_and_changelog.py`
- [x] CI green on the matrix
