### PR TITLE
Add Profiles violation report collector (prof-report-collector, #184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ids, and dedupes violations per scope (slice A; CLI and HTML in later slices).
   `python -m scripts.replay_profiles_capture` replays saved build captures using
   ``Progress( … )`` scope markers.
+- Profiles violation capture during builds (slice B, `prof-report-collector`):
+  ``--cxx-profiles-report`` activates an in-process collector wired through
+  ``ToolchainProcessor`` with per-sconscript spawn scope; session summary logs at
+  ``sconstruct_end`` (HTML/JSON in slice C).
 
 ### Changed
 

--- a/cuppa/construct.py
+++ b/cuppa/construct.py
@@ -31,6 +31,7 @@ import cuppa.core.build_layout
 import cuppa.modules.registration
 import cuppa.build_platform
 import cuppa.output_processor
+import cuppa.progress
 import cuppa.recursive_glob
 import cuppa.configure
 import cuppa.version
@@ -1044,6 +1045,8 @@ class Construct(object):
             ] )
 
             cuppa.core.environment.EnvironmentMethods.add_progress_tracking( sconscript_env )
+
+            cuppa.progress.NotifyProgress.notify_sconscript_env_ready( sconscript_env )
 
             sconscript_exports = {
                 'env'                     : sconscript_env,

--- a/cuppa/cpp/cxx_profiles_report.py
+++ b/cuppa/cpp/cxx_profiles_report.py
@@ -164,6 +164,28 @@ def parse_profiles_diagnostic( line ):
     )
 
 
+def profiles_scope_from_construction_env( env ):
+    """Build a ``ProfilesScope`` from a sconscript construction ``env``."""
+    from cuppa.progress import NotifyProgress
+
+    scope = NotifyProgress.scope_from_env( env )
+    if scope is None:
+        return unscoped_profiles_scope()
+
+    sconscript, variant_dir = scope
+    toolchain = NotifyProgress.toolchain_name( env )
+    if not toolchain:
+        return unscoped_profiles_scope()
+
+    _toolchain_from_path, variant_label = parse_variant_scope_fields( variant_dir )
+    return ProfilesScope(
+        sconscript=sconscript,
+        variant_dir=variant_dir,
+        toolchain=toolchain,
+        variant_label=variant_label,
+    )
+
+
 def parse_variant_scope_fields( variant_dir ):
     """Derive toolchain and variant label from a cuppa variant directory path.
 

--- a/cuppa/cpp/profiles_report_collector.py
+++ b/cuppa/cpp/profiles_report_collector.py
@@ -1,0 +1,111 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   In-process Profiles violation collector (prof-report-collector)
+#-------------------------------------------------------------------------------
+
+import threading
+
+from cuppa.colourise import as_notice
+from cuppa.cpp.cxx_profiles_report import (
+    ProfilesInventory,
+    format_capture_summary,
+    parse_profiles_diagnostic,
+)
+from cuppa.log import logger
+from cuppa.progress import NotifyProgress, VariantCompletionTracker
+
+
+class ProfilesReportSession(object):
+    """Thread-safe session store and Progress scope bookkeeping."""
+
+    def __init__( self ):
+        self._lock = threading.Lock()
+        self._inventory = ProfilesInventory()
+        self._variant_completion = VariantCompletionTracker()
+
+    @property
+    def inventory( self ):
+        return self._inventory
+
+    def record( self, scope, diagnostic ):
+        with self._lock:
+            self._inventory.record( scope, diagnostic )
+
+    def on_progress( self, progress, sconscript, variant, env, target, source ):
+        self._variant_completion.note_progress( progress, variant )
+        if progress == 'sconstruct_end':
+            self._emit_session_summary()
+
+    def _emit_session_summary( self ):
+        with self._lock:
+            if self._inventory.total_references() == 0:
+                logger.info(
+                    "C++ Profiles report: no violations captured "
+                    "(see --cxx-profiles-report; HTML output lands in a later slice)"
+                )
+                return
+            incomplete = self._variant_completion.incomplete_variants()
+            if incomplete:
+                logger.warn(
+                    "C++ Profiles report: incomplete scope(s) [{}]".format(
+                        as_notice( ', '.join( sorted( incomplete ) ) )
+                    )
+                )
+            logger.info(
+                "C++ Profiles report capture summary:\n{}".format(
+                    format_capture_summary( self._inventory )
+                )
+            )
+
+
+class ProfilesDiagnosticCollector(object):
+    """Process-wide collector activated by ``--cxx-profiles-report``."""
+
+    _session = None
+    _register_lock = threading.Lock()
+    _spawn_hook_registered = False
+
+    @classmethod
+    def activate( cls ):
+        with cls._register_lock:
+            if cls._session is None:
+                cls._session = ProfilesReportSession()
+                NotifyProgress.register_callback( None, cls._session.on_progress )
+                cls._register_spawn_processor_hook()
+            return cls._session
+
+    @classmethod
+    def _register_spawn_processor_hook( cls ):
+        if cls._spawn_hook_registered:
+            return
+        NotifyProgress.register_sconscript_env_hook( cls._rebind_spawn_processor )
+        cls._spawn_hook_registered = True
+
+    @classmethod
+    def _rebind_spawn_processor( cls, env ):
+        if hasattr( env, 'get_option' ) and env.get_option( 'raw_output' ):
+            return
+        import cuppa.output_processor
+        cuppa.output_processor.Processor.install( env )
+
+    @classmethod
+    def active( cls ):
+        return cls._session
+
+    @classmethod
+    def record_line( cls, scope, line ):
+        session = cls._session
+        if session is None or not line:
+            return
+        diagnostic = parse_profiles_diagnostic( line )
+        if diagnostic is not None:
+            session.record( scope, diagnostic )
+
+    @classmethod
+    def reset( cls ):
+        """Clear the active session (unit tests only)."""
+        cls._session = None

--- a/cuppa/methods/cxx_profiles_report.py
+++ b/cuppa/methods/cxx_profiles_report.py
@@ -1,0 +1,59 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   C++ Profiles violation report (--cxx-profiles-report)
+#-------------------------------------------------------------------------------
+
+from cuppa.colourise import as_error
+from cuppa.cpp.profiles_report_collector import ProfilesDiagnosticCollector
+from cuppa.log import logger
+
+
+class CxxProfilesReportMethod:
+    """Opt-in capture of Profiles diagnostics during builds."""
+
+    @classmethod
+    def add_options( cls, add_option ):
+        add_option(
+            '--cxx-profiles-report',
+            dest='cxx_profiles_report',
+            action='store_true',
+            help='Capture Profiles diagnostics during the build for a violation '
+                 'report (requires --cxx-profiles or --cxx-profiles-enforce=; '
+                 'HTML output is a follow-on slice)',
+        )
+
+    @classmethod
+    def get_options( cls, env ):
+        enabled = bool( env.get_option( 'cxx_profiles_report' ) )
+        env[ 'cxx_profiles_report' ] = enabled
+        if not enabled:
+            return
+
+        profiles_active = bool( env.get( 'cxx_profiles' ) ) or bool(
+            env.get( 'cxx_profiles_enforce' )
+        )
+        if not profiles_active:
+            import SCons.Errors
+            message = (
+                "--cxx-profiles-report requires C++ Profiles to be active "
+                "(use --cxx-profiles or --cxx-profiles-enforce=)"
+            )
+            logger.error(
+                "--cxx-profiles-report requires C++ Profiles to be active "
+                "(use {} or {} )".format(
+                    as_error( '--cxx-profiles' ),
+                    as_error( '--cxx-profiles-enforce=' ),
+                )
+            )
+            raise SCons.Errors.StopError( message )
+
+        ProfilesDiagnosticCollector.activate()
+        logger.debug( "C++ Profiles violation capture enabled" )
+
+    @classmethod
+    def add_to_env( cls, cuppa_env ):
+        pass

--- a/cuppa/output_processor.py
+++ b/cuppa/output_processor.py
@@ -21,6 +21,7 @@ import logging
 
 import cuppa.timer
 from cuppa.colourise import as_colour, as_emphasised, as_highlighted, as_notice
+from cuppa.cpp.profiles_report_collector import ProfilesDiagnosticCollector
 from cuppa.log import logger
 from cuppa.utility.python2to3 import as_str, errno, Queue
 
@@ -320,10 +321,14 @@ class Processor:
 class SpawnedProcessor(object):
 
     def __init__( self, scons_env ):
+        from cuppa.cpp.cxx_profiles_report import profiles_scope_from_construction_env
+
+        self._profiles_scope = profiles_scope_from_construction_env( scons_env )
         self._processor = ToolchainProcessor(
                 scons_env['toolchain'],
                 scons_env['minimal_output'],
-                scons_env['ignore_duplicates'] )
+                scons_env['ignore_duplicates'],
+                self._profiles_scope )
 
     def __call__( self, line ):
         return self._processor( line )
@@ -335,10 +340,11 @@ class SpawnedProcessor(object):
 
 class ToolchainProcessor:
 
-    def __init__( self, toolchain, minimal_output, ignore_duplicates ):
+    def __init__( self, toolchain, minimal_output, ignore_duplicates, profiles_scope=None ):
         self.toolchain              = toolchain
         self.minimal_output         = minimal_output
         self.ignore_duplicates      = ignore_duplicates
+        self._profiles_scope        = profiles_scope
         self.errors                 = 0
         self.warnings               = 0
         self.start_time             = time.time()
@@ -372,6 +378,9 @@ class ToolchainProcessor:
 
 
     def __call__( self, line ):
+
+        if self._profiles_scope is not None:
+            ProfilesDiagnosticCollector.record_line( self._profiles_scope, line )
 
         ( matches, interpretor, error_id, warning_id ) = self.interpret( line )
 

--- a/cuppa/progress.py
+++ b/cuppa/progress.py
@@ -10,6 +10,7 @@
 
 import logging
 import os.path
+import threading
 
 from cuppa.colourise import as_notice, as_info
 from cuppa.log import logger
@@ -20,6 +21,7 @@ from SCons.Script import Action
 class NotifyProgress(object):
 
     _callbacks = set()
+    _sconscript_env_hooks = set()
 
     _sconstruct_begin = None
     _sconstruct_end   = None
@@ -39,6 +41,25 @@ class NotifyProgress(object):
 
 
     @classmethod
+    def register_sconscript_env_hook( cls, hook ):
+        """Register a callback invoked once each sconscript env is ready to build.
+
+        Hooks receive the cloned sconscript construction ``env`` (after
+        ``build_dir`` / ``sconscript_file`` are set). Intended for rebinding
+        per-sconscript services such as ``SPAWN`` without coupling ``construct``
+        to individual features.
+        """
+        cls._sconscript_env_hooks.add( hook )
+
+
+    @classmethod
+    def notify_sconscript_env_ready( cls, env ):
+        """Invoke registered sconscript-env hooks; errors propagate to the build."""
+        for hook in cls._sconscript_env_hooks:
+            hook( env )
+
+
+    @classmethod
     def call_callbacks( cls, event, sconscript, variant, env, target, source ):
         if 'cuppa_progress_callbacks' in env:
             for callback in env['cuppa_progress_callbacks']:
@@ -50,6 +71,25 @@ class NotifyProgress(object):
     @classmethod
     def variant( cls, env ):
         return os.path.split(env['build_dir'])[0]
+
+
+    @classmethod
+    def scope_from_env( cls, env ):
+        """Return ``(sconscript, variant_dir)`` for a construction env, or ``None``."""
+        try:
+            if not env.get( 'build_dir' ) or not env.get( 'sconscript_file' ):
+                return None
+            return ( cls.sconscript( env ), cls.variant( env ) )
+        except ( AttributeError, KeyError, TypeError ):
+            return None
+
+
+    @classmethod
+    def toolchain_name( cls, env ):
+        try:
+            return env[ 'toolchain' ].name()
+        except ( AttributeError, KeyError, TypeError ):
+            return None
 
 
     @classmethod
@@ -107,6 +147,29 @@ class NotifyProgress(object):
             cls._sconstruct_end = progress( '#SconstructEnd', 'sconstruct_end', None, None, empty_env )
 
         env.Requires( cls._sconstruct_end, end )
+
+
+class VariantCompletionTracker(object):
+    """Track Progress variant paths that started but have not yet finished."""
+
+    def __init__( self ):
+        self._lock = threading.Lock()
+        self._open_variants = set()
+        self._complete_variants = set()
+
+    def note_progress( self, event, variant ):
+        if event == 'started' and variant:
+            with self._lock:
+                self._open_variants.add( variant )
+                self._complete_variants.discard( variant )
+        elif event == 'finished' and variant:
+            with self._lock:
+                self._open_variants.discard( variant )
+                self._complete_variants.add( variant )
+
+    def incomplete_variants( self ):
+        with self._lock:
+            return self._open_variants - self._complete_variants
 
 
 def progress( label, event, sconscript, variant, env ):

--- a/design/plans/cxx-profiles-report.md
+++ b/design/plans/cxx-profiles-report.md
@@ -362,7 +362,9 @@ Extend with an optional **`ProfilesDiagnosticCollector`** registered when
 
 **Scope stack:** maintained by a **`NotifyProgress.register_callback`** handler (same extension
 point as `CoverageIndexBuilder.on_progress` and test suites), not by guessing from the
-processor's install-time env.
+processor's install-time env. Spawn scope uses **`NotifyProgress.scope_from_env`** (same
+``variant`` / ``sconscript`` rules as Progress markers); per-sconscript ``SPAWN`` rebinding
+uses **`NotifyProgress.register_sconscript_env_hook``** so ``construct`` stays feature-agnostic.
 
 **Why not only scrape log files:** post-hoc grep can reconstruct scope **only for serial builds**
 (as the sample demonstrates). In-process capture stays correct for the same reason and avoids
@@ -611,8 +613,9 @@ Target cycle: **1.8.0** for **`prof-report-parser` … `prof-report-manifest`** 
 | Slice | Status |
 |-------|--------|
 | Plan | **This document** (`prof-report-collector` spawn scope settled) |
-| A — `prof-report-parser` | **In progress** — `cuppa/cpp/cxx_profiles_report.py` + unit tests ([#190](https://github.com/ja11sop/cuppa/pull/190)) |
-| B — `prof-report-collector` | Not started |
+| A — `prof-report-parser` | **Done** — merged [#190](https://github.com/ja11sop/cuppa/pull/190) |
+| B — `prof-report-collector` | **On branch** — PR after slice B lands ([#184](https://github.com/ja11sop/cuppa/issues/184)) |
+| B½ — `prof-report-parser-layers` | **Planned** — see §Parser layering follow-on (before slice C) |
 | C — `prof-report-html` | Not started |
 | D — `prof-report-manifest` | Not started |
 | E — `prof-report-method` | Deferred |
@@ -626,3 +629,47 @@ Target cycle: **1.8.0** for **`prof-report-parser` … `prof-report-manifest`** 
 4. **Cross-variant roll-up:** union adds counts across scopes — confirm product choice when comparing `dbg` vs `rel` (settled above; note in Antora).
 5. **GitHub `link_style`:** extend shared helper vs duplicate URL template in Profiles module only?
 6. **`_unscoped` bucket:** when spawn scope cannot be derived, record under session `_unscoped` with warning in HTML — never guess variant.
+
+## Parser layering follow-on (`prof-report-parser-layers`)
+
+Slice A shipped a deliberate v1 shortcut: Alliance Clang line shape parsing and a flat
+``std::init`` message→rule table live together in ``cuppa/cpp/cxx_profiles_report.py``.
+Slice B smoke (serial and ``--parallel``) validates capture and scope; rule attribution still
+assumes ``std::init`` prose even though the **profile name** is parsed from
+`` under profile '…'`` and grouped correctly in the inventory.
+
+Land **before slice C HTML** so doc links and rule sections live in profile modules, not in the
+generic report builder.
+
+### Target layout
+
+| Module | Responsibility |
+|--------|----------------|
+| ``cxx_profiles_report.py`` (or ``profiles_report/inventory.py``) | Scope, dedupe, ``ProfilesInventory``, replay, JSON view model — **no rule tables** |
+| ``profiles_report/parse_clang.py`` | Clang ``: error: … under profile '…'`` line detector → path, message, **profile** |
+| ``profiles_report/profiles/std_init.py`` | ``std::init`` classifiers, P4222 / ProfilesFramework.rst doc anchors |
+| *(future)* ``parse_gcc.py``, ``profiles/std_type.py``, … | New compiler shapes and profile rule sets |
+
+**Dispatch:** ``parse_profiles_diagnostic(line, compiler='clang')`` then
+``classify_rule(profile, normalised_message)`` — classifiers are keyed by profile, not one
+global tuple.
+
+### Spec-driven fixtures (not smoke-only)
+
+Add ``examples/profiles-std-init-violations/`` (name illustrative): minimal C++ that deliberately
+violates each documented ``std::init`` rule (including rows not seen in consumer smoke, e.g.
+``uninit_read``, ``destroy_uninit``). Workflow:
+
+1. Build with Profiles-capable Clang + ``--cxx-profiles-enforce=std::init``.
+2. Capture diagnostic lines into ``tests/fixtures/profiles_capture/`` (one snippet or golden file
+   per rule id).
+3. Unit tests assert each golden line → expected ``(profile, rule_id)``.
+
+Automation (CI integration test comparing live build to golden) can follow; manual capture once
+is enough to expand the classifier table beyond observed production trees.
+
+### Refusal rules (unchanged)
+
+- Unknown message under a known profile → ``_unclassified`` with raw text preserved.
+- Unknown compiler line shape → ignore (or empty bucket + notice until a parser exists).
+- Do not map ``std::init`` patterns onto other profile names without an explicit classifier module.

--- a/tests/unit/test_cxx_profiles_report.py
+++ b/tests/unit/test_cxx_profiles_report.py
@@ -18,6 +18,7 @@ from cuppa.cpp.cxx_profiles_report import (
     parse_progress_line,
     parse_profiles_diagnostic,
     parse_variant_scope_fields,
+    profiles_scope_from_construction_env,
     replay_profiles_capture,
     unscoped_profiles_scope,
 )
@@ -212,6 +213,21 @@ def test_parse_variant_scope_fields():
     assert parse_variant_scope_fields(
         '_build/test/matching_engine/clang24_profiles_2026_08_07_27/dbg/x86_64/cxx2c',
     ) == ( 'clang24_profiles_2026_08_07_27', 'dbg' )
+
+
+def test_profiles_scope_from_construction_env_matches_notify_progress_variant():
+    class FakeToolchain(object):
+        def name( self ):
+            return 'clang24_profiles'
+
+    env = {
+        'sconscript_file': './widget/sconscript',
+        'build_dir': '_build/widget/clang24_profiles/dbg/x86_64/cxx2c/working',
+        'toolchain': FakeToolchain(),
+    }
+    scope = profiles_scope_from_construction_env( env )
+    assert scope.variant_dir == '_build/widget/clang24_profiles/dbg/x86_64/cxx2c'
+    assert scope == _SAMPLE_SCOPE
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_profiles_report_collector.py
+++ b/tests/unit/test_profiles_report_collector.py
@@ -1,0 +1,168 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+import threading
+
+import pytest
+
+from cuppa.cpp.cxx_profiles_report import (
+    ProfilesScope,
+    profiles_scope_from_construction_env,
+    unscoped_profiles_scope,
+)
+from cuppa.cpp.profiles_report_collector import ProfilesDiagnosticCollector
+from cuppa.progress import NotifyProgress
+
+pytestmark = pytest.mark.unit
+
+_PROFILE_LINE = (
+    "/home/user/project/include/widget/table.hpp"
+    ":120:5: error: constructor does not initialize member 'Buffer_' "
+    "under profile 'std::init'"
+)
+
+_SAMPLE_SCOPE = ProfilesScope(
+    sconscript='./widget/sconscript',
+    variant_dir='_build/widget/clang24_profiles/dbg/x86_64/cxx2c',
+    toolchain='clang24_profiles',
+    variant_label='dbg',
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_collector():
+    ProfilesDiagnosticCollector.reset()
+    yield
+    ProfilesDiagnosticCollector.reset()
+
+
+class _FakeToolchain(object):
+    def name( self ):
+        return 'clang24_profiles'
+
+
+def test_profiles_scope_from_construction_env():
+    env = {
+        'sconscript_file': './widget/sconscript',
+        'build_dir': '_build/widget/clang24_profiles/dbg/x86_64/cxx2c/working',
+        'toolchain': _FakeToolchain(),
+    }
+    scope = profiles_scope_from_construction_env( env )
+    assert scope == _SAMPLE_SCOPE
+
+
+def test_profiles_scope_from_construction_env_falls_back_when_incomplete():
+    assert profiles_scope_from_construction_env( {} ) == unscoped_profiles_scope()
+    assert profiles_scope_from_construction_env( { 'build_dir': '_build/x' } ) == unscoped_profiles_scope()
+
+
+def test_collector_records_profiles_lines():
+    session = ProfilesDiagnosticCollector.activate()
+    ProfilesDiagnosticCollector.record_line( _SAMPLE_SCOPE, _PROFILE_LINE )
+    assert session.inventory.total_references() == 1
+    assert session.inventory.unique_locations() == 1
+
+
+def test_collector_ignores_non_profiles_lines():
+    session = ProfilesDiagnosticCollector.activate()
+    ProfilesDiagnosticCollector.record_line( _SAMPLE_SCOPE, 'ordinary compiler noise' )
+    assert session.inventory.total_references() == 0
+
+
+def test_collector_merge_is_thread_safe():
+    session = ProfilesDiagnosticCollector.activate()
+    barrier = threading.Barrier( 4 )
+
+    def worker():
+        barrier.wait()
+        ProfilesDiagnosticCollector.record_line( _SAMPLE_SCOPE, _PROFILE_LINE )
+
+    threads = [ threading.Thread( target=worker ) for _ in range( 4 ) ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert session.inventory.total_references() == 4
+    assert session.inventory.unique_locations() == 1
+
+
+def test_collector_progress_tracks_variant_completion():
+    session = ProfilesDiagnosticCollector.activate()
+    variant = _SAMPLE_SCOPE.variant_dir
+
+    session.on_progress( 'started', './widget/sconscript', variant, None, None, None )
+    assert variant in session._variant_completion.incomplete_variants()
+
+    session.on_progress( 'finished', './widget/sconscript', variant, None, None, None )
+    assert variant not in session._variant_completion.incomplete_variants()
+
+
+def test_cxx_profiles_report_requires_profiles_active():
+    from cuppa.methods.cxx_profiles_report import CxxProfilesReportMethod
+    import SCons.Errors
+
+    class FakeEnv(dict):
+        def __init__( self, options ):
+            super().__init__()
+            self._options = options
+
+        def get_option( self, name ):
+            return self._options.get( name )
+
+    env = FakeEnv( { 'cxx_profiles_report': True } )
+    with pytest.raises( SCons.Errors.StopError ):
+        CxxProfilesReportMethod.get_options( env )
+
+    env = FakeEnv( { 'cxx_profiles_report': True } )
+    env['cxx_profiles'] = True
+    CxxProfilesReportMethod.get_options( env )
+    assert env['cxx_profiles_report'] is True
+    assert ProfilesDiagnosticCollector.active() is not None
+
+
+def test_collector_registers_spawn_processor_rebind_hook():
+    ProfilesDiagnosticCollector.activate()
+    assert ProfilesDiagnosticCollector._rebind_spawn_processor in NotifyProgress._sconscript_env_hooks
+
+
+def test_spawn_processor_hook_skips_raw_output(monkeypatch):
+    ProfilesDiagnosticCollector.activate()
+    calls = []
+
+    class FakeProcessor(object):
+        @classmethod
+        def install(cls, env):
+            calls.append(env)
+
+    monkeypatch.setattr('cuppa.output_processor.Processor', FakeProcessor)
+
+    class FakeEnv(dict):
+        def get_option(self, name):
+            return name == 'raw_output'
+
+    ProfilesDiagnosticCollector._rebind_spawn_processor(FakeEnv())
+    assert calls == []
+
+    class NormalEnv(dict):
+        def get_option(self, name):
+            return False
+
+    env = NormalEnv()
+    ProfilesDiagnosticCollector._rebind_spawn_processor(env)
+    assert calls == [env]
+
+
+def test_cxx_profiles_report_disabled_does_not_activate():
+    from cuppa.methods.cxx_profiles_report import CxxProfilesReportMethod
+
+    class FakeEnv(dict):
+        def get_option( self, name ):
+            return None
+
+    env = FakeEnv()
+    CxxProfilesReportMethod.get_options( env )
+    assert env['cxx_profiles_report'] is False
+    assert ProfilesDiagnosticCollector.active() is None

--- a/tests/unit/test_progress.py
+++ b/tests/unit/test_progress.py
@@ -6,7 +6,7 @@
 import pytest
 
 import cuppa.progress as progress_module
-from cuppa.progress import NotifyProgress
+from cuppa.progress import NotifyProgress, VariantCompletionTracker
 
 
 pytestmark = pytest.mark.unit
@@ -51,6 +51,7 @@ def _make_env(sconscript_file, build_dir):
 @pytest.fixture(autouse=True)
 def _reset_notifyprogress_state(monkeypatch):
     NotifyProgress._callbacks = set()
+    NotifyProgress._sconscript_env_hooks = set()
     NotifyProgress._sconstruct_begin = None
     NotifyProgress._sconstruct_end = None
     NotifyProgress._begin = {}
@@ -158,3 +159,38 @@ def test_register_callback_routes_env_specific_and_global_callbacks():
 
     assert ("local", "finished", "a/sconscript", "_build/a/dbg", env) in events
     assert ("global", "finished", "a/sconscript", "_build/a/dbg", env) in events
+
+
+def test_scope_from_env_matches_variant_and_sconscript():
+    env = _make_env("test/sconscript", "_build/test/gcc15/dbg/x86_64/c++20/working")
+    assert NotifyProgress.scope_from_env(env) == (
+        "test/sconscript",
+        "_build/test/gcc15/dbg/x86_64/c++20",
+    )
+
+
+def test_scope_from_env_returns_none_when_fields_missing():
+    assert NotifyProgress.scope_from_env({}) is None
+    assert NotifyProgress.scope_from_env({"build_dir": "_build/x/working"}) is None
+
+
+def test_notify_sconscript_env_ready_invokes_registered_hooks():
+    calls = []
+    env = _make_env("a/sconscript", "_build/a/dbg/working")
+
+    NotifyProgress.register_sconscript_env_hook(lambda e: calls.append(e))
+
+    NotifyProgress.notify_sconscript_env_ready(env)
+
+    assert calls == [env]
+
+
+def test_variant_completion_tracker_notes_started_and_finished():
+    tracker = VariantCompletionTracker()
+    variant = "_build/test/dbg/x86_64/c++20"
+
+    tracker.note_progress("started", variant)
+    assert tracker.incomplete_variants() == {variant}
+
+    tracker.note_progress("finished", variant)
+    assert tracker.incomplete_variants() == set()


### PR DESCRIPTION
## Summary

- Slice B (`prof-report-collector`): `--cxx-profiles-report` activates in-process capture of Clang Profiles diagnostics when Profiles are enabled; thread-safe session store; capture summary at `sconstruct_end` (HTML deferred to slice C).
- Per-spawn scope via `ToolchainProcessor` + sconscript `Processor.install` rebind through `NotifyProgress.register_sconscript_env_hook` — validated serial and `--parallel` on a consumer tree (identical totals).
- `NotifyProgress` extensions: `scope_from_env`, sconscript-env hooks, `VariantCompletionTracker` (Progress graph unchanged).
- Plan addendum: `prof-report-parser-layers` (profile/toolchain parser split + spec-driven fixtures) before slice C.

Groundwork for [#184](https://github.com/ja11sop/cuppa/issues/184).

## Test plan

- [x] `venv/bin/flake8 cuppa`
- [x] `venv/bin/pylint -E cuppa`
- [x] `venv/bin/pytest -m unit`
- [x] Consumer smoke: serial + `--parallel` with `--cxx-profiles-report` — identical capture summary (8624 refs / 2328 unique locations)
- [x] CI green on matrix
