### PR TITLE
Fix Profiles manifest clean matching (prof-report-manifest-clean)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-### Security
+- C++ Profiles `.cuppa-reports` clean matching: `invocation_key` now ignores `--clean` and
+  `--remove-builds` in `sys.argv` so a clean run can match the report invocation. A
+  `--clean --cxx-profiles-report` configure pass removes matching manifest entries without
+  activating the Profiles collector when Profiles flags are omitted (report options on the clean
+  command must still match those used when the report was generated).
 
 ## [1.7.0] - 2026-08-10
 

--- a/cuppa/methods/cxx_profiles_report.py
+++ b/cuppa/methods/cxx_profiles_report.py
@@ -56,10 +56,15 @@ class CxxProfilesReportMethod:
         if not enabled:
             return
 
+        from cuppa.reports.manifest import maybe_remove_cxx_profiles_on_clean
+        maybe_remove_cxx_profiles_on_clean( env )
+
         profiles_active = bool( env.get( 'cxx_profiles' ) ) or bool(
             env.get( 'cxx_profiles_enforce' )
         )
         if not profiles_active:
+            if env.get( 'clean' ) or env.get( 'remove_builds' ):
+                return
             import SCons.Errors
             message = (
                 "--cxx-profiles-report requires C++ Profiles to be active "
@@ -73,9 +78,6 @@ class CxxProfilesReportMethod:
                 )
             )
             raise SCons.Errors.StopError( message )
-
-        from cuppa.reports.manifest import maybe_remove_cxx_profiles_on_clean
-        maybe_remove_cxx_profiles_on_clean( env )
 
         ProfilesDiagnosticCollector.activate()
         logger.debug( "C++ Profiles violation capture enabled" )

--- a/cuppa/reports/manifest.py
+++ b/cuppa/reports/manifest.py
@@ -20,6 +20,27 @@ MANIFEST_BASENAME = '.cuppa-reports'
 SCHEMA_VERSION = 1
 KIND_CXX_PROFILES = 'cxx-profiles'
 
+# Flags that do not affect report output location or matching; omit from invocation_key.
+_INVOCATION_ARGV_IGNORE = frozenset(
+    [
+        '--clean',
+        '--remove-builds',
+        '-c',
+        '-R',
+    ],
+)
+
+
+def normalize_invocation_argv( argv ):
+    """Drop clean/remove-build flags so report and clean invocations share a key."""
+    normalized = []
+    for arg in argv:
+        key = arg.split( '=', 1 )[ 0 ]
+        if key in _INVOCATION_ARGV_IGNORE:
+            continue
+        normalized.append( arg )
+    return normalized
+
 
 def manifest_path( project_root ):
     return os.path.join( project_root, MANIFEST_BASENAME )
@@ -62,7 +83,7 @@ def cxx_profiles_report_options( env ):
 def compute_invocation_key( cwd, argv, options ):
     payload = {
         'cwd': os.path.abspath( cwd ),
-        'argv': list( argv ),
+        'argv': normalize_invocation_argv( argv ),
         'options': options,
     }
     digest = hashlib.sha256(

--- a/docs/modules/ROOT/pages/integration/test-cxx-profiles.adoc
+++ b/docs/modules/ROOT/pages/integration/test-cxx-profiles.adoc
@@ -26,6 +26,10 @@ clear failure with a normal gcc/clang that lacks Profiles.
 | `--cxx-profiles-report` with enforce + error-limit disabled
 | Writes `_artifacts/cxx-profiles/` HTML + JSON; skips without Profiles Clang
 
+| `test_profiles_report_clean_removes_manifest_artefacts`
+| Same report flags plus `--clean` on a second invocation
+| Removes `.cuppa-reports` entries and listed HTML/JSON; skips without Profiles Clang
+
 | `test_profiles_unsupported_toolchain_fails`
 | `--cxx-profiles` on a non-Profiles toolchain
 | Expects StopError / clear message

--- a/tests/integration/methods/test_cxx_profiles.py
+++ b/tests/integration/methods/test_cxx_profiles.py
@@ -104,6 +104,51 @@ def test_profiles_report_emits_html_and_json( tmp_path ):
     assert 'C++ Profiles report:' in combined or report_dir.exists()
 
 
+def test_profiles_report_clean_removes_manifest_artefacts( tmp_path ):
+    """--clean with matching --cxx-profiles-report flags removes listed report files."""
+    _, toolchain_flag = require_profiles_capable_toolchain()
+    write_sconstruct( tmp_path )
+    write_sconscript(
+        tmp_path,
+        "Import('env')\n"
+        "env.Build( 'app', [ 'main.cpp' ] )\n",
+    )
+    ( tmp_path / 'main.cpp' ).write_text(
+        'int main()\n'
+        '{\n'
+        '    int Value [[uninit]];\n'
+        '    return Value;\n'
+        '}\n'
+    )
+    report_flags = [
+        '--dbg',
+        '--cxx-profiles',
+        '--cxx-profiles-enforce=std::init',
+        '--cxx-disable-error-limit',
+        '--cxx-profiles-report',
+        toolchain_flag,
+    ]
+    run_cuppa( tmp_path, *report_flags )
+
+    report_dir = tmp_path / '_artifacts' / 'cxx-profiles'
+    index_html = report_dir / 'cxx-profiles-index.html'
+    index_json = report_dir / 'cxx-profiles-index.json'
+    manifest = tmp_path / '.cuppa-reports'
+
+    assert index_html.is_file()
+    assert index_json.is_file()
+    assert manifest.is_file()
+
+    clean_result = run_cuppa( tmp_path, *report_flags, '--clean' )
+    assert_success( clean_result )
+
+    assert not index_html.is_file()
+    assert not index_json.is_file()
+    assert not manifest.is_file()
+    combined = ( clean_result.stdout or '' ) + ( clean_result.stderr or '' )
+    assert 'C++ Profiles report clean:' in combined
+
+
 def test_profiles_unsupported_toolchain_fails( tmp_path ):
     """--cxx-profiles on a non-Profiles toolchain should StopError clearly."""
     # Prefer an explicit gcc (or default) that cannot support -fprofiles.

--- a/tests/unit/test_cuppa_reports_manifest.py
+++ b/tests/unit/test_cuppa_reports_manifest.py
@@ -22,6 +22,7 @@ from cuppa.reports.manifest import (
     cxx_profiles_report_options,
     manifest_path,
     maybe_remove_cxx_profiles_on_clean,
+    normalize_invocation_argv,
     paths_from_entry,
     read_entries,
     remove_matching_entries,
@@ -60,6 +61,29 @@ def test_compute_invocation_key_is_stable():
     key_b = compute_invocation_key( '/tmp/project', [ 'cuppa', '-D' ], options )
     assert key_a == key_b
     assert key_a.startswith( 'sha256:' )
+
+
+def test_compute_invocation_key_ignores_clean_and_remove_builds_flags():
+    options = {
+        'destination': '_artifacts/cxx-profiles',
+        'link_style': 'local',
+        'report_root': None,
+        'enforce': [ 'std::init' ],
+        'cxx_profiles': True,
+    }
+    report_argv = [
+        'cuppa',
+        '-D',
+        '--dbg',
+        '--cxx-profiles',
+        '--cxx-profiles-enforce=std::init',
+        '--cxx-profiles-report',
+    ]
+    clean_argv = report_argv + [ '--clean' ]
+    key_report = compute_invocation_key( '/tmp/project', report_argv, options )
+    key_clean = compute_invocation_key( '/tmp/project', clean_argv, options )
+    assert key_report == key_clean
+    assert normalize_invocation_argv( clean_argv ) == normalize_invocation_argv( report_argv )
 
 
 def test_paths_from_entry_unions_session_and_scope_paths():


### PR DESCRIPTION
## Summary

Fix slice D manifest cleanup so `--clean` can match `.cuppa-reports` entries from a prior `--cxx-profiles-report` run.

- `invocation_key` now ignores `--clean` / `--remove-builds` in `sys.argv` (they previously prevented any match).
- Run manifest removal before Profiles activation; allow a clean-only configure with `--cxx-profiles-report` to delete matching artefacts without starting the diagnostic collector.
- Add integration test `test_profiles_report_clean_removes_manifest_artefacts` and unit coverage for key stability.

Groundwork for [#184](https://github.com/ja11sop/cuppa/issues/184) slice D hardening; slice H (context summary) follows separately.

## Test plan

- [x] `venv/bin/flake8 cuppa/reports/manifest.py cuppa/methods/cxx_profiles_report.py`
- [x] `venv/bin/pylint -E cuppa/reports/manifest.py cuppa/methods/cxx_profiles_report.py`
- [x] `venv/bin/pytest tests/unit/test_cuppa_reports_manifest.py`
- [x] CI green on matrix (integration clean test requires Profiles-capable Clang)