### PR TITLE
Skip GitLab package retar on publish when archive is current (#204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-profile compile failures are tallied for a non-zero exit after the index write, and
   profile-shaped diagnostics keep an Error label with warning colours ([#199](https://github.com/ja11sop/cuppa/issues/199)).
 
+### Fixed
+
+- GitLab `GitlabPackagePublisher` writes a ``.packaged`` stamp and skips recreating the tarball
+  when staged headers/libs are not newer than the existing archive, so ``--publish-package`` after
+  a release build does not re-tar large packages ([#204](https://github.com/ja11sop/cuppa/issues/204)).
+
 ### Added
 
 - `--artefacts-root` (default `_artefacts`; legacy `_artifacts/` kept when present): project-relative root for generated reports and

--- a/cuppa/package_managers/gitlab.py
+++ b/cuppa/package_managers/gitlab.py
@@ -135,6 +135,44 @@ def create_package_archive( archive_path, working_dir, source_dir ):
     return completion.returncode
 
 
+def newest_mtime_under( root ):
+    """Return the newest file mtime under ``root``, or ``0.0`` when absent or empty."""
+    if not root or not os.path.exists( root ):
+        return 0.0
+    newest = 0.0
+    for dirpath, _dirnames, filenames in os.walk( root ):
+        for filename in filenames:
+            path = os.path.join( dirpath, filename )
+            try:
+                newest = max( newest, os.path.getmtime( path ) )
+            except OSError:
+                pass
+    return newest
+
+
+def package_archive_is_up_to_date( archive_path, staging_roots ):
+    """Return True when ``archive_path`` exists and is not older than staged package content."""
+    if not archive_path or not os.path.isfile( archive_path ):
+        return False
+    try:
+        archive_mtime = os.path.getmtime( archive_path )
+    except OSError:
+        return False
+    for root in staging_roots:
+        if newest_mtime_under( root ) > archive_mtime:
+            return False
+    return True
+
+
+def package_sidecar_id( package_file_path, suffix ):
+    """Sidecar stamp basename (``.packaged`` / ``.published``) for a package archive path."""
+    return (
+            strip_package_archive_extension(
+                    package_file_path.replace( "/", "_" )
+            ).replace( ".", "_" ) + suffix
+    )
+
+
 def extract_package_archive( archive_path, extraction_dir ):
     """Extract a GitLab package archive into ``extraction_dir`` (preserves ``package/version/…``)."""
     from cuppa.utility.download import (
@@ -229,7 +267,9 @@ class GitlabPackagePublisher:
         self._target_lib_dir    = env.Dir( os.path.join( env['final_dir'], self._package_folder, "lib" ) )
         self._package_variant   = tool_variant( env, variant=variant )
         self._package_file_name = package_file_name( env, package=package, variant=variant )
-        self._package_location  = env.File( os.path.join( env['abs_final_dir'], self._package_file_name ) )
+        self._package_archive = env.File(
+                os.path.join( env['abs_final_dir'], self._package_file_name )
+        )
         self._package_source_dir = package
 
         self._clean_targets = Flatten( [
@@ -239,20 +279,20 @@ class GitlabPackagePublisher:
 
         self._curl_command = 'curl --fail-with-body --header "{token}" --upload-file {package_file} "{package_location}"'.format(
                 token = get_header_token( custom_token ),
-                package_file = str( self._package_location ),
+                package_file = str( self._package_archive ),
                 package_location = package_url( env, registry=registry, package=package, version=version )
         )
 
         self._package_file_path = os.path.join( self._package_folder, self._package_file_name )
 
-        self._package_published_id = env.File(
-                strip_package_archive_extension(
-                        self._package_file_path.replace( "/", "_" )
-                ).replace( ".", "_" ) + ".published"
-        )
+        sidecar = package_sidecar_id( self._package_file_path, '' )
+        self._package_built_id = env.File( sidecar + '.packaged' )
+        self._package_published_id = env.File( sidecar + '.published' )
 
 
     def build_package( self, target, source, env ):
+
+        from SCons.Script import Touch
 
         if not os.path.exists( str(self._target_include_dir) ):
             logger.info( "For package [{}], include dir [{}] does not exist so copying include files from [{}]...".format(
@@ -284,19 +324,38 @@ class GitlabPackagePublisher:
             shutil.copytree( source_modules, target_modules )
 
         logger.info( "Creating package [{}]...".format( as_info( str(target[0]) ) ) )
+        archive_path = str( self._package_archive )
+        staging_roots = [
+                str( self._target_include_dir ),
+                str( self._target_lib_dir ),
+        ]
+        modules_dir = os.path.join( str( self._package_base_dir ), 'modules' )
+        if os.path.isdir( modules_dir ):
+            staging_roots.append( modules_dir )
+
+        if package_archive_is_up_to_date( archive_path, staging_roots ):
+            logger.info(
+                    "Package archive [{}] is up to date; skipping recreate".format(
+                            as_info( archive_path )
+                    )
+            )
+            env.Execute( Touch( target[0] ) )
+            return None
+
         returncode = create_package_archive(
-                str( self._package_location ),
+                archive_path,
                 env['abs_final_dir'],
                 self._package_source_dir,
         )
         if returncode != 0:
             logger.error( "Creating package archive [{}] failed with return code [{}]".format(
-                    as_error( str( self._package_location ) ),
+                    as_error( archive_path ),
                     as_error( str( returncode ) ) )
             )
             return returncode
 
-        logger.info( "Package [{}] created".format( as_info( str(target[0]) ) ) )
+        env.Execute( Touch( target[0] ) )
+        logger.info( "Package [{}] created".format( as_info( archive_path ) ) )
 
         return None
 
@@ -305,7 +364,7 @@ class GitlabPackagePublisher:
 
         from SCons.Script import Touch
 
-        logger.info( "Publishing package [{}]...".format( as_info( str(source[0]) ) ) )
+        logger.info( "Publishing package [{}]...".format( as_info( str(self._package_archive) ) ) )
         logger.info( "Using commnd [{}]".format( as_notice( self._curl_command ) ) )
 
         completion = subprocess.run( shlex.split( self._curl_command ) )
@@ -317,7 +376,7 @@ class GitlabPackagePublisher:
             return completion.returncode
 
         env.Execute( Touch( target[0] ) )
-        logger.info( "Package [{}] published".format( as_info( str(source[0]) ) ) )
+        logger.info( "Package [{}] published".format( as_info( str(self._package_archive) ) ) )
 
         return None
 
@@ -335,7 +394,11 @@ class GitlabPackagePublisher:
 
 
     def package( self ):
-        return self._package_location
+        return self._package_built_id
+
+
+    def package_archive( self ):
+        return self._package_archive
 
 
     def clean_targets( self ):

--- a/docs/modules/ROOT/pages/packages.adoc
+++ b/docs/modules/ROOT/pages/packages.adoc
@@ -12,7 +12,10 @@ You can publish to a GitLab generic package registry (`env.PublishPackage` +
 
 == Publishing (GitLab generic)
 
-From a sconscript, `env.PublishPackage(...)` with a `GitlabPackagePublisher` builds a toolchain-scoped tarball.
+From a sconscript, `env.PublishPackage(...)` with a `GitlabPackagePublisher` builds a toolchain-scoped tarball
+and writes a ``.packaged`` stamp beside it in ``final/``. When staged headers and libs are not newer than the
+existing archive, cuppa skips recreating the tarball — so a follow-up ``cuppa --rel --publish-package`` can
+upload without re-tarring multi-gigabyte trees.
 Add `--publish-package` to upload it to the GitLab generic registry.
 `env.InstallPackage(...)` installs a package into the local cuppa dependencies layout.
 

--- a/tests/unit/test_gitlab_package_publisher.py
+++ b/tests/unit/test_gitlab_package_publisher.py
@@ -1,0 +1,137 @@
+import time
+
+import pytest
+
+from cuppa.package_managers import gitlab
+
+
+pytestmark = pytest.mark.unit
+
+
+def _publisher_env( tmp_path, touched=None ):
+    class Env:
+        abs_final_dir = str( tmp_path )
+
+        def __getitem__( self, key ):
+            if key == 'abs_final_dir':
+                return str( tmp_path )
+            raise KeyError( key )
+
+        def Execute( self, action ):
+            if touched is not None:
+                touched.append( action )
+
+    return Env()
+
+
+def test_package_sidecar_id():
+    path = "widget/2.0.0/widget_debian_gcc15_rel_x86_64_cxx2c.tar.gz"
+    assert gitlab.package_sidecar_id( path, '.packaged' ) == (
+        "widget_2_0_0_widget_debian_gcc15_rel_x86_64_cxx2c.packaged"
+    )
+
+
+def test_package_archive_is_up_to_date(tmp_path):
+    staging = tmp_path / "widget" / "1.0.0"
+    include_dir = staging / "include"
+    lib_dir = staging / "lib"
+    include_dir.mkdir( parents=True )
+    lib_dir.mkdir( parents=True )
+    ( include_dir / "widget.hpp" ).write_text( "header\n", encoding="utf-8" )
+    ( lib_dir / "libwidget.a" ).write_text( "lib\n", encoding="utf-8" )
+    time.sleep( 0.02 )
+
+    archive = tmp_path / "widget_debian_gcc15_rel.tar.gz"
+    archive.write_bytes( b"archive" )
+
+    assert gitlab.package_archive_is_up_to_date(
+            str( archive ),
+            [ str( include_dir ), str( lib_dir ) ],
+    )
+
+    ( lib_dir / "libwidget.a" ).write_text( "updated\n", encoding="utf-8" )
+    assert not gitlab.package_archive_is_up_to_date(
+            str( archive ),
+            [ str( include_dir ), str( lib_dir ) ],
+    )
+
+
+def test_build_package_skips_create_when_archive_current( tmp_path, monkeypatch ):
+    create_calls = []
+
+    def _record_create( archive_path, working_dir, source_dir ):
+        create_calls.append( ( archive_path, working_dir, source_dir ) )
+        return 0
+
+    monkeypatch.setattr( gitlab, 'create_package_archive', _record_create )
+
+    staging = tmp_path / "widget" / "1.0.0"
+    include_dir = staging / "include"
+    lib_dir = staging / "lib"
+    include_dir.mkdir( parents=True )
+    lib_dir.mkdir( parents=True )
+    ( include_dir / "widget.hpp" ).write_text( "header\n", encoding="utf-8" )
+    ( lib_dir / "libwidget.a" ).write_text( "lib\n", encoding="utf-8" )
+    time.sleep( 0.02 )
+
+    archive = tmp_path / "widget_debian_gcc15_rel.tar.gz"
+    archive.write_bytes( b"archive" )
+
+    stamp = tmp_path / "widget_debian_gcc15_rel.packaged"
+    publisher = gitlab.GitlabPackagePublisher.__new__( gitlab.GitlabPackagePublisher )
+    publisher._target_include_dir = str( include_dir )
+    publisher._target_lib_dir = str( lib_dir )
+    publisher._package_base_dir = str( staging )
+    publisher._package_archive = str( archive )
+    publisher._package_source_dir = "widget"
+    publisher._package_file_name = archive.name
+    publisher._source_lib_dir = str( lib_dir )
+
+    touched = []
+    env = _publisher_env( tmp_path, touched )
+
+    assert publisher.build_package( [ str( stamp ) ], [], env ) is None
+    assert create_calls == []
+    assert touched
+
+
+def test_build_package_creates_archive_when_staging_newer( tmp_path, monkeypatch ):
+    create_calls = []
+
+    monkeypatch.setattr(
+            gitlab,
+            'create_package_archive',
+            lambda archive_path, working_dir, source_dir: create_calls.append(
+                    ( archive_path, working_dir, source_dir )
+            ) or 0,
+    )
+
+    staging = tmp_path / "widget" / "1.0.0"
+    include_dir = staging / "include"
+    lib_dir = staging / "lib"
+    include_dir.mkdir( parents=True )
+    lib_dir.mkdir( parents=True )
+    ( include_dir / "widget.hpp" ).write_text( "header\n", encoding="utf-8" )
+    ( lib_dir / "libwidget.a" ).write_text( "lib\n", encoding="utf-8" )
+
+    archive = tmp_path / "widget_debian_gcc15_rel.tar.gz"
+    archive.write_bytes( b"old" )
+    time.sleep( 0.02 )
+    ( lib_dir / "libwidget.a" ).write_text( "new\n", encoding="utf-8" )
+
+    stamp = tmp_path / "widget_debian_gcc15_rel.packaged"
+    publisher = gitlab.GitlabPackagePublisher.__new__( gitlab.GitlabPackagePublisher )
+    publisher._target_include_dir = str( include_dir )
+    publisher._target_lib_dir = str( lib_dir )
+    publisher._package_base_dir = str( staging )
+    publisher._package_archive = str( archive )
+    publisher._package_source_dir = "widget"
+    publisher._package_file_name = archive.name
+    publisher._source_lib_dir = str( lib_dir )
+
+    env = _publisher_env( tmp_path )
+
+    assert publisher.build_package( [ str( stamp ) ], [], env ) is None
+    assert create_calls == [
+            ( str( archive ), str( tmp_path ), "widget" ),
+    ]


### PR DESCRIPTION
## Summary

Fixes [#204](https://github.com/ja11sop/cuppa/issues/204): `cuppa --rel --publish-package` no longer re-tars a GitLab package when the existing archive in `final/` is still current relative to staged headers/libs.

- `PublishPackage` build target is now a ``.packaged`` stamp (parallel to ``.published`` for upload).
- `build_package` compares staged tree mtimes against the archive and skips `tar`/`zip` when nothing changed.
- Upload still uses the existing ``*.tar.gz`` / ``*.zip`` path.

On a typical publish-only rerun (unchanged CMake/install output), SCons should treat the ``.packaged`` stamp as up to date and skip `build_package` entirely — no retar and no full-tree walk.

**Follow-on (not in this PR):** CMake / multi-gigabyte install trees that stage under `final/<package>/<version>/` still pay a one-time copy and can go stale on reinstall — tracked in [#209](https://github.com/ja11sop/cuppa/issues/209) (see google_cloud_cpp example on #204).

## Test plan

- [x] `pytest tests/unit/test_gitlab_package_publisher.py`
- [x] `pytest -m unit`
- [x] CI green on matrix