### PR TITLE
prof-report-parser: Profiles violation report parser (#184 slice A)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,6 +272,20 @@ create_pull_request( title='…', body='…', labels=['impact:minor'] )
 update_pull_request( number=154, title='…', body='…' )
 ```
 
+### Pull request bodies
+
+When **opening** or updating an open PR (before it is merge-ready), the description should carry
+only what reviewers and CI need up front:
+
+- **Summary** — what the PR does and why; link umbrella issues and design plans when relevant.
+- **Test plan** — checklist of verification steps (local gate, focused tests, CI matrix).
+
+Do **not** put a **squash commit message** (or “suggested squash message”) in the PR body at
+open time. Squash title and body are chosen **once the PR is green and merge-ready**, from the
+**actual diff** against the base branch plus context from related issues and plans — not from what
+was intended when the PR was opened. Late fixes, scope trims, and housekeeping commits often change
+that story.
+
 ### Before pushing a pull request branch
 
 **Always run the full local Python test gate before `git push`.** Waiting for CI to report a unit
@@ -354,10 +368,13 @@ commits.
    checklist is
    stale — do not treat an unchecked “CI green” box as unknown when `watch-pr` already
    succeeded.
-6. **Squash commit message** — when the person will squash-merge, draft a single commit message
-   that matches this repo’s style (imperative subject, blank line, why/what prose, no trailers;
-   reference umbrella issues in prose, not `Fixes`/`Closes` unless that slice should close them).
-   Offer it in the chat (and optionally paste into the GitHub squash UI) before merge.
+6. **Squash commit message** — when the person will squash-merge, read the PR diff against base
+   (for example `git diff origin/master...HEAD`), the linked issue, and any design plan progress
+   snapshot, then draft a single commit message that matches what **actually landed** and this
+   repo’s style (imperative subject, blank line, why/what prose, no trailers; reference umbrella
+   issues in prose, not `Fixes`/`Closes` unless that slice should close them). Offer it in the
+   chat (and optionally paste into the GitHub squash UI) before merge — do not add it to the PR
+   body when opening the pull request (see [Pull request bodies](#pull-request-bodies)).
 
 ### After pushing a pull request branch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Profiles violation report parser groundwork ([#184](https://github.com/ja11sop/cuppa/issues/184)):
+  `cuppa/cpp/cxx_profiles_report.py` parses Clang Profiles diagnostics, classifies rule
+  ids, and dedupes violations per scope (slice A; CLI and HTML in later slices).
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Profiles violation report parser groundwork ([#184](https://github.com/ja11sop/cuppa/issues/184)):
   `cuppa/cpp/cxx_profiles_report.py` parses Clang Profiles diagnostics, classifies rule
   ids, and dedupes violations per scope (slice A; CLI and HTML in later slices).
+  `python -m scripts.replay_profiles_capture` replays saved build captures using
+  ``Progress( … )`` scope markers.
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@ Maintainer **target bundle** for the release (plans landed; implementation follo
 | ID | Work | Plan |
 |----|------|------|
 | `console-terse-output` | `--terse-output` Phase 1 (one-line success; failures verbose) | [`terse-build-output.md`](design/plans/terse-build-output.md) |
-| `profiles-violation-report` | `--cxx-profiles-report` slices A–D (parser, **parallel-safe spawn scope**, HTML/JSON, manifest) | [`cxx-profiles-report.md`](design/plans/cxx-profiles-report.md) |
+| `profiles-violation-report` | `--cxx-profiles-report` A–D (`prof-report-parser`, `prof-report-collector`, `prof-report-html`, `prof-report-manifest`) | [`cxx-profiles-report.md`](design/plans/cxx-profiles-report.md) |
 | `console-log-hygiene` | Demote toolchain registration spam; fix variant default log text | [`build-log-hygiene.md`](design/plans/build-log-hygiene.md) |
 | `cli-info` | `cuppa --info` — version without loading sconstruct | [`cuppa-info.md`](design/plans/cuppa-info.md) |
 
@@ -152,7 +152,7 @@ Umbrella: [#127](https://github.com/ja11sop/cuppa/issues/127) ([#177](https://gi
 
 | ID | Work | Priority | Notes |
 |----|------|----------|-------|
-| `profiles-violation-report` | `--cxx-profiles-report`: capture, classify, dedupe, HTML+JSON inventory | High | [`design/plans/cxx-profiles-report.md`](design/plans/cxx-profiles-report.md); **1.8.0 target** — [#184](https://github.com/ja11sop/cuppa/issues/184) |
+| `profiles-violation-report` | `--cxx-profiles-report`: capture, classify, dedupe, HTML+JSON inventory | High | [`design/plans/cxx-profiles-report.md`](design/plans/cxx-profiles-report.md); **1.8.0 target** — [#184](https://github.com/ja11sop/cuppa/issues/184); slices `prof-report-parser` … `prof-report-manifest` |
 | `profiles-designators` | Additional profile names as Alliance Clang / WG21 stabilise | Medium | Cuppa passes opaque strings through |
 | `profiles-native-enforce` | Wire `profiles_enforce_flags` when a compiler adds native enforce flags | Low | Hook exists; `-include` fallback remains |
 | `profiles-carve-outs` | Build policy to skip session enforce on selected paths | Low | Separate from source attributes |

--- a/cuppa/cpp/cxx_profiles_report.py
+++ b/cuppa/cpp/cxx_profiles_report.py
@@ -1,0 +1,335 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   C++ Profiles violation report — parse, classify, scope-aware aggregation
+#-------------------------------------------------------------------------------
+
+import re
+from collections import namedtuple
+
+
+ProfilesScope = namedtuple(
+    'ProfilesScope',
+    [ 'sconscript', 'variant_dir', 'toolchain', 'variant_label' ],
+)
+
+ProfilesDiagnostic = namedtuple(
+    'ProfilesDiagnostic',
+    [
+        'path',
+        'line',
+        'column',
+        'message',
+        'profile',
+        'normalised_message',
+        'rule_id',
+    ],
+)
+
+ProfilesLocation = namedtuple(
+    'ProfilesLocation',
+    [
+        'scope',
+        'path',
+        'line',
+        'column',
+        'profile',
+        'normalised_message',
+        'rule_id',
+        'reference_count',
+        'raw_message',
+    ],
+)
+
+_UNSCOPED = ProfilesScope(
+    sconscript='_unscoped',
+    variant_dir='_unscoped',
+    toolchain='_unscoped',
+    variant_label='_unscoped',
+)
+
+_PROFILE_SUFFIX = " under profile '"
+_QUOTED_FRAGMENT_RE = re.compile( r"'[^']*'" )
+
+_RULE_CLASSIFIERS = (
+    (
+        re.compile(
+            r"^variable '…' must be initialized or marked '…'$"
+        ),
+        'uninit_decl',
+    ),
+    (
+        re.compile(
+            r"^non-local variable '…' requires constant initialization$"
+        ),
+        'static_runtime_init',
+    ),
+    (
+        re.compile(
+            r"^constructor does not initialize member '…'$"
+        ),
+        'ctor_uninit_member',
+    ),
+    (
+        re.compile(
+            r"^constructor does not initialize base class '…'$"
+        ),
+        'ctor_uninit_member',
+    ),
+    (
+        re.compile(
+            r"^pointer to uninitialized memory must be marked '…'$"
+        ),
+        'ref_to_uninit',
+    ),
+)
+
+UNCLASSIFIED_RULE_ID = '_unclassified'
+
+
+def unscoped_profiles_scope():
+    """Return the fallback scope when spawn or Progress attribution is unknown."""
+    return _UNSCOPED
+
+
+def normalise_message( message ):
+    """Collapse quoted identifiers so template and member names share one pattern key."""
+    return _QUOTED_FRAGMENT_RE.sub( "'…'", message )
+
+
+def classify_rule( normalised_message ):
+    """Map a normalised diagnostic message to a Profiles rule id."""
+    for pattern, rule_id in _RULE_CLASSIFIERS:
+        if pattern.match( normalised_message ):
+            return rule_id
+    return UNCLASSIFIED_RULE_ID
+
+
+def parse_profiles_diagnostic( line ):
+    """Parse one Clang Profiles diagnostic line, or return ``None`` if it does not match."""
+    text = line.rstrip( '\r\n' )
+    suffix_index = text.rfind( _PROFILE_SUFFIX )
+    if suffix_index == -1:
+        return None
+
+    profile_end = text.rfind( "'", len( text ) - 1 )
+    if profile_end <= suffix_index:
+        return None
+
+    profile = text[ suffix_index + len( _PROFILE_SUFFIX ):profile_end ]
+    before_profile = text[ :suffix_index ]
+
+    error_marker = ': error: '
+    error_index = before_profile.find( error_marker )
+    if error_index == -1:
+        return None
+
+    message = before_profile[ error_index + len( error_marker ):]
+    location_part = before_profile[ :error_index ]
+
+    column_index = location_part.rfind( ':' )
+    if column_index == -1:
+        return None
+    try:
+        column = int( location_part[ column_index + 1: ] )
+    except ValueError:
+        return None
+
+    rest = location_part[ :column_index ]
+    line_index = rest.rfind( ':' )
+    if line_index == -1:
+        return None
+    try:
+        line_number = int( rest[ line_index + 1: ] )
+    except ValueError:
+        return None
+
+    path = rest[ :line_index ]
+    if not path:
+        return None
+
+    normalised = normalise_message( message )
+    return ProfilesDiagnostic(
+        path=path,
+        line=line_number,
+        column=column,
+        message=message,
+        profile=profile,
+        normalised_message=normalised,
+        rule_id=classify_rule( normalised ),
+    )
+
+
+def location_dedupe_key( scope, diagnostic ):
+    """Return the scope-aware dedupe key for one parsed diagnostic."""
+    return (
+        scope.sconscript,
+        scope.variant_dir,
+        diagnostic.path,
+        diagnostic.line,
+        diagnostic.column,
+        diagnostic.profile,
+        diagnostic.normalised_message,
+    )
+
+
+class ProfilesInventory:
+    """In-memory Profiles violation inventory with scope-aware dedupe."""
+
+    def __init__( self ):
+        self._locations = {}
+
+    def record( self, scope, diagnostic ):
+        """Record one parsed diagnostic, incrementing reference counts for duplicates."""
+        key = location_dedupe_key( scope, diagnostic )
+        existing = self._locations.get( key )
+        if existing is not None:
+            self._locations[ key ] = existing._replace(
+                reference_count=existing.reference_count + 1,
+            )
+            return existing
+
+        location = ProfilesLocation(
+            scope=scope,
+            path=diagnostic.path,
+            line=diagnostic.line,
+            column=diagnostic.column,
+            profile=diagnostic.profile,
+            normalised_message=diagnostic.normalised_message,
+            rule_id=diagnostic.rule_id,
+            reference_count=1,
+            raw_message=diagnostic.message,
+        )
+        self._locations[ key ] = location
+        return location
+
+    def locations( self ):
+        return tuple( self._locations.values() )
+
+    def total_references( self ):
+        return sum( location.reference_count for location in self._locations.values() )
+
+    def unique_locations( self ):
+        return len( self._locations )
+
+    def as_report_model( self ):
+        """Return a minimal JSON-serialisable view model for tests and later HTML."""
+        scopes = {}
+        for location in self._locations.values():
+            scope_key = (
+                location.scope.sconscript,
+                location.scope.variant_dir,
+                location.scope.toolchain,
+            )
+            scope_entry = scopes.setdefault(
+                scope_key,
+                {
+                    'sconscript': location.scope.sconscript,
+                    'variant_dir': location.scope.variant_dir,
+                    'toolchain': location.scope.toolchain,
+                    'variant_label': location.scope.variant_label,
+                    'profiles': {},
+                },
+            )
+            profile_entry = scope_entry[ 'profiles' ].setdefault(
+                location.profile,
+                { 'rules': {}, 'files': {} },
+            )
+            rule_entry = profile_entry[ 'rules' ].setdefault(
+                location.rule_id,
+                { 'total_references': 0, 'unique_files': set(), 'files': {} },
+            )
+            rule_entry[ 'total_references' ] += location.reference_count
+            rule_entry[ 'unique_files' ].add( location.path )
+            file_entry = rule_entry[ 'files' ].setdefault(
+                location.path,
+                { 'total_references': 0, 'locations': [] },
+            )
+            file_entry[ 'total_references' ] += location.reference_count
+            file_entry[ 'locations' ].append(
+                {
+                    'line': location.line,
+                    'column': location.column,
+                    'references': location.reference_count,
+                    'message': location.raw_message,
+                    'normalised_message': location.normalised_message,
+                },
+            )
+
+            file_roll = profile_entry[ 'files' ].setdefault(
+                location.path,
+                { 'total_references': 0, 'rules': {} },
+            )
+            file_roll[ 'total_references' ] += location.reference_count
+            file_rule = file_roll[ 'rules' ].setdefault(
+                location.rule_id,
+                { 'total_references': 0 },
+            )
+            file_rule[ 'total_references' ] += location.reference_count
+
+        serialised_scopes = []
+        for scope_entry in scopes.values():
+            profiles = []
+            for profile_name, profile_data in sorted( scope_entry[ 'profiles' ].items() ):
+                rules = []
+                for rule_id, rule_data in sorted( profile_data[ 'rules' ].items() ):
+                    files = []
+                    for path, file_data in sorted( rule_data[ 'files' ].items() ):
+                        files.append(
+                            {
+                                'path': path,
+                                'total_references': file_data[ 'total_references' ],
+                                'locations': file_data[ 'locations' ],
+                            },
+                        )
+                    rules.append(
+                        {
+                            'rule_id': rule_id,
+                            'total_references': rule_data[ 'total_references' ],
+                            'unique_files': len( rule_data[ 'unique_files' ] ),
+                            'files': files,
+                        },
+                    )
+                files_view = []
+                for path, file_data in sorted( profile_data[ 'files' ].items() ):
+                    rules_on_file = [
+                        {
+                            'rule_id': rule_id,
+                            'total_references': rule_entry[ 'total_references' ],
+                        }
+                        for rule_id, rule_entry in sorted( file_data[ 'rules' ].items() )
+                    ]
+                    files_view.append(
+                        {
+                            'path': path,
+                            'total_references': file_data[ 'total_references' ],
+                            'rules': rules_on_file,
+                        },
+                    )
+                profiles.append(
+                    {
+                        'profile': profile_name,
+                        'rules': rules,
+                        'files': files_view,
+                    },
+                )
+            serialised_scopes.append(
+                {
+                    'sconscript': scope_entry[ 'sconscript' ],
+                    'variant_dir': scope_entry[ 'variant_dir' ],
+                    'toolchain': scope_entry[ 'toolchain' ],
+                    'variant_label': scope_entry[ 'variant_label' ],
+                    'profiles': profiles,
+                },
+            )
+
+        return {
+            'scopes': serialised_scopes,
+            'rollup': {
+                'total_references': self.total_references(),
+                'unique_locations': self.unique_locations(),
+            },
+        }

--- a/cuppa/cpp/cxx_profiles_report.py
+++ b/cuppa/cpp/cxx_profiles_report.py
@@ -165,11 +165,15 @@ def parse_profiles_diagnostic( line ):
 
 
 def parse_variant_scope_fields( variant_dir ):
-    """Derive toolchain and variant label from a cuppa variant directory path."""
+    """Derive toolchain and variant label from a cuppa variant directory path.
+
+    Variant dirs end with ``<toolchain>/<variant>/<arch>/<abi>`` under ``_build/…`` —
+    see ``cuppa.core.build_layout.tool_variant_dir``.
+    """
     parts = variant_dir.strip( '/' ).split( '/' )
-    if len( parts ) >= 4 and parts[0] == '_build':
-        return parts[ 2 ], parts[ 3 ]
-    return '_unknown', '_unknown'
+    if len( parts ) < 6 or parts[ 0 ] != '_build':
+        return '_unknown', '_unknown'
+    return parts[ -4 ], parts[ -3 ]
 
 
 def parse_progress_line( line ):

--- a/cuppa/cpp/cxx_profiles_report.py
+++ b/cuppa/cpp/cxx_profiles_report.py
@@ -53,6 +53,7 @@ _UNSCOPED = ProfilesScope(
 
 _PROFILE_SUFFIX = " under profile '"
 _QUOTED_FRAGMENT_RE = re.compile( r"'[^']*'" )
+_PROGRESS_LINE_RE = re.compile( r'^Progress\(\s*(.+)\s*\)\s*$' )
 
 _RULE_CLASSIFIERS = (
     (
@@ -161,6 +162,133 @@ def parse_profiles_diagnostic( line ):
         normalised_message=normalised,
         rule_id=classify_rule( normalised ),
     )
+
+
+def parse_variant_scope_fields( variant_dir ):
+    """Derive toolchain and variant label from a cuppa variant directory path."""
+    parts = variant_dir.strip( '/' ).split( '/' )
+    if len( parts ) >= 4 and parts[0] == '_build':
+        return parts[ 2 ], parts[ 3 ]
+    return '_unknown', '_unknown'
+
+
+def parse_progress_line( line ):
+    """Parse one ``Progress( … )`` console line, or return ``None`` if it does not match."""
+    match = _PROGRESS_LINE_RE.match( line.rstrip( '\r\n' ) )
+    if not match:
+        return None
+
+    inner = match.group( 1 ).strip()
+    if inner == 'SconstructBegin':
+        return 'sconstruct_begin', None, None
+    if inner == 'SconstructEnd':
+        return 'sconstruct_end', None, None
+    if inner.startswith( 'Begin sconscript: [' ) and inner.endswith( ']' ):
+        return 'begin', inner[ len( 'Begin sconscript: [' ): -1 ], None
+    if inner.startswith( 'End sconscript: [' ) and inner.endswith( ']' ):
+        return 'end', inner[ len( 'End sconscript: [' ): -1 ], None
+    if inner.startswith( 'Starting variant: [' ) and inner.endswith( ']' ):
+        return 'started', None, inner[ len( 'Starting variant: [' ): -1 ]
+    if inner.startswith( 'Finished variant: [' ) and inner.endswith( ']' ):
+        return 'finished', None, inner[ len( 'Finished variant: [' ): -1 ]
+    return None
+
+
+class ProfilesScopeStack:
+    """Track the open Progress scope while replaying a serial capture file."""
+
+    def __init__( self ):
+        self._sconscript = None
+        self._variant_dir = None
+
+    def apply_progress( self, event, sconscript, variant_dir ):
+        if event == 'begin':
+            self._sconscript = sconscript
+        elif event == 'started':
+            self._variant_dir = variant_dir
+        elif event == 'finished':
+            if self._variant_dir == variant_dir:
+                self._variant_dir = None
+        elif event == 'end':
+            if self._sconscript == sconscript:
+                self._sconscript = None
+                self._variant_dir = None
+        elif event == 'sconstruct_end':
+            self._sconscript = None
+            self._variant_dir = None
+
+    def current_scope( self ):
+        if self._sconscript and self._variant_dir:
+            toolchain, variant_label = parse_variant_scope_fields( self._variant_dir )
+            return ProfilesScope(
+                sconscript=self._sconscript,
+                variant_dir=self._variant_dir,
+                toolchain=toolchain,
+                variant_label=variant_label,
+            )
+        return unscoped_profiles_scope()
+
+
+def replay_profiles_capture( lines ):
+    """Replay saved build output lines into a scoped ``ProfilesInventory``."""
+    inventory = ProfilesInventory()
+    stack = ProfilesScopeStack()
+    unscoped_diagnostics = 0
+
+    for line in lines:
+        progress = parse_progress_line( line )
+        if progress is not None:
+            stack.apply_progress( *progress )
+            continue
+
+        diagnostic = parse_profiles_diagnostic( line )
+        if diagnostic is None:
+            continue
+
+        scope = stack.current_scope()
+        if scope.sconscript == '_unscoped':
+            unscoped_diagnostics += 1
+        inventory.record( scope, diagnostic )
+
+    return inventory, unscoped_diagnostics
+
+
+def format_capture_summary( inventory, unscoped_diagnostics=0 ):
+    """Return a human-readable summary of a replayed capture."""
+    lines = [
+        'total_references: {}'.format( inventory.total_references() ),
+        'unique_locations: {}'.format( inventory.unique_locations() ),
+    ]
+    if unscoped_diagnostics:
+        lines.append( 'unscoped_diagnostics: {}'.format( unscoped_diagnostics ) )
+
+    model = inventory.as_report_model()
+    for scope in model[ 'scopes' ]:
+        lines.append( '' )
+        lines.append(
+            'scope: {}  {}'.format( scope[ 'sconscript' ], scope[ 'variant_dir' ] )
+        )
+        lines.append(
+            '  toolchain: {}  variant: {}'.format(
+                scope[ 'toolchain' ],
+                scope[ 'variant_label' ],
+            )
+        )
+        for profile in scope[ 'profiles' ]:
+            lines.append( '  profile: {}'.format( profile[ 'profile' ] ) )
+            for rule in sorted(
+                profile[ 'rules' ],
+                key=lambda entry: ( -entry[ 'total_references' ], entry[ 'rule_id' ] ),
+            ):
+                lines.append(
+                    '    {}  {} refs  {} files'.format(
+                        rule[ 'rule_id' ],
+                        rule[ 'total_references' ],
+                        rule[ 'unique_files' ],
+                    )
+                )
+
+    return '\n'.join( lines )
 
 
 def location_dedupe_key( scope, diagnostic ):

--- a/design/plans/cxx-profiles-report.md
+++ b/design/plans/cxx-profiles-report.md
@@ -557,18 +557,22 @@ Registry records: `kind`, default subdir, CLI flag, manifest kind string. Enable
 
 ## Work slices
 
-| Slice | Deliverable | Notes |
-|-------|-------------|-------|
-| **A — Parser + unit tests** | `cuppa/cpp/cxx_profiles_report.py` — parse, normalise, classify; `ProfilesScope` type | Fixture strings from samples; scope-aware dedupe keys |
-| **B — Collector + parallel spawn scope** | Progress callback **and** per-action `env` → `SpawnedProcessor`; thread-safe session store | Includes former slice F; do not ship collector without spawn scope |
-| **C — HTML + JSON** | Jinja templates + `CxxProfilesReportBuilder` at `sconstruct_end` | By rule / By file / Roll-up tabs; `link_style`; incomplete scope banner |
-| **D — Manifest + clean** | `.cuppa-reports` schema v1; matched `--clean` / `--remove-builds` | `invocation_key`, `partial`, path union |
-| **E — Method (optional)** | `env.CxxProfilesReport()` + collate | Deferred past A–D if cycle is tight |
-| **F — Phase 6 hook** | `artefact_roots` / `--set-artefacts-folder` when #135 lands | Supersedes manifest hack for declared trees |
+Slice **letters** (A–F) are shorthand in tables; **`prof-report-*` ids** are the stable names for
+issues, PR titles, and ROADMAP cross-links (same pattern as `list-tc-*` in
+[`list-toolchains-verbose.md`](list-toolchains-verbose.md)).
 
-Target cycle: **1.8.0** for slices **A–D** (B **must** include parallel spawn scope); E–F optional / blocked.
+| Letter | Id | Deliverable | Notes |
+|--------|-----|-------------|-------|
+| **A** | `prof-report-parser` | `cuppa/cpp/cxx_profiles_report.py` — parse, normalise, classify; `ProfilesScope` type | Fixture strings from samples; scope-aware dedupe keys |
+| **B** | `prof-report-collector` | Progress callback **and** per-action `env` → `SpawnedProcessor`; thread-safe session store | Includes former slice F; do not ship collector without spawn scope |
+| **C** | `prof-report-html` | Jinja templates + `CxxProfilesReportBuilder` at `sconstruct_end` | By rule / By file / Roll-up tabs; `link_style`; incomplete scope banner |
+| **D** | `prof-report-manifest` | `.cuppa-reports` schema v1; matched `--clean` / `--remove-builds` | `invocation_key`, `partial`, path union |
+| **E** | `prof-report-method` | `env.CxxProfilesReport()` + collate | Deferred past A–D if cycle is tight |
+| **F** | `prof-report-artefacts` | `artefact_roots` / `--set-artefacts-folder` when #135 lands | Supersedes manifest hack for declared trees |
 
-**Tracking:** [#184](https://github.com/ja11sop/cuppa/issues/184) — one issue; land slices as **multiple PRs** against `cxx-profiles-report` (checklist on the issue).
+Target cycle: **1.8.0** for **`prof-report-parser` … `prof-report-manifest`** (slice A–D; **`prof-report-collector` must** include parallel spawn scope); E–F optional / blocked.
+
+**Tracking:** [#184](https://github.com/ja11sop/cuppa/issues/184) — one issue; land slices as **multiple PRs** (checklist on the issue; cite letter and/or `prof-report-*` id).
 
 ## Refusal rules
 
@@ -577,7 +581,7 @@ Target cycle: **1.8.0** for slices **A–D** (B **must** include parallel spawn 
 | Auto-fix sources from the report | Out of scope — report is read-only |
 | `--cxx-profiles-report` without Profiles enabled | StopError |
 | Invent rule ids not in Clang docs | Use `_unclassified`; file issue to extend table |
-| Silent mis-attribution under `-j` | Refuse — ship spawn scope in slice B |
+| Silent mis-attribution under `-j` | Refuse — ship spawn scope in **`prof-report-collector`** (slice B) |
 | Assign diagnostics to wrong variant without `_unscoped` fallback | Refuse |
 | MSVC Profiles diagnostics in v1 | StopError or empty report with notice until interpretor exists |
 
@@ -606,13 +610,13 @@ Target cycle: **1.8.0** for slices **A–D** (B **must** include parallel spawn 
 
 | Slice | Status |
 |-------|--------|
-| Plan | **This document** (parallel spawn scope in slice B) |
-| A — Parser | **In progress** — `cuppa/cpp/cxx_profiles_report.py` + unit tests on branch |
-| B — Collector + parallel spawn scope | Not started |
-| C — HTML/JSON | Not started |
-| D — Manifest | Not started |
-| E — Method | Deferred |
-| F — Phase 6 | Blocked on #135 |
+| Plan | **This document** (`prof-report-collector` spawn scope settled) |
+| A — `prof-report-parser` | **In progress** — `cuppa/cpp/cxx_profiles_report.py` + unit tests ([#190](https://github.com/ja11sop/cuppa/pull/190)) |
+| B — `prof-report-collector` | Not started |
+| C — `prof-report-html` | Not started |
+| D — `prof-report-manifest` | Not started |
+| E — `prof-report-method` | Deferred |
+| F — `prof-report-artefacts` | Blocked on #135 |
 
 ## Open questions (resolve in first PR)
 

--- a/design/plans/cxx-profiles-report.md
+++ b/design/plans/cxx-profiles-report.md
@@ -563,7 +563,7 @@ issues, PR titles, and ROADMAP cross-links (same pattern as `list-tc-*` in
 
 | Letter | Id | Deliverable | Notes |
 |--------|-----|-------------|-------|
-| **A** | `prof-report-parser` | `cuppa/cpp/cxx_profiles_report.py` — parse, normalise, classify; `ProfilesScope` type | Fixture strings from samples; scope-aware dedupe keys |
+| **A** | `prof-report-parser` | `cuppa/cpp/cxx_profiles_report.py` — parse, normalise, classify; `ProfilesScope` type; `scripts/replay_profiles_capture.py` | Fixture strings from samples; scope-aware dedupe keys; Progress replay smoke |
 | **B** | `prof-report-collector` | Progress callback **and** per-action `env` → `SpawnedProcessor`; thread-safe session store | Includes former slice F; do not ship collector without spawn scope |
 | **C** | `prof-report-html` | Jinja templates + `CxxProfilesReportBuilder` at `sconstruct_end` | By rule / By file / Roll-up tabs; `link_style`; incomplete scope banner |
 | **D** | `prof-report-manifest` | `.cuppa-reports` schema v1; matched `--clean` / `--remove-builds` | `invocation_key`, `partial`, path union |

--- a/design/plans/cxx-profiles-report.md
+++ b/design/plans/cxx-profiles-report.md
@@ -607,7 +607,7 @@ Target cycle: **1.8.0** for slices **A–D** (B **must** include parallel spawn 
 | Slice | Status |
 |-------|--------|
 | Plan | **This document** (parallel spawn scope in slice B) |
-| A — Parser | Not started |
+| A — Parser | **In progress** — `cuppa/cpp/cxx_profiles_report.py` + unit tests on branch |
 | B — Collector + parallel spawn scope | Not started |
 | C — HTML/JSON | Not started |
 | D — Manifest | Not started |

--- a/design/process/agent-workflow-journey.md
+++ b/design/process/agent-workflow-journey.md
@@ -2,7 +2,7 @@
 
 - **Status:** living
 - **Related:** [`AGENTS.md`](../../AGENTS.md) (agent ops); Antora Contributing (human versioning/release)
-- **Updated:** 2026-08-09
+- **Updated:** 2026-08-11
 - **Maintainer:** primary author of this journey; others append only (see `AGENTS.md`)
 - **Privacy:** obey the private-projects rule; never copy names from `INTERNAL_PROJECTS.local.md`
 - **Source:** Cursor sessions spanning roughly mid-July → 2026-08-07 on cuppa
@@ -209,6 +209,7 @@ Use this as an ordered checklist. Cuppa did not follow it perfectly (see §5); t
 - [ ] Ship vertical slices (list → remove → purge → wipe; or clone → checkout → reset).
 - [ ] Settle vocabulary in the plan before coding (`base` vs `default`, selectors, …).
 - [ ] Housekeeping pass on every merge-ready PR: docs, changelog, roadmap, plan, test plan, squash message.
+- [ ] Squash commit drafts belong at **merge readiness** (from the landed diff + issue/plan context), not in the PR body at open time.
 
 ### Stage 7 — Encode repeated pain
 

--- a/scripts/replay_profiles_capture.py
+++ b/scripts/replay_profiles_capture.py
@@ -1,0 +1,32 @@
+"""Replay a saved Profiles build capture through the parser.
+
+    python -m scripts.replay_profiles_capture path/to/profile_output.txt
+
+The capture file should contain cuppa ``Progress( … )`` scope markers and Clang
+Profiles diagnostics (``under profile '…'`` suffix). Scope is inferred from the
+Progress lines; only the capture file path needs to be supplied.
+"""
+
+import argparse
+import sys
+
+from cuppa.cpp.cxx_profiles_report import format_capture_summary, replay_profiles_capture
+
+
+def main( argv=None ):
+    parser = argparse.ArgumentParser( description=__doc__ )
+    parser.add_argument(
+        'capture_file',
+        help='Saved build output with Progress() markers and Profiles diagnostics',
+    )
+    arguments = parser.parse_args( argv )
+
+    with open( arguments.capture_file, encoding='utf-8', errors='replace' ) as handle:
+        inventory, unscoped = replay_profiles_capture( handle )
+
+    print( format_capture_summary( inventory, unscoped ) )
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit( main() )

--- a/tests/fixtures/profiles_capture/sample_capture.txt
+++ b/tests/fixtures/profiles_capture/sample_capture.txt
@@ -1,0 +1,6 @@
+Progress( SconstructBegin )
+Progress( Begin sconscript: [./widget/sconscript] )
+Progress( Starting variant: [_build/widget/clang24_profiles/dbg/x86_64/cxx2c] )
+/home/user/include/widget/nonce.hpp:35:39: error: variable 'RandomValues' must be initialized or marked '[[uninit]]' under profile 'std::init'
+/home/user/include/widget/number.hpp:79:25: error: non-local variable 'decimal_places_1' requires constant initialization under profile 'std::init'
+/home/user/include/widget/table.hpp:120:5: error: constructor does not initialize member 'Buffer_' under profile 'std::init'

--- a/tests/unit/test_cxx_profiles_report.py
+++ b/tests/unit/test_cxx_profiles_report.py
@@ -5,18 +5,31 @@
 
 import pytest
 
+from pathlib import Path
+
 from cuppa.cpp.cxx_profiles_report import (
     ProfilesInventory,
     ProfilesScope,
     UNCLASSIFIED_RULE_ID,
     classify_rule,
+    format_capture_summary,
     location_dedupe_key,
     normalise_message,
+    parse_progress_line,
     parse_profiles_diagnostic,
+    parse_variant_scope_fields,
+    replay_profiles_capture,
     unscoped_profiles_scope,
 )
 
 pytestmark = pytest.mark.unit
+
+_FIXTURE_CAPTURE = (
+    Path( __file__ ).resolve().parents[ 1 ]
+    / 'fixtures'
+    / 'profiles_capture'
+    / 'sample_capture.txt'
+)
 
 
 _SAMPLE_SCOPE = ProfilesScope(
@@ -190,3 +203,60 @@ def test_inventory_report_model_shape():
 
 def test_unscoped_profiles_scope_is_stable():
     assert unscoped_profiles_scope().sconscript == '_unscoped'
+
+
+def test_parse_variant_scope_fields():
+    assert parse_variant_scope_fields(
+        '_build/widget/clang24_profiles/dbg/x86_64/cxx2c',
+    ) == ( 'clang24_profiles', 'dbg' )
+
+
+@pytest.mark.parametrize(
+    'line, expected',
+    [
+        (
+            'Progress( SconstructBegin )',
+            ( 'sconstruct_begin', None, None ),
+        ),
+        (
+            'Progress( Begin sconscript: [./widget/sconscript] )',
+            ( 'begin', './widget/sconscript', None ),
+        ),
+        (
+            'Progress( Starting variant: [_build/widget/clang24_profiles/dbg/x86_64/cxx2c] )',
+            ( 'started', None, '_build/widget/clang24_profiles/dbg/x86_64/cxx2c' ),
+        ),
+        (
+            'Progress( Finished variant: [_build/widget/clang24_profiles/dbg/x86_64/cxx2c] )',
+            ( 'finished', None, '_build/widget/clang24_profiles/dbg/x86_64/cxx2c' ),
+        ),
+    ],
+)
+def test_parse_progress_line( line, expected ):
+    assert parse_progress_line( line ) == expected
+
+
+def test_replay_profiles_capture_builds_scope_from_progress_markers():
+    inventory, unscoped = replay_profiles_capture( _FIXTURE_CAPTURE.read_text().splitlines() )
+    assert unscoped == 0
+    assert inventory.total_references() == 3
+    assert inventory.unique_locations() == 3
+    scope = inventory.locations()[ 0 ].scope
+    assert scope.sconscript == './widget/sconscript'
+    assert scope.variant_dir == '_build/widget/clang24_profiles/dbg/x86_64/cxx2c'
+    assert scope.toolchain == 'clang24_profiles'
+    assert scope.variant_label == 'dbg'
+
+
+def test_replay_profiles_capture_records_unscoped_without_progress():
+    inventory, unscoped = replay_profiles_capture( [ _UNINIT_LINE ] )
+    assert unscoped == 1
+    assert inventory.locations()[ 0 ].scope.sconscript == '_unscoped'
+
+
+def test_format_capture_summary_lists_rules():
+    inventory, _unscoped = replay_profiles_capture( _FIXTURE_CAPTURE.read_text().splitlines() )
+    summary = format_capture_summary( inventory )
+    assert 'total_references: 3' in summary
+    assert 'static_runtime_init' in summary
+    assert './widget/sconscript' in summary

--- a/tests/unit/test_cxx_profiles_report.py
+++ b/tests/unit/test_cxx_profiles_report.py
@@ -1,0 +1,192 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+import pytest
+
+from cuppa.cpp.cxx_profiles_report import (
+    ProfilesInventory,
+    ProfilesScope,
+    UNCLASSIFIED_RULE_ID,
+    classify_rule,
+    location_dedupe_key,
+    normalise_message,
+    parse_profiles_diagnostic,
+    unscoped_profiles_scope,
+)
+
+pytestmark = pytest.mark.unit
+
+
+_SAMPLE_SCOPE = ProfilesScope(
+    sconscript='./widget/sconscript',
+    variant_dir='_build/widget/clang24_profiles/dbg/x86_64/cxx2c',
+    toolchain='clang24_profiles',
+    variant_label='dbg',
+)
+
+_UNINIT_LINE = (
+    "/home/user/_cuppa/_download/example.org/common_types/include/widget/nonce.hpp"
+    ":35:39: error: variable 'RandomValues' must be initialized or marked "
+    "'[[uninit]]' under profile 'std::init'"
+)
+
+_STATIC_INIT_LINE = (
+    "/home/user/_cuppa/_download/example.org/common_types/include/widget/number.hpp"
+    ":79:25: error: non-local variable 'decimal_places_1' requires constant "
+    "initialization under profile 'std::init'"
+)
+
+_CTOR_MEMBER_LINE = (
+    "/home/user/project/include/widget/table.hpp"
+    ":120:5: error: constructor does not initialize member 'Buffer_' "
+    "under profile 'std::init'"
+)
+
+_CTOR_BASE_LINE = (
+    "/home/user/project/include/widget/string.hpp"
+    ":44:5: error: constructor does not initialize base class "
+    "'std::array<char, 11>' under profile 'std::init'"
+)
+
+_REF_LINE = (
+    "/home/user/project/src/widget.cpp"
+    ":10:12: error: pointer to uninitialized memory must be marked "
+    "'[[ref_to_uninit]]' under profile 'std::init'"
+)
+
+_UNKNOWN_LINE = (
+    "/home/user/project/src/widget.cpp"
+    ":99:1: error: something unexpected happened under profile 'std::init'"
+)
+
+
+def test_normalise_message_collapses_quoted_identifiers():
+    message = (
+        "constructor does not initialize member 'AssetMetrics_'"
+    )
+    assert normalise_message( message ) == (
+        "constructor does not initialize member '…'"
+    )
+
+
+@pytest.mark.parametrize(
+    'message, rule_id',
+    [
+        (
+            "variable '…' must be initialized or marked '…'",
+            'uninit_decl',
+        ),
+        (
+            "non-local variable '…' requires constant initialization",
+            'static_runtime_init',
+        ),
+        (
+            "constructor does not initialize member '…'",
+            'ctor_uninit_member',
+        ),
+        (
+            "constructor does not initialize base class '…'",
+            'ctor_uninit_member',
+        ),
+        (
+            "pointer to uninitialized memory must be marked '…'",
+            'ref_to_uninit',
+        ),
+        (
+            "something unexpected happened",
+            UNCLASSIFIED_RULE_ID,
+        ),
+    ],
+)
+def test_classify_rule( message, rule_id ):
+    assert classify_rule( message ) == rule_id
+
+
+def test_parse_profiles_diagnostic_extracts_fields():
+    diagnostic = parse_profiles_diagnostic( _UNINIT_LINE )
+    assert diagnostic is not None
+    assert diagnostic.line == 35
+    assert diagnostic.column == 39
+    assert diagnostic.profile == 'std::init'
+    assert diagnostic.rule_id == 'uninit_decl'
+    assert diagnostic.normalised_message == (
+        "variable '…' must be initialized or marked '…'"
+    )
+
+
+def test_parse_profiles_diagnostic_ignores_non_profiles_lines():
+    assert parse_profiles_diagnostic( "note: unrelated compiler output" ) is None
+    assert parse_profiles_diagnostic(
+        "/tmp/foo.cpp:1:1: error: plain error without profile suffix"
+    ) is None
+
+
+def test_location_dedupe_key_includes_scope():
+    first = parse_profiles_diagnostic( _STATIC_INIT_LINE )
+    second_scope = _SAMPLE_SCOPE._replace( variant_dir='_build/widget/rel/x86_64/cxx2c' )
+    assert location_dedupe_key( _SAMPLE_SCOPE, first ) != location_dedupe_key(
+        second_scope,
+        first,
+    )
+
+
+def test_inventory_dedupes_within_scope():
+    inventory = ProfilesInventory()
+    diagnostic = parse_profiles_diagnostic( _STATIC_INIT_LINE )
+    inventory.record( _SAMPLE_SCOPE, diagnostic )
+    inventory.record( _SAMPLE_SCOPE, diagnostic )
+
+    assert inventory.total_references() == 2
+    assert inventory.unique_locations() == 1
+    location = inventory.locations()[ 0 ]
+    assert location.reference_count == 2
+
+
+def test_inventory_keeps_same_file_in_two_scopes_separate():
+    inventory = ProfilesInventory()
+    diagnostic = parse_profiles_diagnostic( _STATIC_INIT_LINE )
+    rel_scope = _SAMPLE_SCOPE._replace(
+        variant_dir='_build/widget/rel/x86_64/cxx2c',
+        variant_label='rel',
+    )
+    inventory.record( _SAMPLE_SCOPE, diagnostic )
+    inventory.record( rel_scope, diagnostic )
+
+    assert inventory.total_references() == 2
+    assert inventory.unique_locations() == 2
+
+
+def test_inventory_report_model_shape():
+    inventory = ProfilesInventory()
+    for line in (
+        _UNINIT_LINE,
+        _STATIC_INIT_LINE,
+        _CTOR_MEMBER_LINE,
+        _CTOR_BASE_LINE,
+        _REF_LINE,
+        _UNKNOWN_LINE,
+    ):
+        inventory.record( _SAMPLE_SCOPE, parse_profiles_diagnostic( line ) )
+
+    model = inventory.as_report_model()
+    assert model[ 'rollup' ][ 'total_references' ] == 6
+    assert model[ 'rollup' ][ 'unique_locations' ] == 6
+    assert len( model[ 'scopes' ] ) == 1
+    scope = model[ 'scopes' ][ 0 ]
+    assert scope[ 'sconscript' ] == _SAMPLE_SCOPE.sconscript
+    profile = scope[ 'profiles' ][ 0 ]
+    assert profile[ 'profile' ] == 'std::init'
+    rule_ids = { rule[ 'rule_id' ] for rule in profile[ 'rules' ] }
+    assert rule_ids == {
+        'uninit_decl',
+        'static_runtime_init',
+        'ctor_uninit_member',
+        'ref_to_uninit',
+        UNCLASSIFIED_RULE_ID,
+    }
+
+
+def test_unscoped_profiles_scope_is_stable():
+    assert unscoped_profiles_scope().sconscript == '_unscoped'

--- a/tests/unit/test_cxx_profiles_report.py
+++ b/tests/unit/test_cxx_profiles_report.py
@@ -209,6 +209,9 @@ def test_parse_variant_scope_fields():
     assert parse_variant_scope_fields(
         '_build/widget/clang24_profiles/dbg/x86_64/cxx2c',
     ) == ( 'clang24_profiles', 'dbg' )
+    assert parse_variant_scope_fields(
+        '_build/test/matching_engine/clang24_profiles_2026_08_07_27/dbg/x86_64/cxx2c',
+    ) == ( 'clang24_profiles_2026_08_07_27', 'dbg' )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

**`prof-report-parser`** (slice A) for [#184](https://github.com/ja11sop/cuppa/issues/184) — Profiles violation report parser groundwork:

- `cuppa/cpp/cxx_profiles_report.py`: parse Clang Profiles diagnostics, normalise message patterns, classify rule ids, scope-aware dedupe and JSON view model
- `Progress( … )` scope stack + `replay_profiles_capture()` for serial capture files
- `python -m scripts.replay_profiles_capture` — live replay smoke (file path only)
- Unit tests with anonymised fixtures from the plan samples
- CHANGELOG entry under `[1.8.0]`
- Agent guidance: squash commit drafts belong at merge readiness, not in PR bodies at open time

No CLI wiring yet (`prof-report-collector` / slice B+).

## Test plan

- [x] `venv/bin/flake8 cuppa/cpp/cxx_profiles_report.py tests/unit/test_cxx_profiles_report.py scripts/replay_profiles_capture.py`
- [x] `pytest -m unit tests/unit/test_cxx_profiles_report.py`
- [x] `python -m scripts.check_version_bump --base-ref origin/master --labels impact:minor`
- [x] CI green on the matrix

### Optional smoke (recommended live verification)

Replay a saved Profiles build capture — scope is inferred from ``Progress( … )`` markers; supply only the dump file path:

- [x] `python -m scripts.replay_profiles_capture /path/to/profile_output.txt`

Expect a summary with `total_references`, per-scope rule counts (`uninit_decl`, `static_runtime_init`, …), and `unscoped_diagnostics: 0` when Progress markers precede the diagnostic block.

- [x] Spot-check any `_unclassified` rule rows for follow-up in **`prof-report-collector`** / **`prof-report-html`**
