### PR TITLE
Fix force-wipe name/@ hints disagreeing with matching (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Force-wipe unqualified-stem hints emit matching ``name/@`` tokens instead of
+  host/path forms that reported ``no leaf matches`` ([#178](https://github.com/ja11sop/cuppa/issues/178)).
+  Dry-run report parents summarise matched identities, not the raw selector string.
+
 ### Security
 
 ## [1.6.0] - 2026-08-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Force-wipe unqualified-stem hints emit matching ``name/@`` tokens instead of
   host/path forms that reported ``no leaf matches`` ([#178](https://github.com/ja11sop/cuppa/issues/178)).
-  Dry-run report parents summarise matched identities, not the raw selector string.
-  Location stem-duplicate notices run only for list / remove / purge / wipe (debug
-  log, not warn); ordinary builds stay quiet. ``--list-scope=compact`` omits those
-  notices and wipe candidates so the tree does not advertise hidden leaves.
+  Dry-run report parents use a neutral ``related dependencies`` label (not the
+  raw selector or a dumped identity list). Location stem-duplicate notices run
+  only for list / remove / purge / wipe (debug log, not warn); ordinary builds
+  stay quiet. ``--list-scope=compact`` omits those notices and wipe candidates
+  so the tree does not advertise hidden leaves.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Force-wipe unqualified-stem hints emit matching ``name/@`` tokens instead of
   host/path forms that reported ``no leaf matches`` ([#178](https://github.com/ja11sop/cuppa/issues/178)).
   Dry-run report parents summarise matched identities, not the raw selector string.
+  Location stem-duplicate notices run only for list / remove / purge / wipe (debug
+  log, not warn); ordinary builds stay quiet. ``--list-scope=compact`` omits those
+  notices and wipe candidates so the tree does not advertise hidden leaves.
 
 ### Security
 

--- a/cuppa/construct.py
+++ b/cuppa/construct.py
@@ -574,25 +574,9 @@ class Construct(object):
                 logger.info( as_info_label( "Running in DUMP mode, no building will be attempted" ) )
                 cuppa_env.dump()
 
-            # Location warns about unused unqualified stems when factories create Location
-            # objects (often during storage resolve / BuildWith), not at registration.
-            # Storage actions flush the wipe hint after resolve; builds flush at sconstruct end.
-            if (
-                    not cuppa_env.get( 'list_dependencies' )
-                    and not cuppa.core.storage_actions.wants_storage_action( cuppa_env )
-            ):
-                from cuppa.core import dependency_actions
-                from cuppa.progress import NotifyProgress
-
-                def _flush_unqualified_duplicate_hints(
-                        event, sconscript, variant, env, target, source
-                ):
-                    if event == 'sconstruct_end':
-                        dependency_actions.emit_location_unqualified_duplicate_hints()
-
-                NotifyProgress.register_callback( None, _flush_unqualified_duplicate_hints )
-
-            # Develop-family actions report on dependencies, so they run once those are
+            # Unqualified stem notices belong to dependency-management commands
+            # (list / remove / purge / wipe); those flush their own wipe hints.
+            # Ordinary builds only prefer the canonical folder — no console spam.
             # registered, and none of them builds. Several may be combined (e.g. clone then
             # update); each runs in turn and the worst exit status wins.
             develop_actions = []

--- a/cuppa/core/dependency_actions.py
+++ b/cuppa/core/dependency_actions.py
@@ -161,7 +161,7 @@ def write_unqualified_duplicate_wipe_hint( out, tokens, see_earlier_warnings=Fal
     if not tokens:
         return
     out.write( "\n" )
-    earlier = " (see earlier warnings)" if see_earlier_warnings else ""
+    earlier = " (noted during resolve)" if see_earlier_warnings else ""
     out.write(
             as_remove_notice( "Unqualified stem duplicates" )
             + earlier
@@ -258,11 +258,15 @@ def apply_list_scope( data, scope, tree_builder=None ):
     filtered = dict( data )
     filtered['rows'] = rows
     filtered['scope'] = scope
-    # Compute before scope filter; compact must still advertise wipe candidates.
+    # Tokens are computed before the scope filter. Compact hides unused siblings,
+    # so do not advertise wipe candidates the tree cannot show.
     if 'unqualified_duplicate_tokens' in data:
-        filtered['unqualified_duplicate_tokens'] = list(
-                data.get( 'unqualified_duplicate_tokens' ) or []
-        )
+        if scope == 'compact':
+            filtered['unqualified_duplicate_tokens'] = []
+        else:
+            filtered['unqualified_duplicate_tokens'] = list(
+                    data.get( 'unqualified_duplicate_tokens' ) or []
+            )
 
     downloads_listing = (
             'archive_count' in data

--- a/cuppa/core/dependency_actions.py
+++ b/cuppa/core/dependency_actions.py
@@ -60,12 +60,9 @@ def _is_unqualified_qualifier( qualifier ):
 def _unqualified_wipe_name( row ):
     """Prefer a registry-style name for ``name/@`` wipe tokens, or ``None``."""
     for key in ( 'dependency', 'short_name', 'stem' ):
-        name = ( row.get( key ) or '' ).strip()
-        if not name:
-            continue
-        if name.startswith( ( 'git_', 'https_', 'svn_', 'hg_', 'bzr_', 'http_' ) ):
-            continue
-        return name
+        leaf = dependency_identity.wipe_token_leaf_name( row.get( key ) )
+        if leaf:
+            return leaf
     return None
 
 

--- a/cuppa/core/dependency_identity.py
+++ b/cuppa/core/dependency_identity.py
@@ -77,6 +77,28 @@ def short_name_from_git_tree( path ):
     return short_name_from_git_url( repository ), repository
 
 
+def wipe_token_leaf_name( name ):
+    """Reduce a display/identity name to a ``name/@`` force-wipe leaf.
+
+    Host/path short names (``gitlab.example/org/widget``) become the repo
+    segment (``widget``) so Location hints match registry-style
+    ``dependency`` / ``short_name`` candidates. Encoded folder stems
+    (``git_https_…``) return ``None`` so callers can fall through.
+    """
+    text = ( name or '' ).strip()
+    if not text:
+        return None
+    if '/' in text:
+        text = text.rstrip( '/' ).rsplit( '/', 1 )[-1]
+    if text.endswith( '.git' ):
+        text = text[:-4]
+    if not text or text.startswith(
+            ( 'git_', 'https_', 'svn_', 'hg_', 'bzr_', 'http_' )
+    ):
+        return None
+    return text
+
+
 def boost_archive_from_folder( folder ):
     """Return ``(short_name, version)`` for a Boost source archive folder, or ``(None, None)``."""
     if not folder or 'boost' not in folder.lower():

--- a/cuppa/core/dependency_removal.py
+++ b/cuppa/core/dependency_removal.py
@@ -3196,13 +3196,22 @@ def _matches_unqualified_stem( candidates ):
 
 
 def _row_name_candidates( row ):
-    return {
+    """Names a force-wipe token may match, including host/path → leaf forms."""
+    from cuppa.core.dependency_identity import wipe_token_leaf_name
+
+    raw = {
             item for item in (
                     ( row.get( 'short_name' ) or '' ).strip(),
                     ( row.get( 'dependency' ) or '' ).strip(),
                     ( row.get( 'stem' ) or '' ).strip(),
             ) if item
     }
+    candidates = set( raw )
+    for item in raw:
+        leaf = wipe_token_leaf_name( item )
+        if leaf:
+            candidates.add( leaf )
+    return candidates
 
 
 def _fnmatch_any( candidates, patterns ):
@@ -3223,8 +3232,14 @@ def _row_matches_force_token( row, name, qualifier ):
             return False
     else:
         want = _normalise_wipe_name( name )
-        if want not in { _normalise_wipe_name( item ) for item in name_candidates }:
-            return False
+        normalised = { _normalise_wipe_name( item ) for item in name_candidates }
+        if want not in normalised:
+            # Accept host/path tokens (``gitlab.example/org/widget``) against
+            # registry-style leaves (``widget``) and the reverse.
+            from cuppa.core.dependency_identity import wipe_token_leaf_name
+            leaf = wipe_token_leaf_name( name )
+            if not leaf or _normalise_wipe_name( leaf ) not in normalised:
+                return False
 
     row_qual = row.get( 'qualifier' )
     # Prefer an explicit display label on the row when present.
@@ -3722,12 +3737,17 @@ def force_wipe_dependencies( construct, cuppa_env, out=None ):
     leftovers, download_leftovers = _collect_force_wipe_context(
             rows, dl_rows, targets, download_targets,
     )
-    raw_spec = cuppa_env.get( 'force_wipe_dependencies' )
-    if isinstance( raw_spec, ( list, tuple ) ):
-        raw_spec = raw_spec[0] if raw_spec else ''
-    summary_label = "related dependencies for {}".format(
-            str( raw_spec ).strip() or 'selection'
-    )
+    # Prefer matched identity names — never the raw comma-separated selector.
+    if targets:
+        matched_names = sorted( {
+                ( item.dependency or '' ).strip()
+                for item in targets if ( item.dependency or '' ).strip()
+        } )
+        summary_label = "related dependencies for {}".format(
+                ', '.join( matched_names ) if matched_names else 'selection'
+        )
+    else:
+        summary_label = None
     used_by_warnings = _collect_used_by_wipe_notices(
             targets, by_path, this_project, default_branch,
     )

--- a/cuppa/core/dependency_removal.py
+++ b/cuppa/core/dependency_removal.py
@@ -3393,7 +3393,7 @@ def _execute_force_wipe(
     if not summary_label:
         summary_label = (
                 'unreferenced dependencies' if unreferenced
-                else 'related dependencies for selection'
+                else 'related dependencies'
         )
     actionable_downloads = [ item for item in download_targets if not item.missing ]
     if not targets and not actionable_downloads:
@@ -3737,17 +3737,9 @@ def force_wipe_dependencies( construct, cuppa_env, out=None ):
     leftovers, download_leftovers = _collect_force_wipe_context(
             rows, dl_rows, targets, download_targets,
     )
-    # Prefer matched identity names — never the raw comma-separated selector.
-    if targets:
-        matched_names = sorted( {
-                ( item.dependency or '' ).strip()
-                for item in targets if ( item.dependency or '' ).strip()
-        } )
-        summary_label = "related dependencies for {}".format(
-                ', '.join( matched_names ) if matched_names else 'selection'
-        )
-    else:
-        summary_label = None
+    # Neutral section root — do not list token / identity names (noisy and often
+    # still encoded folder stems). Leaves under wiped / remaining carry identity.
+    summary_label = 'related dependencies'
     used_by_warnings = _collect_used_by_wipe_notices(
             targets, by_path, this_project, default_branch,
     )

--- a/cuppa/location.py
+++ b/cuppa/location.py
@@ -177,8 +177,16 @@ class Location(object):
 
     @staticmethod
     def _unqualified_wipe_name( path ):
-        """Prefer a short registry-style name for ``name/@`` wipe tokens."""
-        from cuppa.core.dependency_identity import short_name_from_git_tree
+        """Prefer a short registry-style name for ``name/@`` wipe tokens.
+
+        Git remotes yield host/path display names (``gitlab.example/org/widget``);
+        force-wipe matching uses registry-style leaves (``widget``), so reduce to
+        the final path segment before emitting a hint.
+        """
+        from cuppa.core.dependency_identity import (
+            short_name_from_git_tree,
+            wipe_token_leaf_name,
+        )
         from cuppa.core.dependency_storage import split_location_folder_name
 
         short = None
@@ -186,12 +194,14 @@ class Location(object):
             short, _repository = short_name_from_git_tree( path )
         except ( TypeError, ValueError, OSError ):
             short = None
-        if short and not str( short ).startswith(
-                ( 'git_', 'https_', 'svn_', 'hg_', 'bzr_', 'http_' )
-        ):
-            return short
+        leaf = wipe_token_leaf_name( short )
+        if leaf:
+            return leaf
         folder = os.path.basename( str( path ).rstrip( '\\/' ) )
         stem, _qualifier = split_location_folder_name( folder )
+        leaf = wipe_token_leaf_name( stem ) or wipe_token_leaf_name( folder )
+        if leaf:
+            return leaf
         return stem or folder or '-'
 
 

--- a/cuppa/location.py
+++ b/cuppa/location.py
@@ -158,7 +158,30 @@ class Location(object):
         return getattr( self, '_default_branch', None )
 
 
+    def _should_notice_unqualified_duplicate( self ):
+        """True when unused stem pairs should be logged / queued for wipe hints.
+
+        Ordinary builds still prefer the canonical folder; notices are for
+        ``--list-dependencies`` / remove / purge / wipe only. Compact list
+        scope hides the sibling leaf, so notices there would be invisible.
+        """
+        cuppa_env = getattr( self, '_cuppa_env', None ) or {}
+        from cuppa.core import dependency_actions
+        if not dependency_actions.wants_dependency_action( cuppa_env ):
+            return False
+        if cuppa_env.get( 'list_dependencies' ):
+            scope = dependency_actions.normalise_list_scope(
+                    cuppa_env.get( 'list_scope' )
+                    or cuppa_env.get( 'list_dependencies_scope' )
+            )
+            if scope == 'compact':
+                return False
+        return True
+
+
     def _warn_unqualified_duplicate( self, unqualified, canonical ):
+        if not self._should_notice_unqualified_duplicate():
+            return
         warned = getattr( Location, '_unqualified_duplicate_warned', None )
         if warned is None:
             Location._unqualified_duplicate_warned = set()
@@ -167,10 +190,11 @@ class Location(object):
         if key in warned:
             return
         warned.add( key )
-        logger.warn(
+        # Disk-space cleanup hint only — trees carry the user-facing notice.
+        logger.debug(
             "Location has both [{}] and [{}]; using the canonical branch folder. "
             "The unqualified copy is unused by this selection and is a removal candidate.".format(
-                    as_warning( unqualified ), as_info( canonical )
+                    unqualified, canonical
             )
         )
 

--- a/docs/modules/ROOT/pages/dependencies-location.adoc
+++ b/docs/modules/ROOT/pages/dependencies-location.adoc
@@ -31,13 +31,16 @@ xref:build-layout.adoc[Build layout] for the defaults and for how to move them.
 VCS folders use a canonical `stem@<branch>` spelling once the branch is known — including the
 default branch (`--location-default-branch`, usually `master`). An older unqualified stem is
 kept if it is the only copy on disk (cuppa does not move or delete it). When both exist, resolve
-uses the canonical folder and warns that the unqualified duplicate is unused by this selection.
-Any command that triggers that warning also prints a dry-run
+uses the canonical folder. Dependency-management commands
+(`--list-dependencies`, `--remove-dependencies`, `--purge-dependencies`, wipe / force-wipe)
+record that pair at **debug** log level and surface it in their trees: remove-coloured
+`@master (unqualified)` (or `@main (unqualified)`, …) leaves and a dry-run
 `--force-wipe-dependencies=` hint using the `name/@` shorthand (bare `@` means the unqualified
-stem, not `@master`) after that command's report footer, unless you are already on
-`--list-dependencies` — that mode labels the
-unused sibling `@master (unqualified)` (or `@main (unqualified)`, …) in remove colour and prints
-the same hint in its footer (merging inventory tokens with any Location warnings). The label uses
+stem, not `@master`) after the report footer. Ordinary builds prefer the canonical folder
+quietly — they do not print Location warnings or wipe hints for this case.
+`--list-dependencies` merges inventory tokens with any Location notices unless
+`--list-scope=compact` (compact hides unused siblings, so notices and wipe candidates for
+those leaves are omitted). The label uses
 `--location-default-branch` (default `master`); it does
 not inspect HEAD inside the unqualified clone. Drop `-n` after confirming. Under `--offline`,
 candidates whose inventory `used_by` names another project are omitted from that hint.

--- a/docs/modules/ROOT/pages/dependencies-managing.adoc
+++ b/docs/modules/ROOT/pages/dependencies-managing.adoc
@@ -453,17 +453,19 @@ A token with no matching leaf (or a matched path that is already gone) does **no
 rest of the list: other tokens still wipe, and each miss appears in the judgement tree (warning
 on dry-run, past-tense note after a real wipe). Ambiguous non-wildcard tokens still fail hard.
 
-When both an unqualified stem and `stem@<default>` exist, Location warns and (for every command
-except `--list-dependencies`) prints the same dry-run `--force-wipe-dependencies=` hint with
-`name/@` tokens after that command's report footer. `--list-dependencies` colours the unused `@<default> (unqualified)` leaf with
-the remove accent and ends with that hint in its footer (including under `--list-scope=compact`,
-where those rows are hidden). Under `--offline`, candidates with inventory `used_by` from another
-project are omitted from that hint. Confirm with `-n`, then drop `-n` to wipe. If inventory
-still records another project's use of the unqualified path, force-wipe reports it after the
-report table (judgement tree, like other removal notices). On a dry-run (`-n`) that notice is a
-warning in the present tense so you can still abort; after a real wipe it becomes a past-tense
-note (`wiped…`, `removing the copy was safe`) and explains that proceeding was safe when the
-canonical folder is present.
+When both an unqualified stem and `stem@<default>` exist, dependency-management commands
+(list / remove / purge / wipe) note the pair at debug log level. Those commands also print a
+dry-run `--force-wipe-dependencies=` hint with `name/@` tokens after the report footer
+(except `--list-dependencies`, which colours the unused `@<default> (unqualified)` leaf with
+the remove accent and ends with that hint in its footer). Under `--list-scope=compact` the
+sibling is hidden, so Location notices and wipe candidates for it are omitted — use
+`referenced` or `all` to inspect them. Under `--offline`, candidates with inventory `used_by`
+from another project are omitted from that hint. Confirm with `-n`, then drop `-n` to wipe. If
+inventory still records another project's use of the unqualified path, force-wipe reports it
+after the report table (judgement tree, like other removal notices). On a dry-run (`-n`) that
+notice is a warning in the present tense so you can still abort; after a real wipe it becomes a
+past-tense note (`wiped…`, `removing the copy was safe`) and explains that proceeding was safe
+when the canonical folder is present.
 
 Exact tokens must resolve to exactly one leaf (zero or multiple → error with candidates).
 Shell / `fnmatch` wildcards (`*`, `?`, `[…]`) on either side wipe **all** matching leaves —

--- a/tests/integration/test_list_dependencies.py
+++ b/tests/integration/test_list_dependencies.py
@@ -734,8 +734,7 @@ cuppa.run(
     assert "--force-wipe-dependencies=" in plain
     assert "widget/@" in plain
     assert "Drop -n and re-run after confirming" in plain
-    err = (text.stderr or "") + (listed.stderr or "")
-    assert "removal candidate" in err or "unqualified" in plain
+    # Location notice is debug; the tree / wipe hint is the user-facing signal.
 
     compact = run_cuppa(
         project,
@@ -747,6 +746,8 @@ cuppa.run(
     )
     assert_success(compact)
     compact_plain = strip_ansi(compact.stdout)
-    assert "--force-wipe-dependencies=" in compact_plain
-    assert "widget/@" in compact_plain
+    # Compact hides the sibling — do not advertise a wipe you cannot inspect.
+    assert "--force-wipe-dependencies=" not in compact_plain
     assert "@master (unqualified)" not in compact_plain
+    compact_err = compact.stderr or ""
+    assert "removal candidate" not in compact_err

--- a/tests/unit/test_dependency_identity.py
+++ b/tests/unit/test_dependency_identity.py
@@ -31,6 +31,17 @@ def test_short_name_from_https_strips_git_suffix():
         'github.com/fmtlib/fmt'
 
 
+def test_wipe_token_leaf_name_reduces_host_path():
+    from cuppa.core.dependency_identity import wipe_token_leaf_name
+
+    assert wipe_token_leaf_name( 'gitlab.example/org/widget' ) == 'widget'
+    assert wipe_token_leaf_name( 'github.com/fmtlib/fmt.git' ) == 'fmt'
+    assert wipe_token_leaf_name( 'widget' ) == 'widget'
+    assert wipe_token_leaf_name( 'git_https_example.com__org_widget.git' ) is None
+    assert wipe_token_leaf_name( '' ) is None
+    assert wipe_token_leaf_name( None ) is None
+
+
 def test_boost_archive_from_underscored_folder():
     name, version = boost_archive_from_folder(
             'https_boostorg.jfrog.io__artifactory_main_release_1.86.0_source_boost_1_86_0.tar.gz'

--- a/tests/unit/test_dependency_removal.py
+++ b/tests/unit/test_dependency_removal.py
@@ -313,8 +313,8 @@ def test_row_matches_force_token_host_path_equals_leaf():
     assert dependency_removal._row_matches_force_token( host_path_row, 'widget', '@' )
 
 
-def test_force_wipe_summary_label_uses_matched_names( tmp_path, monkeypatch ):
-    """Report parent must not echo the raw comma-separated selector (#178)."""
+def test_force_wipe_summary_label_is_neutral( tmp_path, monkeypatch ):
+    """Report parent is ``related dependencies``, not a token / name dump (#178)."""
     import io
     from cuppa.core import dependency_actions, dependency_downloads
 
@@ -363,7 +363,8 @@ def test_force_wipe_summary_label_uses_matched_names( tmp_path, monkeypatch ):
     assert status == 0
     text = out.getvalue()
     assert raw not in text
-    assert 'related dependencies for boost' in text
+    assert 'related dependencies for' not in text
+    assert 'related dependencies' in text
 
 
 def test_force_token_is_wildcard():

--- a/tests/unit/test_dependency_removal.py
+++ b/tests/unit/test_dependency_removal.py
@@ -291,6 +291,81 @@ def test_row_matches_force_token_bare_at_is_unqualified_stem():
     assert not dependency_removal._row_matches_force_token( archive, 'boost', '@' )
 
 
+def test_row_matches_force_token_host_path_equals_leaf():
+    """Host/path wipe tokens match registry-style leaves and the reverse (#178)."""
+    unqualified = {
+        'short_name': 'widget',
+        'dependency': 'widget',
+        'qualifier': '@master (unqualified)',
+        'type': 'repository',
+        'path': '/tmp/git_https_example.com__org_widget.git',
+    }
+    assert dependency_removal._row_matches_force_token(
+            unqualified, 'gitlab.example/org/widget', '@'
+    )
+    host_path_row = {
+        'short_name': 'gitlab.example/org/widget',
+        'dependency': 'gitlab.example/org/widget',
+        'qualifier': '@master (unqualified)',
+        'type': 'repository',
+        'path': '/tmp/git_https_example.com__org_widget.git',
+    }
+    assert dependency_removal._row_matches_force_token( host_path_row, 'widget', '@' )
+
+
+def test_force_wipe_summary_label_uses_matched_names( tmp_path, monkeypatch ):
+    """Report parent must not echo the raw comma-separated selector (#178)."""
+    import io
+    from cuppa.core import dependency_actions, dependency_downloads
+
+    root = tmp_path / 'deps'
+    downloads = tmp_path / 'downloads'
+    root.mkdir()
+    downloads.mkdir()
+    leaf = root / 'boost_1_86_0'
+    leaf.mkdir()
+    ( leaf / 'x' ).write_text( 'old' )
+
+    rows = [
+            {
+                'short_name': 'boost',
+                'dependency': 'boost',
+                'qualifier': '1.86.0',
+                'type': 'archive',
+                'kind': 'archive',
+                'path': str( leaf ),
+                'size_bytes': 1,
+                'state': 'unreferenced',
+            },
+    ]
+    monkeypatch.setattr(
+            dependency_actions, '_collect_rows',
+            lambda *a, **k: { 'rows': rows },
+    )
+    monkeypatch.setattr(
+            dependency_downloads, 'collect_download_rows',
+            lambda *a, **k: { 'rows': [] },
+    )
+    monkeypatch.setattr( dependency_removal, '_inventory_by_path', lambda _root: {} )
+
+    raw = 'boost/1.86.0,gitlab.example/org/widget/@'
+    cuppa_env = {
+            'force_wipe_dependencies': raw,
+            'dependencies_root': str( root ),
+            'downloads_root': str( downloads ),
+            'sconstruct_dir': str( tmp_path / 'proj' ),
+            'dry_run': True,
+            'location_default_branch': 'master',
+    }
+    ( tmp_path / 'proj' ).mkdir()
+    out = io.StringIO()
+    status = dependency_removal.force_wipe_dependencies( None, cuppa_env, out=out )
+    assert status == 0
+    text = out.getvalue()
+    assert raw not in text
+    assert 'related dependencies for boost' in text
+
+
 def test_force_token_is_wildcard():
     assert not dependency_removal.force_token_is_wildcard( 'boost', '1.86.0' )
     assert dependency_removal.force_token_is_wildcard( 'boost', '1.8*' )

--- a/tests/unit/test_list_scope.py
+++ b/tests/unit/test_list_scope.py
@@ -400,6 +400,32 @@ def test_mark_unqualified_duplicate_rows_only_unused_siblings():
     assert 'removal_candidate' not in rows[2]
 
 
+def test_mark_unqualified_duplicate_rows_host_path_only_short_name():
+    """When only host/path short names exist, still emit leaf ``name/@`` (#178)."""
+    rows = [
+            {
+                **_row( 'gitlab.example/org/widget', 'referenced', 100 ),
+                'qualifier': '@master',
+                'path': '/tmp/git_https_example.com__org_widget.git@master',
+                'type': 'repository',
+                'kind': 'repository',
+                'short_name': 'gitlab.example/org/widget',
+                'dependency': 'gitlab.example/org/widget',
+            },
+            {
+                **_row( 'gitlab.example/org/widget', 'unreferenced', 80 ),
+                'qualifier': '@master (unqualified)',
+                'path': '/tmp/git_https_example.com__org_widget.git',
+                'type': 'repository',
+                'kind': 'repository',
+                'short_name': 'gitlab.example/org/widget',
+                'dependency': 'gitlab.example/org/widget',
+            },
+    ]
+    tokens = dependency_actions.mark_unqualified_duplicate_rows( rows )
+    assert tokens == [ 'widget/@' ]
+
+
 def test_mark_unqualified_duplicate_rows_groups_by_folder_stem():
     """Resolve may label the selected leaf ``widget`` while the stem stays encoded."""
     rows = [

--- a/tests/unit/test_list_scope.py
+++ b/tests/unit/test_list_scope.py
@@ -482,7 +482,7 @@ def test_mark_unqualified_duplicate_rows_with_unreferenced_branch_sibling():
     assert rows[1].get( 'removal_candidate' ) == 'unqualified_duplicate'
 
 
-def test_apply_list_scope_preserves_unqualified_duplicate_tokens():
+def test_apply_list_scope_drops_unqualified_tokens_for_compact():
     rows = [
             {
                 **_row( 'widget', 'referenced', 100 ),
@@ -497,5 +497,7 @@ def test_apply_list_scope_preserves_unqualified_duplicate_tokens():
     data = _data( rows )
     data['unqualified_duplicate_tokens'] = [ 'widget/@' ]
     compact = dependency_actions.apply_list_scope( data, 'compact' )
-    assert compact['unqualified_duplicate_tokens'] == [ 'widget/@' ]
+    assert compact['unqualified_duplicate_tokens'] == []
     assert len( compact['rows'] ) == 1
+    referenced = dependency_actions.apply_list_scope( data, 'referenced' )
+    assert referenced['unqualified_duplicate_tokens'] == [ 'widget/@' ]

--- a/tests/unit/test_location_core.py
+++ b/tests/unit/test_location_core.py
@@ -266,7 +266,8 @@ def test_extract_zip_strips_top_directory(tmp_path):
     assert not (target / "pkg-1.0").exists()
 
 
-def _select_location(tmp_path, default_branch="master", relative=True, match_branch=None):
+def _select_location(tmp_path, default_branch="master", relative=True, match_branch=None,
+                     list_dependencies=False, list_scope=None):
     location = Location.__new__(Location)
     location._cuppa_env = {
         "clean": False,
@@ -274,6 +275,8 @@ def _select_location(tmp_path, default_branch="master", relative=True, match_bra
         "location_match_current_branch": False,
         "location_match_branch": match_branch,
         "location_match_tag": None,
+        "list_dependencies": list_dependencies,
+        "list_scope": list_scope,
     }
     location._supports_relative_versioning = relative
     location._default_branch = default_branch
@@ -300,25 +303,54 @@ def test_select_repository_directory_canonical_only(tmp_path):
     assert location._select_repository_directory(stem) == stem + "@master"
 
 
-def test_select_repository_directory_both_prefers_canonical_and_warns(tmp_path, caplog):
+def test_select_repository_directory_both_prefers_canonical_quietly_on_build(tmp_path, caplog):
+    """Ordinary builds prefer canonical without logging or wipe-token bookkeeping."""
     location, stem = _select_location(tmp_path)
     os.mkdir(stem)
     os.mkdir(stem + "@master")
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("DEBUG"):
+        chosen = location._select_repository_directory(stem)
+    assert chosen == stem + "@master"
+    assert "removal candidate" not in caplog.text
+    assert Location.take_unqualified_duplicate_wipe_tokens() == []
+
+
+def test_select_repository_directory_both_notices_on_list_dependencies(tmp_path, caplog):
+    location, stem = _select_location(tmp_path, list_dependencies=True)
+    os.mkdir(stem)
+    os.mkdir(stem + "@master")
+    with caplog.at_level("DEBUG"):
         chosen = location._select_repository_directory(stem)
     assert chosen == stem + "@master"
     assert "removal candidate" in caplog.text
-    # Second call does not warn again.
+    # Debug, not warn — no WARNING records for this notice.
+    assert not any(
+            record.levelname == "WARNING" and "removal candidate" in record.getMessage()
+            for record in caplog.records
+    )
+    # Second call does not notice again.
     caplog.clear()
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("DEBUG"):
         assert location._select_repository_directory(stem) == stem + "@master"
     assert "removal candidate" not in caplog.text
+
+
+def test_select_repository_directory_both_skips_notice_for_compact(tmp_path, caplog):
+    location, stem = _select_location(
+            tmp_path, list_dependencies=True, list_scope='compact',
+    )
+    os.mkdir(stem)
+    os.mkdir(stem + "@master")
+    with caplog.at_level("DEBUG"):
+        assert location._select_repository_directory(stem) == stem + "@master"
+    assert "removal candidate" not in caplog.text
+    assert Location.take_unqualified_duplicate_wipe_tokens() == []
 
 
 def test_take_unqualified_duplicate_wipe_tokens_consumes_pending(tmp_path):
     from cuppa.location import Location
 
-    location, stem = _select_location(tmp_path)
+    location, stem = _select_location(tmp_path, list_dependencies=True)
     os.mkdir(stem)
     os.mkdir(stem + "@master")
     Location._unqualified_duplicate_warned = set()
@@ -348,7 +380,7 @@ def test_emit_location_unqualified_duplicate_hints_writes_once(tmp_path):
     from cuppa.core import dependency_actions
     from cuppa.location import Location
 
-    location, stem = _select_location(tmp_path)
+    location, stem = _select_location(tmp_path, list_dependencies=True)
     os.mkdir(stem)
     os.mkdir(stem + "@master")
     Location._unqualified_duplicate_warned = set()
@@ -358,7 +390,7 @@ def test_emit_location_unqualified_duplicate_hints_writes_once(tmp_path):
     text = out.getvalue()
     assert "force-wipe-dependencies=" in text
     assert "/@" in text
-    assert "see earlier warnings" in text
+    assert "noted during resolve" in text
     assert "Drop -n" in text
     out2 = io.StringIO()
     dependency_actions.emit_location_unqualified_duplicate_hints(out=out2)
@@ -370,7 +402,7 @@ def test_force_wipe_emits_unqualified_hint_after_report(tmp_path):
     from cuppa.core import dependency_removal
     from cuppa.location import Location
 
-    location, stem = _select_location(tmp_path)
+    location, stem = _select_location(tmp_path, list_dependencies=True)
     os.mkdir(stem)
     os.mkdir(stem + "@master")
     Location._unqualified_duplicate_warned = set()
@@ -394,11 +426,11 @@ def test_force_wipe_emits_unqualified_hint_after_report(tmp_path):
 
 
 def test_select_repository_directory_url_already_qualified_is_not_double_suffixed(tmp_path, caplog):
-    location, stem = _select_location(tmp_path)
+    location, stem = _select_location(tmp_path, list_dependencies=True)
     qualified = stem + "@master"
     os.mkdir(stem)
     os.mkdir(qualified)
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("DEBUG"):
         chosen = location._select_repository_directory(qualified)
     assert chosen == qualified
     assert "removal candidate" in caplog.text

--- a/tests/unit/test_location_core.py
+++ b/tests/unit/test_location_core.py
@@ -329,6 +329,21 @@ def test_take_unqualified_duplicate_wipe_tokens_consumes_pending(tmp_path):
     assert Location.take_unqualified_duplicate_wipe_tokens() == []
 
 
+def test_unqualified_wipe_name_reduces_host_path(monkeypatch, tmp_path):
+    """Location hints must emit ``widget/@``, not ``host/org/widget/@`` (#178)."""
+    from cuppa.location import Location
+
+    def fake_git_tree( path ):
+        return 'gitlab.example/org/widget', 'ssh://git@gitlab.example/org/widget.git'
+
+    monkeypatch.setattr(
+            'cuppa.core.dependency_identity.short_name_from_git_tree',
+            fake_git_tree,
+    )
+    stem = str( tmp_path / 'git_https_gitlab.example__org_widget.git' )
+    assert Location._unqualified_wipe_name( stem ) == 'widget'
+
+
 def test_emit_location_unqualified_duplicate_hints_writes_once(tmp_path):
     from cuppa.core import dependency_actions
     from cuppa.location import Location


### PR DESCRIPTION
## Summary
- Location / list unqualified-stem wipe hints now emit matching `name/@` leaf tokens instead of host/path forms that reported `no leaf matches` (#178).
- Force-wipe also accepts host/path ↔ leaf name equivalence when matching.
- Dry-run report parent summarises matched identities, not the raw comma-separated selector.
- Unqualified stem-duplicate Location notices run only for list / remove / purge / wipe (debug log, not warn); ordinary builds stay quiet.
- `--list-scope=compact` omits those notices and wipe candidates so the tree does not advertise hidden leaves.

## Test plan
- [x] `flake8 cuppa` / `pylint -E cuppa`
- [x] `pytest -m unit`
- [x] `pytest -m integration`
- [x] CI green on the matrix
