### PR TITLE
Mirror compile object paths under working/ for nested sources (#213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Compile()` mirrors nested source paths under `working/` so same-basename objects no longer
   collide ([#213](https://github.com/ja11sop/cuppa/issues/213)).
 - `--cxx-profiles-report` inventory Progress ordering: `Finished variant` now `Depends` on build
-  targets (not `Requires` alone), so process test suites finish before the suite summary runs.
+  targets (not `Requires` alone), so process test suites finish before the suite summary runs
+  ([#215](https://github.com/ja11sop/cuppa/issues/215)).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Compile()` mirrors nested source paths under `working/` so same-basename objects no longer
+  collide ([#213](https://github.com/ja11sop/cuppa/issues/213)).
+- `--cxx-profiles-report` inventory Progress ordering: `Finished variant` now `Depends` on build
+  targets (not `Requires` alone), so process test suites finish before the suite summary runs.
+
 ### Security
 
 ## [1.8.0] - 2026-08-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--cxx-profiles-report` inventory Progress ordering: `Finished variant` now `Depends` on build
   targets (not `Requires` alone), so process test suites finish before the suite summary runs
   ([#215](https://github.com/ja11sop/cuppa/issues/215)).
+- Profiles scope parsing labels root-``sconscript`` variant dirs correctly (`dbg`, not `_unknown`).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   targets (not `Requires` alone), so process test suites finish before the suite summary runs
   ([#215](https://github.com/ja11sop/cuppa/issues/215)).
 - Profiles scope parsing labels root-``sconscript`` variant dirs correctly (`dbg`, not `_unknown`).
+- Profiles source pages honour ``--reports-link-style`` / ``--cxx-profiles-report-link-style`` when
+  writing the session index at ``sconstruct_end`` (use the cuppa env from activate, not Progress
+  ``empty_env``).
+- Profiles per-file violation summary table uses a **Violations** column (line count) instead of
+  **Distinct/Unique**.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``empty_env``).
 - Profiles per-file violation summary table uses a **Violations** column (line count) instead of
   **Distinct/Unique**.
+- Profiles GitHub/GitLab source links normalise ``git@`` remotes to ``https://`` blob URLs, strip
+  ``…/working/`` compile paths when building repository hrefs, and show the blob URL as the
+  visible link text (local paths remain for ``local`` link style).
 
 ### Security
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -474,7 +474,7 @@ Design: [`native-toolchain-output.md`](design/plans/native-toolchain-output.md),
 
 Experimental Cuppa build of a public C++20 library (Boost.Capy, 2026-08-17) surfaced two platform gaps before a published migration tutorial is honest.
 
-Design: [#213](https://github.com/ja11sop/cuppa/issues/213) (compile object paths), [`sconscript-exports.md`](design/plans/sconscript-exports.md), [`cmake-to-cuppa-migration.md`](design/plans/cmake-to-cuppa-migration.md).
+Design: [#213](https://github.com/ja11sop/cuppa/issues/213) (compile object paths), [`sconscript-exports.md`](design/plans/sconscript-exports.md), [`cmake-to-cuppa-migration.md`](design/plans/cmake-to-cuppa-migration.md), [`static-glob-rename.md`](design/plans/static-glob-rename.md).
 
 ### Today
 
@@ -492,6 +492,7 @@ Design: [#213](https://github.com/ja11sop/cuppa/issues/213) (compile object path
 | `compile-object-paths` | Mirror source tree (or mangled names) under `working/` for `Compile` | High | [#213](https://github.com/ja11sop/cuppa/issues/213); unblock RecursiveGlob — **follow-on PR before migration doc** |
 | `sconscript-exports` | Export registry or explicit tree; dedupe discovered paths | Medium | [`sconscript-exports.md`](design/plans/sconscript-exports.md) |
 | `cmake-to-cuppa-migration` | Antora matrix + phased tutorial + agent checklist | Medium | After compile fix for honest Glob story — [`cmake-to-cuppa-migration.md`](design/plans/cmake-to-cuppa-migration.md) |
+| `static-glob` | `StaticGlob` + shared path vocabulary; deprecate `RecursiveGlob` / `GlobFiles`; Filter + dynamic Glob docs | Medium | [`static-glob-rename.md`](design/plans/static-glob-rename.md) |
 
 ### Out of scope (layout / migration)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -517,7 +517,8 @@ Design: [#213](https://github.com/ja11sop/cuppa/issues/213) (compile object path
 
 | ID | Work | Priority | Notes |
 |----|------|----------|-------|
-| `doc-methods-split` | Hub + per-method Antora pages; optional SCons companions | Medium | [`methods-pages-split.md`](design/plans/methods-pages-split.md); **1.8.0 candidate** (docs-only) |
+| `method-behaviour-audit` | Fix output-path naming + document evaluation/returns taxonomy | High | [#213](https://github.com/ja11sop/cuppa/issues/213) first; doc/asset emitters — [`method-behaviour-audit.md`](design/plans/method-behaviour-audit.md); **before** Methods doc split |
+| `doc-methods-split` | Hub + per-method Antora pages; optional SCons companions | Medium | [`methods-pages-split.md`](design/plans/methods-pages-split.md); **after behaviour audit** (docs-only) |
 | `doc-antora-ui` | Custom UI bundle + supplemental CSS | Low | [`antora-ui-bundle.md`](design/plans/antora-ui-bundle.md); **1.8.0 optional** |
 | `doc-output-samples` | Capture report output as semantic HTML for Antora and local preview | Low | [`colourised-doc-samples.md`](design/plans/colourised-doc-samples.md) |
 | `doc-folder-layout` | Page folders mirroring nav (dependencies/, cxx-profiles/, toolchains/) | Low | **Shipped** — [`doc-folder-layout.md`](design/archive/doc-folder-layout.md) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ Cycle opened ([#183](https://github.com/ja11sop/cuppa/pull/183)); **`1.8.0`** cl
 | `boost_package.use_libs` no source Boost pull | [#206](https://github.com/ja11sop/cuppa/issues/206) / [#207](https://github.com/ja11sop/cuppa/pull/207) |
 | GitLab publish skip retar (``.packaged`` stamp) | [#204](https://github.com/ja11sop/cuppa/issues/204) / [#208](https://github.com/ja11sop/cuppa/pull/208) |
 
-**Deferred to 1.8.1+:** console bundle (`--terse-output`, log hygiene, `cuppa --info` — see plans under Build console output); `prof-report-scope-filter` ([#205](https://github.com/ja11sop/cuppa/issues/205)); Boost package identity slices ([`boost-updates.md`](design/plans/boost-updates.md)); GitLab CMake staging ([#209](https://github.com/ja11sop/cuppa/issues/209)); optional `--native-output`; docs-only Antora UI / methods split.
+**Deferred to 1.8.1+:** console bundle (`--terse-output`, log hygiene, `cuppa --info` — see plans under Build console output); `prof-report-scope-filter` ([#205](https://github.com/ja11sop/cuppa/issues/205)); Boost package identity slices ([`boost-updates.md`](design/plans/boost-updates.md)); GitLab CMake staging ([#209](https://github.com/ja11sop/cuppa/issues/209)); optional `--native-output`; docs-only Antora UI / methods split; **`compile-object-paths`** ([#213](https://github.com/ja11sop/cuppa/issues/213)); **sconscript export/sharing** ([`sconscript-exports.md`](design/plans/sconscript-exports.md)); CMake migration guide ([`cmake-to-cuppa-migration.md`](design/plans/cmake-to-cuppa-migration.md)).
 
 ---
 
@@ -467,6 +467,38 @@ Design: [`native-toolchain-output.md`](design/plans/native-toolchain-output.md),
 |----|------|--------|
 | `console-cmake-clone` | Pixel-perfect Ninja/CMake transcript | Cuppa keeps SCons progress semantics |
 | `console-list-terse` | Terse mode for `--list-*` / wipe judgement trees | Reports are the product |
+
+---
+
+## SCons project layout and CMake migration
+
+Experimental Cuppa build of a public C++20 library (Boost.Capy, 2026-08-17) surfaced two platform gaps before a published migration tutorial is honest.
+
+Design: [#213](https://github.com/ja11sop/cuppa/issues/213) (compile object paths), [`sconscript-exports.md`](design/plans/sconscript-exports.md), [`cmake-to-cuppa-migration.md`](design/plans/cmake-to-cuppa-migration.md).
+
+### Today
+
+| Capability | Status |
+|------------|--------|
+| Single root `sconscript` + `env.Build*` / `RecursiveGlob` | Yes — when source basenames are unique per variant |
+| Cuppa auto-discovers every `sconscript` under launch dir | Yes — each run gets standard `env` exports only |
+| Nested `SConscript(..., exports=...)` + discovery | **No** — child scripts cannot import parent build nodes; duplicate invocation risk |
+| CMake-equivalent `GLOB_RECURSE` into one static lib | **Broken** when two `.cpp` files share a basename |
+
+### Planned / potential
+
+| ID | Work | Priority | Notes |
+|----|------|----------|-------|
+| `compile-object-paths` | Mirror source tree (or mangled names) under `working/` for `Compile` | High | [#213](https://github.com/ja11sop/cuppa/issues/213); unblock RecursiveGlob — **follow-on PR before migration doc** |
+| `sconscript-exports` | Export registry or explicit tree; dedupe discovered paths | Medium | [`sconscript-exports.md`](design/plans/sconscript-exports.md) |
+| `cmake-to-cuppa-migration` | Antora matrix + phased tutorial + agent checklist | Medium | After compile fix for honest Glob story — [`cmake-to-cuppa-migration.md`](design/plans/cmake-to-cuppa-migration.md) |
+
+### Out of scope (layout / migration)
+
+| ID | Item | Reason |
+|----|------|--------|
+| `migrate-autogen` | Automatic `CMakeLists.txt` → sconscript converter | Manual patterns first |
+| `migrate-superproject` | Boost-style monolithic meta-build | Different problem from standalone migration |
 
 ---
 

--- a/cuppa/cpp/cxx_modules.py
+++ b/cuppa/cpp/cxx_modules.py
@@ -51,27 +51,16 @@ def modules_dir( env ):
 
 
 def object_target_for( env, source, obj_prefix, obj_suffix ):
-    """
-    Map a source to its object node.
-
-    Module interface suffixes (.cppm / .cxxm / .ccm) keep the extension in the
-    object stem (e.g. calc.cppm → calc.cppm.o) so they do not collide with a
-    same-basename implementation unit (calc.cpp → calc.o).
-    """
     from cuppa.cpp.module_scanner import INTERFACE_SUFFIXES
+    from cuppa.utility.object_target import object_target_for as resolve_object_target
 
-    basename = os.path.split( str( source ) )[1]
-    stem, ext = os.path.splitext( basename )
-    if ext.lower() in INTERFACE_SUFFIXES:
-        target = basename  # keep "calc.cppm" so object is calc.cppm.o
-    else:
-        target = stem
-    if not source.path.startswith( env['build_root'] ):
-        if os.path.isabs( str( source ) ):
-            return env.File( os.path.join( obj_prefix + target + obj_suffix ) )
-        return env.File( os.path.join( env['build_dir'], obj_prefix + target + obj_suffix ) )
-    offset_dir = os.path.relpath( os.path.split( source.path )[0], env['build_dir'] )
-    return env.File( os.path.join( offset_dir, obj_prefix + target + obj_suffix ) )
+    return resolve_object_target(
+        env,
+        source,
+        obj_prefix,
+        obj_suffix,
+        interface_suffixes=INTERFACE_SUFFIXES,
+    )
 
 
 def _source_abspath( source ):

--- a/cuppa/cpp/profiles_report/inventory.py
+++ b/cuppa/cpp/profiles_report/inventory.py
@@ -47,10 +47,13 @@ def parse_variant_scope_fields( variant_dir ):
     """Derive toolchain and variant label from a cuppa variant directory path.
 
     Variant dirs end with ``<toolchain>/<variant>/<arch>/<abi>`` under ``_build/…`` —
-    see ``cuppa.core.build_layout.tool_variant_dir``.
+    see ``cuppa.core.build_layout.tool_variant_dir``. Root ``sconscript`` layouts omit a
+    project path segment between ``_build/`` and the toolchain folder.
     """
     parts = variant_dir.strip( '/' ).split( '/' )
-    if len( parts ) < 6 or parts[ 0 ] != '_build':
+    # ``_build/<optional-sconscript-path>/<toolchain>/<variant>/<arch>/<abi>`` — root
+    # sconscript has no middle segment (five parts); nested sconscripts have six or more.
+    if len( parts ) < 5 or parts[ 0 ] != '_build':
         return '_unknown', '_unknown'
     return parts[ -4 ], parts[ -3 ]
 

--- a/cuppa/cpp/profiles_report/report_html.py
+++ b/cuppa/cpp/profiles_report/report_html.py
@@ -528,6 +528,7 @@ def enrich_model_for_html(
             link_style,
             link_base,
             display,
+            env,
             suppress_source_links=suppress_source_links,
         )
         file_entry[ 'path_tooltip' ] = file_path_tooltip_text( file_entry )

--- a/cuppa/cpp/profiles_report/source_pages.py
+++ b/cuppa/cpp/profiles_report/source_pages.py
@@ -355,6 +355,61 @@ def build_source_page_title( display_path, source_path, env ):
     }
 
 
+def remote_href_display_path( path, env ):
+    """Repo-relative path for ``github`` / ``gitlab`` blob URLs (not human display)."""
+    if not path:
+        return path
+
+    normalized = os.path.normpath( path ).replace( '\\', '/' )
+    if _WORKING_DIR_MARKER in normalized:
+        return normalized.split( _WORKING_DIR_MARKER, 1 )[ 1 ]
+
+    storage_root = _storage_root_for_path( path, env )
+    if storage_root:
+        rel = _try_relpath( path, storage_root )
+        if rel:
+            parts = rel.split( '/', 1 )
+            remainder = parts[ 1 ] if len( parts ) > 1 else ''
+            if remainder:
+                return remainder
+            return rel
+
+    for root in ( env.get( 'sconstruct_dir' ), env.get( 'cxx_profiles_report_root' ) ):
+        rel = _try_relpath( path, root )
+        if rel:
+            if _WORKING_DIR_MARKER in rel:
+                return rel.split( _WORKING_DIR_MARKER, 1 )[ 1 ]
+            return rel
+
+    return path
+
+
+def href_display_path( path, env, link_style, display ):
+    """Choose the path segment appended to a remote blob base."""
+    if link_style in ( 'github', 'gitlab' ):
+        return remote_href_display_path( path, env )
+    return display
+
+
+def source_path_link_label( path, env, link_style, link_base, display ):
+    """Return visible link text that matches what the href opens."""
+    if link_style == 'local':
+        return display_path_on_disk( path )
+    if link_style in ( 'github', 'gitlab' ):
+        from cuppa.cpp.profiles_report.report_html import source_href
+
+        href = source_href(
+            path,
+            None,
+            link_style,
+            link_base,
+            href_display_path( path, env, link_style, display ),
+        )
+        if href:
+            return href
+    return display_path_on_disk( path )
+
+
 def display_path_on_disk( path ):
     """Shorten an on-disk path with a leading ``~/`` when under the home directory."""
     if not path:
@@ -607,12 +662,27 @@ def write_source_pages(
         title = build_source_page_title( display, source_path, env )
         gutter_width_ch = compute_gutter_width_ch( file_entry )
         index_href = '../{}'.format( index_basename )
+        href_path = href_display_path( source_path, env, link_style, display )
+        original_href = source_href(
+            source_path,
+            None,
+            link_style,
+            link_base,
+            href_path,
+        )
+        source_path_display = source_path_link_label(
+            source_path,
+            env,
+            link_style,
+            link_base,
+            display,
+        )
         with open( page_abs, 'w', encoding='utf-8' ) as handle:
             handle.write(
                 template.render(
                     file_entry=file_entry,
                     source_path=source_path,
-                    source_path_display=display_path_on_disk( source_path ),
+                    source_path_display=source_path_display,
                     display_path=display,
                     source_lines=source_lines,
                     source_language=language_for_source( source_path ),
@@ -625,13 +695,7 @@ def write_source_pages(
                         title_prefix=title.get( 'title_prefix', '' ),
                         title_suffix=title.get( 'title_suffix', '' ),
                     ),
-                    original_href=source_href(
-                        source_path,
-                        None,
-                        link_style,
-                        link_base,
-                        display,
-                    ),
+                    original_href=original_href,
                     **title,
                 )
             )
@@ -646,6 +710,7 @@ def annotate_file_links(
     link_style,
     link_base,
     display,
+    env,
     suppress_source_links=False,
 ):
     """Attach report page hrefs for templates and JSON."""
@@ -663,12 +728,13 @@ def annotate_file_links(
         file_entry[ 'page_href' ] = page_rel
         file_entry[ 'href' ] = page_rel
     else:
+        href_path = href_display_path( file_entry[ 'path' ], env, link_style, display )
         file_entry[ 'href' ] = source_href(
             file_entry[ 'path' ],
             None,
             link_style,
             link_base,
-            display,
+            href_path,
         )
     for location in file_entry.get( 'locations', [] ):
         page = source_page_map.get( file_entry[ 'path' ] )
@@ -680,5 +746,5 @@ def annotate_file_links(
                 location.get( 'line' ),
                 link_style,
                 link_base,
-                display,
+                href_display_path( file_entry[ 'path' ], env, link_style, display ),
             )

--- a/cuppa/cpp/profiles_report_collector.py
+++ b/cuppa/cpp/profiles_report_collector.py
@@ -101,10 +101,16 @@ class ProfilesReportSession(object):
         self._emit_session_summary( env, fallback_flush=fallback_flush )
         return True
 
+    def _write_env( self, progress_env ):
+        """Prefer the cuppa env captured at activate time over Progress ``empty_env``."""
+        report_env = ProfilesDiagnosticCollector._report_env
+        return report_env if report_env is not None else progress_env
+
     def _emit_session_summary( self, env, fallback_flush=False ):
         from cuppa.cpp.profiles_report.report_html import write_profiles_reports
         from cuppa.reports.manifest import append_cxx_profiles_entry
 
+        write_env = self._write_env( env )
         with self._lock:
             if self._written:
                 return
@@ -133,14 +139,14 @@ class ProfilesReportSession(object):
             translation_units = frozenset( self._translation_units )
         result = write_profiles_reports(
             self._inventory,
-            env,
+            write_env,
             incomplete_scopes=incomplete,
             parsed_files=parsed_files,
             translation_units=translation_units,
         )
         if result:
             append_cxx_profiles_entry(
-                env,
+                write_env,
                 result[ 'model' ],
                 result[ 'session_paths' ],
                 result[ 'scope_paths' ],

--- a/cuppa/cpp/run_process_test.py
+++ b/cuppa/cpp/run_process_test.py
@@ -121,9 +121,13 @@ class TestSuite(object):
 
 
     def _write_test_case( self, test_case ):
-        expected = test_case['expected'] == test_case['status']
-        passed   = test_case['status'] == 'passed'
-        meaning  = test_case['status']
+        status = test_case.get( 'status' )
+        if status is None:
+            return
+
+        expected = test_case['expected'] == status
+        passed   = status == 'passed'
+        meaning  = status
 
         if not expected and passed:
             meaning = 'unexpected_success'
@@ -169,6 +173,8 @@ class TestSuite(object):
         )
 
         for test in self._tests:
+            if 'status' not in test:
+                continue
             sys.stdout.write(
                 as_emphasised( "\nTest case [{}]".format( test['name'] ) ) + '\n'
             )

--- a/cuppa/cpp/run_process_test.py
+++ b/cuppa/cpp/run_process_test.py
@@ -426,6 +426,7 @@ class RunProcessTest(object):
 
         except OSError as e:
             logger.error( "Execution of [{}] failed with error: {}".format( as_notice(test_command), as_notice(str(e)) ) )
+            test_suite.exit_test( test_case, 'aborted' )
             raise BuildError( e )
 
 

--- a/cuppa/cpp/templates/cxx_profiles_source_file.html
+++ b/cuppa/cpp/templates/cxx_profiles_source_file.html
@@ -161,7 +161,7 @@
               <thead>
                 <tr>
                   <th class="prof-summary-col-rule">Profile::Rule</th>
-                  <th class="prof-summary-col-metric text-center">{% include 'cxx_profiles_partial_heading_distinct_unique.html' %}</th>
+                  <th class="prof-summary-col-metric text-center">Violations</th>
                   <th class="prof-summary-col-metric text-center">Union Refs</th>
                   <th class="prof-summary-col-message">Violation Message</th>
                 </tr>
@@ -171,9 +171,7 @@
                 <tr>
                   <td class="prof-summary-detail prof-summary-col-rule"><span class="prof-mono">{{ item.rule_label_html | safe }}</span></td>
                   <td class="prof-summary-detail prof-summary-col-metric text-center">
-                    {% set distinct = 1 %}
-                    {% set unique = item.line_count %}
-                    <span class="prof-mono">{% include 'cxx_profiles_partial_distinct_unique_value.html' %}</span>
+                    <span class="prof-mono">{{ item.line_count }}</span>
                   </td>
                   <td class="prof-summary-detail prof-summary-col-metric text-center"><span class="prof-mono">{{ item.count }}</span></td>
                   <td class="prof-summary-detail prof-summary-col-message"><div class="prof-violation-message">{{ item.violation_message_html | safe }}</div></td>

--- a/cuppa/methods/compile.py
+++ b/cuppa/methods/compile.py
@@ -15,6 +15,7 @@ from SCons.Node import Node
 
 from cuppa.colourise import as_notice
 from cuppa.log import logger
+from cuppa.utility.object_target import object_target_for
 
 
 class CompileMethod:
@@ -66,16 +67,7 @@ class CompileMethod:
             if os.path.splitext(str(source))[1] == obj_suffix:
                 objects.append( source )
             else:
-                target = None
-                target = os.path.splitext( os.path.split( str(source) )[1] )[0]
-                if not source.path.startswith( env['build_root'] ):
-                    if os.path.isabs( str(source) ):
-                        target = env.File( os.path.join( obj_prefix + target + obj_suffix ) )
-                    else:
-                        target = env.File( os.path.join( env['build_dir'], obj_prefix + target + obj_suffix ) )
-                else:
-                    offset_dir = os.path.relpath( os.path.split( source.path )[0], env['build_dir'] )
-                    target = env.File( os.path.join( offset_dir, obj_prefix + target + obj_suffix ) )
+                target = object_target_for( env, source, obj_prefix, obj_suffix )
 
                 logger.trace( "Object target = [{}]/[{}]".format( as_notice(str(target)), as_notice(target.path) ) )
 

--- a/cuppa/progress.py
+++ b/cuppa/progress.py
@@ -142,15 +142,12 @@ class NotifyProgress(object):
         if variant not in cls._finished:
             cls._finished[variant] = progress( 'Finished', 'finished', sconscript, variant, env )
 
-        if cls.inventory_report_mode():
-            file_deps = [ '#' + env['sconscript_file'], '#' + env['sconstruct_file'] ]
-            finished = env.Depends( cls._finished[variant], file_deps )
-            env.Requires( cls._finished[variant], target )
-        else:
-            finished = env.Depends(
-                    cls._finished[variant],
-                    [ target, '#' + env['sconscript_file'], '#' + env['sconstruct_file'] ]
-            )
+        file_deps = [ '#' + env['sconscript_file'], '#' + env['sconstruct_file'] ]
+        # Depends enforces build order. Requires alone does not — using only Requires in
+        # inventory mode let Finished run before long Run/Test actions completed.
+        env.Depends( cls._finished[variant], file_deps )
+        env.Depends( cls._finished[variant], target )
+        finished = cls._finished[variant]
 
         if not sconscript in cls._end:
             cls._end[sconscript] = progress( 'End', 'end', sconscript, None, sconscript_env )

--- a/cuppa/progress.py
+++ b/cuppa/progress.py
@@ -143,8 +143,8 @@ class NotifyProgress(object):
             cls._finished[variant] = progress( 'Finished', 'finished', sconscript, variant, env )
 
         file_deps = [ '#' + env['sconscript_file'], '#' + env['sconstruct_file'] ]
-        # Depends enforces build order. Requires alone does not — using only Requires in
-        # inventory mode let Finished run before long Run/Test actions completed.
+        # Depends enforces build order. Requires alone does not — inventory mode previously
+        # let Finished run before long Run/Test actions completed ([#215]).
         env.Depends( cls._finished[variant], file_deps )
         env.Depends( cls._finished[variant], target )
         finished = cls._finished[variant]

--- a/cuppa/reports/link_style.py
+++ b/cuppa/reports/link_style.py
@@ -9,7 +9,36 @@
 
 import os
 
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
+
 REPORT_LINK_STYLES = ( 'local', 'gitlab', 'github' )
+
+
+def normalize_repository_browse_url( repository_url ):
+    """Return ``https://host/org/repo`` for ``git@``, ``https://``, and scp-style remotes."""
+    if not repository_url:
+        return None
+    text = str( repository_url ).strip()
+    if not text:
+        return None
+    if '://' in text:
+        parsed = urlparse( text )
+        if parsed.scheme in ( 'http', 'https' ):
+            path = ( parsed.path or '' ).rstrip( '/' )
+            if path.endswith( '.git' ):
+                path = path[:-4]
+            netloc = parsed.netloc.split( '@' )[-1]
+            return 'https://{}{}'.format( netloc, path )
+    from cuppa.core.dependency_identity import short_name_from_git_url
+
+    short = short_name_from_git_url( text )
+    if not short or '/' not in short:
+        return None
+    host, path = short.split( '/', 1 )
+    return 'https://{}/{}'.format( host, path )
 
 
 def resolve_report_link_style(
@@ -35,12 +64,12 @@ def resolve_report_link_style(
 
 def repository_blob_base( repository_url, branch, link_style ):
     """Return the repository blob URL prefix for GitHub or GitLab."""
-    if not repository_url or not branch or link_style not in ( 'gitlab', 'github' ):
+    browse = normalize_repository_browse_url( repository_url )
+    if not browse or not branch or link_style not in ( 'gitlab', 'github' ):
         return ''
-    base = os.path.splitext( str( repository_url ).rstrip( '/' ) )[ 0 ]
     if link_style == 'github':
-        return '{}/blob/{}'.format( base, branch )
-    return '{}/-/blob/{}'.format( base, branch )
+        return '{}/blob/{}'.format( browse, branch )
+    return '{}/-/blob/{}'.format( browse, branch )
 
 
 def initialise_report_linking( env, link_style=None ):
@@ -63,10 +92,14 @@ def initialise_report_linking( env, link_style=None ):
         env.get( 'current_branch' ),
         env.get( 'current_revision' ),
     )
-    if link_style in ( 'gitlab', 'github' ) and url and branch:
-        return repository_blob_base( url, branch, link_style )
-    if url:
-        return url
+    repo_url = repository or url
+    if link_style in ( 'gitlab', 'github' ) and repo_url and branch:
+        blob_base = repository_blob_base( repo_url, branch, link_style )
+        if blob_base:
+            return blob_base
+    browse = normalize_repository_browse_url( repo_url )
+    if browse:
+        return browse
     return ''
 
 

--- a/cuppa/utility/object_target.py
+++ b/cuppa/utility/object_target.py
@@ -1,0 +1,75 @@
+
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   object_target_for
+#-------------------------------------------------------------------------------
+
+import os
+
+
+def _object_subdir_for_source( env, source ):
+    """
+    Directory under build_dir where an object for source should be placed.
+
+    Sources already mirrored under build_root keep their offset from build_dir.
+    Project-relative sources mirror their path under build_dir so nested files
+    with the same basename do not collide. Absolute sources stay flat.
+
+    Use ``source.path`` for layout (SCons ``str(source)`` is often an absolute
+    path even when ``source.path`` is project-relative).
+    """
+    source_path = source.path.replace( '\\', '/' )
+    build_root = env['build_root'].replace( '\\', '/' )
+    build_dir = env['build_dir'].replace( '\\', '/' )
+
+    if source_path.startswith( build_root ):
+        return os.path.relpath( os.path.split( source_path )[0], build_dir )
+
+    if os.path.isabs( source_path ):
+        return ''
+
+    source_dir = os.path.dirname( source_path )
+    if source_dir in ( '', '.' ):
+        return ''
+    return source_dir
+
+
+def object_target_for( env, source, obj_prefix, obj_suffix, *, interface_suffixes=() ):
+    """
+    Map a source to its object node under the variant working directory.
+
+    Returns a path **relative to** ``env['build_dir']`` (the sconscript
+    ``variant_dir``), for example ``src/detail/router/test.o``. SCons places
+    that at ``{build_dir}/src/detail/router/test.o`` on disk — e.g.
+    ``_build/gcc153/dbg/x86_64/cxx2c/working/src/detail/router/test.o`` from
+    the project root.
+
+    Do **not** embed ``build_dir`` in the node path passed to ``env.File``;
+    doing so duplicates the working tree (``working/_build/.../working/...``).
+
+    Module interface suffixes (.cppm / .cxxm / .ccm) keep the extension in the
+    object stem (e.g. calc.cppm → calc.cppm.o) so they do not collide with a
+    same-basename implementation unit (calc.cpp → calc.o).
+    """
+    basename = os.path.split( str( source ) )[1]
+    stem, ext = os.path.splitext( basename )
+    if ext.lower() in interface_suffixes:
+        object_stem = basename
+    else:
+        object_stem = stem
+
+    object_name = obj_prefix + object_stem + obj_suffix
+    object_subdir = _object_subdir_for_source( env, source )
+    source_path = source.path.replace( '\\', '/' )
+
+    if object_subdir:
+        return env.File( os.path.join( object_subdir, object_name ) )
+
+    if os.path.isabs( source_path ):
+        return env.File( os.path.join( obj_prefix + object_stem + obj_suffix ) )
+
+    return env.File( object_name )

--- a/design/README.md
+++ b/design/README.md
@@ -48,6 +48,7 @@ maintainer workflow evolved.
 | [`archive/conan-publish-plan.md`](archive/conan-publish-plan.md) | shipped | Design of `ConanPackagePublisher` and `--publish-package` |
 | [`plans/sconscript-exports.md`](plans/sconscript-exports.md) | proposal | Shared exports between discovered sconscripts; nested lib/test layout |
 | [`plans/cmake-to-cuppa-migration.md`](plans/cmake-to-cuppa-migration.md) | proposal | CMake ↔ Cuppa matrix and migration phases for humans and agents |
+| [`plans/static-glob-rename.md`](plans/static-glob-rename.md) | proposal | Rename RecursiveGlob/GlobFiles to StaticGlob; align path vocabulary with dynamic Glob + Filter |
 
 ## Conventions
 

--- a/design/README.md
+++ b/design/README.md
@@ -46,6 +46,8 @@ maintainer workflow evolved.
 | [`archive/toolchains-as-dependencies.md`](archive/toolchains-as-dependencies.md) | shipped | Fetched compilers as toolchain deps (Clang archives, GCC `.deb` / `--gcc-root=`, multi-select compare; list/force-wipe) — umbrella [#160](https://github.com/ja11sop/cuppa/issues/160); Clang [#159](https://github.com/ja11sop/cuppa/pull/159), GCC [#164](https://github.com/ja11sop/cuppa/pull/164) |
 | [`archive/conan-consumer-plan.md`](archive/conan-consumer-plan.md) | shipped | Design of `conan_deps` / `conan_dependency` consumer support |
 | [`archive/conan-publish-plan.md`](archive/conan-publish-plan.md) | shipped | Design of `ConanPackagePublisher` and `--publish-package` |
+| [`plans/sconscript-exports.md`](plans/sconscript-exports.md) | proposal | Shared exports between discovered sconscripts; nested lib/test layout |
+| [`plans/cmake-to-cuppa-migration.md`](plans/cmake-to-cuppa-migration.md) | proposal | CMake ↔ Cuppa matrix and migration phases for humans and agents |
 
 ## Conventions
 

--- a/design/README.md
+++ b/design/README.md
@@ -26,7 +26,8 @@ maintainer workflow evolved.
 | [`plans/coverage-performance.md`](plans/coverage-performance.md) | proposal | Where `--cov --test` time actually goes, what the A/B measurement ruled out, and the remaining suspects |
 | [`plans/list-toolchains-verbose.md`](plans/list-toolchains-verbose.md) | in progress | Verbose `describe()` shipped ([#172](https://github.com/ja11sop/cuppa/issues/172) / [#170](https://github.com/ja11sop/cuppa/pull/170)); deferred table-driven init |
 | [`plans/antora-ui-bundle.md`](plans/antora-ui-bundle.md) | proposal | Custom Antora UI bundle + supplemental CSS — ROADMAP `doc-antora-ui` |
-| [`plans/methods-pages-split.md`](plans/methods-pages-split.md) | proposal | Hub + per-method Antora pages; optional SCons companion pages — ROADMAP `doc-methods-split` |
+| [`plans/methods-pages-split.md`](plans/methods-pages-split.md) | proposal | Hub + per-method Antora pages; blocked on behaviour audit — ROADMAP `doc-methods-split` |
+| [`plans/method-behaviour-audit.md`](plans/method-behaviour-audit.md) | proposal | Method returns, evaluation time, output-path fixes before Methods doc split |
 | [`plans/native-toolchain-output.md`](plans/native-toolchain-output.md) | proposal | `--native-output`: passthrough native compiler colour — ROADMAP `console-native-output` |
 | [`plans/terse-build-output.md`](plans/terse-build-output.md) | proposal | `--terse-output`: coloured one-line progress — ROADMAP `console-terse-output` / **1.8.0 target** |
 | [`plans/build-log-hygiene.md`](plans/build-log-hygiene.md) | proposal | Configure-time log demotion + variant default message fix — ROADMAP `console-log-hygiene` |

--- a/design/plans/cmake-to-cuppa-migration.md
+++ b/design/plans/cmake-to-cuppa-migration.md
@@ -1,0 +1,104 @@
+# Plan: CMake → Cuppa migration guide (agents and humans)
+
+- **Status:** proposal
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — `cmake-to-cuppa-migration`; [`sconscript-exports.md`](sconscript-exports.md); [#213](https://github.com/ja11sop/cuppa/issues/213)
+- **Updated:** 2026-08-17
+
+## Purpose
+
+Provide a **decision-oriented** guide for moving a CMake-based C++ project (or a slice of it) onto Cuppa: what maps cleanly, what does not yet, and what to do while platform gaps are open.
+
+Audience: maintainers, contributors, and **AI agents** asked to “add a Cuppa build alongside CMake” or “migrate tests to cuppa”.
+
+Canonical product docs stay on the Antora site; this plan defines the **content outline** and the **honest capability matrix** before we publish a tutorial page (likely under Quickstart or a new “Migrating from CMake” page).
+
+## Non-goals
+
+- Replacing CMake inside Boost or other superprojects.
+- Promising feature parity with `FetchContent`, `find_package`, generator expressions, or IDE export in one release.
+- Auto-converting `CMakeLists.txt` — any “translator” is out of scope until manual patterns are stable.
+
+## CMake concept → Cuppa mapping (draft matrix)
+
+| CMake | Cuppa today | Notes / gap |
+|-------|-------------|-------------|
+| `add_library` static/shared | `env.BuildStaticLib` / `env.BuildSharedLib` | Object path collision on nested same-basename sources — [#213](https://github.com/ja11sop/cuppa/issues/213) |
+| `add_executable` + `target_link_libraries` | `env.Build` / `env.BuildTest` | `BuildTest` adds `--test` run via process/boost runner |
+| `target_include_directories` PUBLIC | `env.AppendUnique(CPPPATH=[...])` + package/location deps | |
+| `target_compile_definitions` | `env.AppendUnique(CPPDEFINES=[...])` | Use `Clone()` for private defs (e.g. `*_SOURCE`) |
+| `GLOB_RECURSE` sources | `env.RecursiveGlob` | Fine once compile paths fixed |
+| `add_subdirectory` + target alias | **No export chain** between discovered sconscripts | [`sconscript-exports.md`](sconscript-exports.md) |
+| `CTest` / `add_test` | `--test` + `env.BuildTest` | Custom harnesses (non–Boost.Test) use `default_runner='process'` |
+| `find_package(Boost)` | `boost_package` / built-in Boost | Version/registry-specific |
+| `FetchContent` | `location_dependency` / Conan / GitLab package | Different mental model — link to Dependencies hub |
+| Toolchain / standard | `--toolchains=`, `--stdcpp` | Profiles: separate Profiles Clang archive |
+| Coverage | `--cov --test` | gcov/llvm-cov via cuppa |
+| Install / export | Package publish docs | Not consumer `cmake --install` |
+
+## Recommended migration phases
+
+### Phase 0 — Readiness checklist
+
+- [ ] C++ dialect supported by cuppa toolchains (`--stdcpp` / default `c++2c` on GCC/Clang).
+- [ ] Tests runnable as **process** (exit code) or **Boost.Test** — custom harnesses need one main per executable or a static lib with `main` (Capy `test_suite` pattern).
+- [ ] No hard requirement for nested `add_subdirectory` **until** sconscript exports ship — or use **single root sconscript** interim.
+
+### Phase 1 — Smoke build (library + one test)
+
+1. Add minimal `sconstruct`: `cuppa.run(default_variants=['dbg'])`.
+2. Add `sconscript`: `CPPPATH`, `BuildStaticLib`, one `BuildTest`.
+3. Verify: `cuppa -D --dbg --test --offline`.
+
+Matches [`examples/minimal/`](../../examples/minimal/).
+
+### Phase 2 — Expand sources
+
+1. Replace explicit file lists with `RecursiveGlob` where basenames are unique **or** split libs by subtree until [#213](https://github.com/ja11sop/cuppa/issues/213) lands.
+2. Map `PRIVATE`/`PUBLIC` defs via `Clone()` envs per target class.
+
+### Phase 3 — Tooling extras
+
+- Coverage: `--cov --test`.
+- Profiles inventory: `--cxx-profiles*` + `--cxx-profiles-report` (Profiles Clang only).
+- CI: mirror [`AGENTS.md`](../../AGENTS.md) cuppa flags (`--offline`, `--develop` where applicable).
+
+### Phase 4 — Decompose sconscripts (blocked)
+
+- Split `test/sconscript`, shared libs — **after** export plan ships.
+
+## Agent-oriented guidance (to publish)
+
+Short rules for agents (expand in Antora later):
+
+1. **Do not assume** `SConscript('child', exports=...)` works with Cuppa discovery — read [`sconscript-exports.md`](sconscript-exports.md).
+2. **Do not assume** `RecursiveGlob` equals CMake `GLOB_RECURSE` until object paths are fixed — check for duplicate basenames (`find … -name '*.cpp' | xargs -n1 basename | sort | uniq -d`).
+3. **Prefer** `location_dependency` / `package_dependency` over re-declaring third-party compile flags when a cuppa dep exists.
+4. **Keep CMake** as canonical until the Cuppa graph runs the same test binaries — document “experimental Cuppa” in a sidecar note (see Boost.Capy `CUPPA-NOTES.md` pattern).
+5. **Profiles report** requires Profiles-capable Clang; absence of violations means no HTML index — not a failed capture.
+
+## Validation corpus
+
+| Project shape | Role |
+|---------------|------|
+| [`examples/minimal/`](../../examples/minimal/) | Tiny green path |
+| [`tests/fixtures/dummy_project/`](../../tests/fixtures/dummy_project/) | Glob + BuildTest |
+| Boost.Capy (public) | Real C++20 coroutine library; nested sources + custom test harness; Profiles report — experimental `sconstruct` + `CUPPA-NOTES.md` |
+| Private consumer **project A** (baa-shaped) | Packages + Boost runner — do not name in published docs |
+
+## Deliverables
+
+| ID | Output | Priority |
+|----|--------|----------|
+| `migrate-matrix` | Antora table (CMake ↔ Cuppa) with “gap” callouts | High |
+| `migrate-tutorial` | Step-by-step “library + tests” from a stripped CMakeLists | High |
+| `migrate-agents` | `AGENTS.md` pointer + short agent checklist (link only, no duplicate prose) | Medium |
+| `migrate-profiles` | subsection: Profiles report on a migrated tree | Medium |
+| `migrate-exports` | Update tutorial when sconscript exports land | After `sconscript-exports` |
+
+## Progress snapshot
+
+| Item | Status |
+|------|--------|
+| Boost.Capy experiment | done — surfaced compile + export gaps |
+| Published Antora page | not started — blocked on [#213](https://github.com/ja11sop/cuppa/issues/213) for honest RecursiveGlob story |
+| This plan | proposal |

--- a/design/plans/cmake-to-cuppa-migration.md
+++ b/design/plans/cmake-to-cuppa-migration.md
@@ -26,7 +26,7 @@ Canonical product docs stay on the Antora site; this plan defines the **content 
 | `add_executable` + `target_link_libraries` | `env.Build` / `env.BuildTest` | `BuildTest` adds `--test` run via process/boost runner |
 | `target_include_directories` PUBLIC | `env.AppendUnique(CPPPATH=[...])` + package/location deps | |
 | `target_compile_definitions` | `env.AppendUnique(CPPDEFINES=[...])` | Use `Clone()` for private defs (e.g. `*_SOURCE`) |
-| `GLOB_RECURSE` sources | `env.RecursiveGlob` | Fine once compile paths fixed |
+| `GLOB_RECURSE` sources | `env.StaticGlob` (today `RecursiveGlob`) or SCons `env.Glob('**/*.cpp', …)` | Static = configure snapshot; dynamic = build-graph aware — [`static-glob-rename.md`](static-glob-rename.md) |
 | `add_subdirectory` + target alias | **No export chain** between discovered sconscripts | [`sconscript-exports.md`](sconscript-exports.md) |
 | `CTest` / `add_test` | `--test` + `env.BuildTest` | Custom harnesses (non–Boost.Test) use `default_runner='process'` |
 | `find_package(Boost)` | `boost_package` / built-in Boost | Version/registry-specific |
@@ -71,7 +71,7 @@ Matches [`examples/minimal/`](../../examples/minimal/).
 Short rules for agents (expand in Antora later):
 
 1. **Do not assume** `SConscript('child', exports=...)` works with Cuppa discovery — read [`sconscript-exports.md`](sconscript-exports.md).
-2. **Do not assume** `RecursiveGlob` equals CMake `GLOB_RECURSE` until object paths are fixed — check for duplicate basenames (`find … -name '*.cpp' | xargs -n1 basename | sort | uniq -d`).
+2. **Do not assume** `RecursiveGlob` / `StaticGlob` equals CMake `GLOB_RECURSE` evaluation semantics — static until re-configure; see [`static-glob-rename.md`](static-glob-rename.md). Check duplicate basenames (`find … -name '*.cpp' | xargs -n1 basename | sort | uniq -d`) — [#213](https://github.com/ja11sop/cuppa/issues/213).
 3. **Prefer** `location_dependency` / `package_dependency` over re-declaring third-party compile flags when a cuppa dep exists.
 4. **Keep CMake** as canonical until the Cuppa graph runs the same test binaries — document “experimental Cuppa” in a sidecar note (see Boost.Capy `CUPPA-NOTES.md` pattern).
 5. **Profiles report** requires Profiles-capable Clang; absence of violations means no HTML index — not a failed capture.

--- a/design/plans/cxx-profiles-report.md
+++ b/design/plans/cxx-profiles-report.md
@@ -426,8 +426,8 @@ hrefs still use the project repository until the follow-up slice below.
 
 ### Follow-up: per-repo `remote` link style (patch release)
 
-**Status:** proposal — file a patch issue after [#214](https://github.com/ja11sop/cuppa/pull/214)
-merges; implement on a fresh branch.
+**Status:** proposal — implement on a fresh branch after [#214](https://github.com/ja11sop/cuppa/pull/214)
+merges ([#216](https://github.com/ja11sop/cuppa/issues/216)).
 
 Add **`remote`** to `REPORT_LINK_STYLES` (and CLI choices). Keep **`github`** / **`gitlab`** as
 **force-all overrides** when the whole tree lives on one host.
@@ -1682,7 +1682,7 @@ Target cycle: **1.8.0** for **`prof-report-parser` … `prof-report-manifest`** 
 3. **Report-only exit code:** optional `--cxx-profiles-report-allow-errors` if inventory runs should succeed?
 4. **Cross-variant roll-up:** session **union** for headline / Overview (settled); By-Rule / By-File show **per-build Hits + common/delta** display ([§Variant roll-up display](#prof-report-variant-roll-up-display)) — Antora documents both.
 5. **GitHub `link_style`:** → **Settled** — shared helper in `link_style.py`; per-repo **`remote`**
-   style deferred to follow-up slice above (patch issue after #214).
+   style tracked in [#216](https://github.com/ja11sop/cuppa/issues/216).
 6. **`_unscoped` bucket:** when spawn scope cannot be derived, record under session `_unscoped` with warning in HTML — never guess variant.
 7. **Implied `-i`:** → **Settled yes** — [#199](https://github.com/ja11sop/cuppa/issues/199) / [§Collate index semantics](#prof-report-method-semantics-slice).
 8. **Progress vs failed compiles:** → **Settled yes** — Progress decoupling + fallback flush — [#199](https://github.com/ja11sop/cuppa/issues/199).

--- a/design/plans/cxx-profiles-report.md
+++ b/design/plans/cxx-profiles-report.md
@@ -2,7 +2,7 @@
 
 - **Status:** in progress
 - **Related:** [`ROADMAP.md`](../../ROADMAP.md) — C++ Profiles (`profiles-violation-report`); umbrella [#184](https://github.com/ja11sop/cuppa/issues/184) (closed); semantics [#199](https://github.com/ja11sop/cuppa/issues/199) shipped [#203](https://github.com/ja11sop/cuppa/pull/203); scope filter follow-on [§Collate index scope filter](#prof-report-scope-filter-slice); shipped enablement [`archive/cxx-profiles.md`](../archive/cxx-profiles.md); [`removal-options.md`](removal-options.md) §4.6 Phase 6 artefacts [#135](https://github.com/ja11sop/cuppa/issues/135); test/coverage report patterns (`cuppa/test_report/`, `cuppa/cpp/run_gcov_coverage.py`)
-- **Updated:** 2026-08-16
+- **Updated:** 2026-08-17
 - **Impact:** minor — new opt-in CLI flag and HTML artefacts; no change to default builds
 
 ## Why
@@ -381,6 +381,9 @@ the method default when CI publishes artefacts.
 | `gitlab` | `{remote}/-/blob/{branch}/{relpath}#L{line}` | GitLab CI published artefacts |
 | `github` | `{remote}/blob/{branch}/{relpath}#L{line}` | GitHub Actions published artefacts |
 
+Source-page **link text** matches the active style: local paths for `local`, full blob URL for
+`github` / `gitlab` (same string as the href, without the line fragment).
+
 **Path rebasing:** map absolute diagnostic paths (including dependency trees under
 `~/_cuppa/_download/…`) to a **repo-relative** path when under `sconstruct_dir` or
 `--cxx-profiles-report-root=`; otherwise show absolute path with `local` link only (no remote blob —
@@ -416,6 +419,38 @@ Slice **E** (`env.CollateCxxProfilesIndex(…, link_style=…)`) mirrors `Collat
 `CollateTestReportIndex` kwargs (destination, link_style).
 Collated master index passes `link_style="raw"` VCS metadata into the template header (same as test
 suite index).
+
+**Known limitation (v1 `github` / `gitlab`):** one blob base from the **project** VCS applies to
+every href. Dependency sources get human-readable `host/org/repo@branch/…` display paths but remote
+hrefs still use the project repository until the follow-up slice below.
+
+### Follow-up: per-repo `remote` link style (patch release)
+
+**Status:** proposal — file a patch issue after [#214](https://github.com/ja11sop/cuppa/pull/214)
+merges; implement on a fresh branch.
+
+Add **`remote`** to `REPORT_LINK_STYLES` (and CLI choices). Keep **`github`** / **`gitlab`** as
+**force-all overrides** when the whole tree lives on one host.
+
+| `link_style` | Href shape | When to use |
+|--------------|------------|---------------|
+| `remote` (new) | Per path: infer GitHub vs GitLab from that file's repo URL; project files → project VCS; dependency files → `enrich_described` / `source_url` + qualifier | Mixed GitHub project + GitLab (or GitHub) dependencies; recommended for CI when deps are not all on the project host |
+| `github` / `gitlab` | Single blob base from project VCS for every path | Monorepo or single-host CI publish |
+
+**Implementation sketch:**
+
+- Shared `normalize_repository_browse_url()` + `_hosting_style()` in `cuppa/reports/link_style.py`
+  (dedupe from `report_html.py`).
+- `resolve_path_remote_link(path, env) → (hosting_style, blob_base, repo_relative_path) | None` —
+  reuse `describe_tree_path` / `enrich_described` / `remote_href_display_path()` (shipped in
+  [#214](https://github.com/ja11sop/cuppa/pull/214) for project + working-dir paths).
+- Extend `source_file_href` or call the resolver from Profiles `write_source_pages` /
+  `annotate_file_links` and test-report linking.
+- Default stays **`local`**; document **`remote`** for mixed-dependency Profiles runs in Antora +
+  `cli-reference.adoc`.
+
+**Settled:** name is **`remote`** (not `repo`) — contrasts with `local` and avoids confusion with
+“repository” as a noun.
 
 ## Settled CLI (proposal)
 
@@ -1646,7 +1681,8 @@ Target cycle: **1.8.0** for **`prof-report-parser` … `prof-report-manifest`** 
 2. **Dependency paths:** `--cxx-profiles-report-root=` vs absolute-only links for `_cuppa/_download/…` trees?
 3. **Report-only exit code:** optional `--cxx-profiles-report-allow-errors` if inventory runs should succeed?
 4. **Cross-variant roll-up:** session **union** for headline / Overview (settled); By-Rule / By-File show **per-build Hits + common/delta** display ([§Variant roll-up display](#prof-report-variant-roll-up-display)) — Antora documents both.
-5. **GitHub `link_style`:** extend shared helper vs duplicate URL template in Profiles module only?
+5. **GitHub `link_style`:** → **Settled** — shared helper in `link_style.py`; per-repo **`remote`**
+   style deferred to follow-up slice above (patch issue after #214).
 6. **`_unscoped` bucket:** when spawn scope cannot be derived, record under session `_unscoped` with warning in HTML — never guess variant.
 7. **Implied `-i`:** → **Settled yes** — [#199](https://github.com/ja11sop/cuppa/issues/199) / [§Collate index semantics](#prof-report-method-semantics-slice).
 8. **Progress vs failed compiles:** → **Settled yes** — Progress decoupling + fallback flush — [#199](https://github.com/ja11sop/cuppa/issues/199).

--- a/design/plans/method-behaviour-audit.md
+++ b/design/plans/method-behaviour-audit.md
@@ -1,0 +1,152 @@
+# Plan: Cuppa env method behaviour audit (paths, evaluation, returns)
+
+- **Status:** proposal
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — `method-behaviour-audit`; [#213](https://github.com/ja11sop/cuppa/issues/213); [`methods-pages-split.md`](methods-pages-split.md); [`static-glob-rename.md`](static-glob-rename.md)
+- **Updated:** 2026-08-17
+- **Impact:** patch — behaviour fixes and shared helpers; documentation split follows in a separate docs-only stream
+
+## Purpose
+
+Catalogue **how cuppa `env.*` methods behave** — not just signatures — so we can fix inconsistencies
+before writing per-method Antora pages. The Methods hub today lists names; readers (and agents)
+need to know:
+
+1. **What the call returns** (nodes, env, string, side-effect only).
+2. **When the work is evaluated** (immediate, configure-time snapshot, build action, post-build).
+3. **How output paths are named** (mirrored under `working/`, flat basename, explicit target, `final/` layout).
+
+This plan is the **behaviour and fix** track. [`methods-pages-split.md`](methods-pages-split.md) is the
+**documentation layout** track and must not run ahead of settled behaviour here.
+
+## Prerequisite ordering
+
+```text
+method-behaviour-audit (fixes)  →  static-glob-rename (optional API)  →  methods-pages-split (docs)
+```
+
+Ship [#213](https://github.com/ja11sop/cuppa/issues/213) compile object paths first (branch
+`issue/213-compile-object-paths`). Remaining slices below are follow-on PRs on the same theme.
+
+## Classification axes
+
+Every method family should be documented (eventually) with these columns:
+
+| Axis | Values | Reader question |
+|------|--------|-----------------|
+| **Returns** | Nodes / env / str / list / None | What can I pass to `Build`, `Filter`, `Depends`? |
+| **Evaluation** | Immediate / static snapshot / SCons dynamic / build action / post-build | Will a new file on disk appear without re-running configure? |
+| **Output naming** | Mirror source tree / flat basename / caller target / N/A | Can two same-basename sources collide? |
+| **Progress** | NotifyProgress / none | Does it show in variant Finished output? |
+
+## Issue class A — flat intermediate targets (Compile bug family)
+
+**Pattern:** output path uses **basename only** under a single directory, so nested sources with
+the same name collide (`UserError: Multiple ways to build the same target`).
+
+### Fixed by #213 (on branch)
+
+Shared helper: [`object_target_for`](../../cuppa/utility/object_target.py) — targets **relative
+to** `variant_dir` (`working/`), e.g. `src/detail/except.o` →
+`_build/.../working/src/detail/except.o`.
+
+| Method | Via | Status |
+|--------|-----|--------|
+| `Compile`, `CompileStatic`, `CompileShared` | direct | **Fixed** (#213) |
+| `Build`, `BuildTest`, `BuildBenchmark` | `Compile` | **Fixed** |
+| `BuildStaticLib`, `BuildSharedLib`, `BuildLib` | `Compile*` | **Fixed** |
+| `Module`, `HeaderUnit` | `compile_with_modules` | **Fixed** (TU objects; BMI uses `modules/` tree) |
+
+**Follow-on check:** `--cov` gcov layout vs mirrored objects — sanity pass after #213 lands
+([`run_gcov_coverage.py`](../../cuppa/cpp/run_gcov_coverage.py) derives paths from source nodes).
+
+### Open — same pattern, different product (flat under `final/` or output dir)
+
+| Method | Emitter rule | Collision example | Priority |
+|--------|--------------|-------------------|----------|
+| `MarkdownToHtml` | `{final_dir}/{basename}.html` | `doc/a/readme.md` + `doc/b/readme.md` | Medium |
+| `AsciidocToHtml` | default `{final_dir}/{basename}.html` | same | Medium |
+| `RunAndRedirectToFile` | `{final_dir}/{basename}{ext}` | two programs logged to same `.out` name | Low |
+| `CompileScss` | `{abspath(source)}.css` | uncommon; odd vs `working/` layout | Low |
+
+**Proposed fix pattern:** reuse or extend `object_target_for` / a sibling
+`artifact_target_for(env, source, suffix, *, root='final'|'working')` so doc/asset outputs mirror
+source subdirs under the chosen root unless the caller passes an explicit target list.
+
+## Issue class B — static vs dynamic discovery
+
+| API | Evaluation | Notes |
+|-----|------------|-------|
+| SCons `env.Glob` (`**`) | **Dynamic** | Build-graph aware; new files may appear without editing sconscript |
+| `RecursiveGlob`, `GlobFiles` | **Static** | Python walk/listdir at sconscript load |
+| `Filter` | **Immediate** | Subset of existing nodes; pairs with dynamic Glob |
+
+**Risk:** readers treat `RecursiveGlob` like CMake `GLOB_RECURSE` + Ninja rebuild semantics — it is
+not. Rename and docs: [`static-glob-rename.md`](static-glob-rename.md).
+
+**Filter follow-on:** ensure match patterns work consistently for nodes from static vs dynamic
+discovery (`str(node)` vs `node.path` — see [`filter.py`](../../cuppa/utility/filter.py)).
+
+## Issue class C — already path-aware (reference behaviour)
+
+Document as the **target standard** for emitters:
+
+| Method | Output naming |
+|--------|---------------|
+| `RenderJinjaTemplate` | `{final_dir}/{path_offset}/{file}` |
+| `CreateVersion` | `offset_path` under `working/` |
+| `CopyFiles` / `CopyFilesAs` | SCons `Install` / `InstallAs` |
+| `ExpandTemplateFile` | caller-supplied target |
+| `TargetFrom` | `relpath(source.path, build_dir)` (string helper, not a build action) |
+
+## Issue class D — env / orchestration (no path collision)
+
+No flat intermediate target bug; document evaluation only:
+
+| Group | Methods | Returns | Evaluation |
+|-------|---------|---------|------------|
+| Env mutators | `StdCpp`, `ReplaceFlags`, `RemoveFlags`, `CxxProfiles`, … | env | Immediate |
+| Deps | `BuildWith`, `Using`, `Toolchain` | side effects | Configure |
+| Run/test drivers | `Run`, `Test`, `Coverage`, collate helpers | side effects / reports | Build / post-build |
+| Packages | `PublishPackage`, `InstallPackage` | package nodes | Configure / build |
+
+## Work slices
+
+| ID | Deliverable | Depends on | Impact |
+|----|-------------|------------|--------|
+| `mba-213` | Land compile object path mirror ([#213](https://github.com/ja11sop/cuppa/issues/213)) | — | patch |
+| `mba-cov-check` | Coverage integration pass after mirrored `.o` paths | `mba-213` | patch |
+| `mba-artifact-paths` | Shared helper + fix Markdown/AsciiDoc/RunAndRedirect emitters | `mba-213` | patch |
+| `mba-scss` | Decide SCSS output root (`working/` mirror vs beside source) | optional | patch |
+| `mba-static-glob` | StaticGlob rename + path vocabulary | [`static-glob-rename.md`](static-glob-rename.md) | minor |
+| `mba-filter` | Filter matching parity for Glob + StaticGlob nodes | `mba-static-glob` | patch |
+| `mba-doc` | Export classification tables into Methods hub + child pages | [`methods-pages-split.md`](methods-pages-split.md) | none |
+
+## Acceptance criteria (audit complete)
+
+1. No cuppa method in class A left with flat-basename-only naming for nested source trees unless
+   explicitly documented as intentional.
+2. Classification table (this plan) reflected in Methods hub index — per [`methods-pages-split.md`](methods-pages-split.md).
+3. Integration tests for at least one doc/asset emitter with duplicate basenames in different dirs.
+4. Static vs dynamic discovery documented; StaticGlob rename landed or explicitly deferred with
+   issue link.
+
+## Progress snapshot
+
+| Slice | Status |
+|-------|--------|
+| Audit document | this plan |
+| #213 compile fix | on branch `issue/213-compile-object-paths` |
+| Doc/asset flat naming | not started |
+| Coverage sanity | not started |
+| Methods doc split | blocked on this plan |
+
+## Non-goals
+
+- Full SCons API reference.
+- Renaming every method for consistency in one release.
+- Auto-generated docs from `add_method` registration.
+
+## References
+
+- Boost.Capy experiment — [`cmake-to-cuppa-migration.md`](cmake-to-cuppa-migration.md)
+- Modules object stem rule — [`cxx-modules.adoc`](../../docs/modules/ROOT/pages/cxx-modules.adoc)

--- a/design/plans/methods-pages-split.md
+++ b/design/plans/methods-pages-split.md
@@ -2,8 +2,24 @@
 
 - **Status:** proposal
 - **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Documentation tooling (`doc-methods-split`); hub [`methods.adoc`](../../docs/modules/ROOT/pages/methods.adoc); [`dependencies.adoc`](../../docs/modules/ROOT/pages/dependencies.adoc) hub pattern; Phase 3 doc split [`removal-options.md`](removal-options.md) §7.1
-- **Updated:** 2026-08-11
+- **Updated:** 2026-08-17
 - **Impact:** none — documentation and navigation only
+
+## Prerequisite — behaviour before pages
+
+Do **not** split Methods into child pages until [`method-behaviour-audit.md`](method-behaviour-audit.md)
+fixes and classifications are settled (or explicitly deferred with issue links). Otherwise each
+new page documents behaviour that is still wrong or inconsistent — especially **output path naming**
+and **static vs dynamic** source discovery.
+
+**Order:**
+
+```text
+method-behaviour-audit  →  static-glob-rename (optional)  →  methods-pages-split (this plan)
+```
+
+[#213](https://github.com/ja11sop/cuppa/issues/213) (compile object paths) is the first audit slice;
+doc/asset emitters with flat basenames are the next.
 
 ## Why
 
@@ -54,6 +70,30 @@ Group related registrations to avoid forty tiny pages:
 Each group page: signature, when to use, minimal example, progress/NotifyProgress note, xrefs to
 toolchains/modules/coverage as needed.
 
+## Behaviour fields (every child page)
+
+Import the classification from [`method-behaviour-audit.md`](method-behaviour-audit.md). Each method
+page (or group page subsection) should state:
+
+| Field | What to document |
+|-------|------------------|
+| **Returns** | Nodes, env, string, list, or side-effect only — and what callers can chain |
+| **Evaluation** | Immediate / static snapshot (configure) / SCons dynamic / build action / post-build |
+| **Output paths** | Mirror under `working/` or `final/`, flat basename, or caller explicit — collision notes |
+| **Progress** | Participates in NotifyProgress or not |
+
+**Examples by group:**
+
+| Nav group | Evaluation highlight | Path highlight |
+|-----------|---------------------|----------------|
+| Build | Build action via SCons | Objects mirror source tree under `working/` ([#213](https://github.com/ja11sop/cuppa/issues/213)) |
+| Files & templates | Mix: static glob, Filter immediate, Glob dynamic | StaticGlob vs `env.Glob('**')`; Filter after dynamic Glob |
+| Docs assets | Build action | Today: flat `{final}/{basename}` — **document fix when audit lands** |
+| C++ modules | Build action | Interface suffix in object stem (`.cppm.o` vs `.o`) + mirrored paths |
+
+Link to [`static-glob-rename.md`](static-glob-rename.md) from the Files group instead of duplicating
+the full static/dynamic essay.
+
 ## Phase 2 — SCons companions (proposal)
 
 | Page | Cover |
@@ -77,10 +117,11 @@ Leave on **`methods.adoc`**:
 
 | Slice | Deliverable | Notes |
 |-------|-------------|-------|
-| A | Hub trim + nav skeleton | Empty child stubs with `xref` |
-| B | Build + test groups | Highest traffic |
+| **0** | Behaviour audit fixes | [`method-behaviour-audit.md`](method-behaviour-audit.md) — **before A** |
+| A | Hub trim + nav skeleton | Empty child stubs with `xref` + behaviour field template |
+| B | Build + test groups | Highest traffic; #213 semantics |
 | C | Coverage + C++ groups | Link cxx-modules / cxx-profiles |
-| D | Remaining groups | Files, packages, flags |
+| D | Remaining groups | Files (StaticGlob), packages, flags |
 | E | Phase 2 SCons pages | Optional same cycle |
 | F | Redirect grep in repo | Fix internal links to `#anchors` that moved |
 
@@ -101,9 +142,9 @@ Leave on **`methods.adoc`**:
 | Size | Large editorial effort; can land incrementally (slice B–C enough for 1.8.0) |
 | Release impact | `none` |
 
-**Suggested:** **1.8.0** friendly as **incremental docs PRs** (slices A–C) even while 1.8.0.dev code
-work is elsewhere. Good pairing with [`antora-ui-bundle.md`](antora-ui-bundle.md) if docs cycle
-gets a visible refresh.
+**Suggested:** defer slices **A–F** until **slice 0** (behaviour audit) is largely complete. Then
+land docs as **incremental docs PRs** (`impact:none`). Good pairing with
+[`antora-ui-bundle.md`](antora-ui-bundle.md) if the docs cycle gets a visible refresh.
 
 ## Folder layout (optional polish)
 

--- a/design/plans/sconscript-exports.md
+++ b/design/plans/sconscript-exports.md
@@ -1,0 +1,97 @@
+# Plan: Sconscript exports and shared build products
+
+- **Status:** proposal
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — `sconscript-exports`; blocks multi-file Cuppa layouts like CMake `add_subdirectory`; pairs with [#213](https://github.com/ja11sop/cuppa/issues/213)
+- **Updated:** 2026-08-17
+
+## Problem
+
+Cuppa discovers **every** `sconscript` under the launch directory and invokes each with the same per-variant `env`, but **without** SCons `exports=` from a parent script ([`construct.py`](../../cuppa/construct.py) `call_project_sconscript_files` → `SCons.Script.SConscript(..., exports=sconscript_exports)` where `sconscript_exports` is only the standard cuppa keys: `env`, `build_root`, …).
+
+A natural CMake-shaped layout:
+
+```text
+sconstruct
+sconscript          # libraries
+test/sconscript     # imports capy_libs from parent
+```
+
+does not work:
+
+```python
+# test/sconscript
+Import('env', 'capy_libs')   # Import of non-existent variable 'capy_libs'
+```
+
+Manual `SConscript('test/sconscript', exports=[...])` inside a root sconscript **also fails** today because Cuppa **still auto-discovers** `test/sconscript` and runs it a second time without exports.
+
+This is a **design side-effect**, not an accident: early cuppa projects used one sconscript per repo or per top-level folder, with libraries declared inline or via `env.BuildWith` package deps.
+
+## Goals (exploration — first slice)
+
+1. **Document current behaviour** in Antora (`concepts.adoc` or `methods.adoc`): discovered sconscripts are siblings, not a tree with inherited exports.
+2. **Choose a direction** for enabling CMake-like decomposition without duplicate invocation.
+3. **Spike** the smallest API that unblocks a real consumer (Boost.Capy Cuppa sketch): shared static libs built once, tests in `test/sconscript`.
+
+## Non-goals (initial slice)
+
+- Full SCons `Return()` parity with arbitrary values across arbitrary depth.
+- Replacing `location_dependency` / `package_dependency` — those already solve sharing via `env.BuildWith`.
+- Auto-wiring CMake `add_subdirectory` — see [`cmake-to-cuppa-migration.md`](cmake-to-cuppa-migration.md).
+
+## Settled decisions (to confirm before implementation)
+
+| Question | Options | Working bias |
+|----------|---------|--------------|
+| Discovery vs explicit tree | (A) Only run sconscripts reached from explicit `SConscript()` calls; (B) discovery + optional `exports` registry; (C) discovery with parent path hints | **B or C** — keep `-D` descent ergonomics, add export map |
+| Export surface | SCons `Export()` / `Import()` only vs cuppa `env.export('name', nodes)` | Start with **SCons-native** where possible |
+| Duplicate invocation | Skip auto-discovery when a path was already loaded with exports | **Yes** — required for nested layout |
+| Default | Single root sconscript remains valid | **Unchanged** — zero migration for existing projects |
+
+## Design directions (to compare in spike)
+
+### Direction A — Explicit tree only
+
+- Turn off recursive sconscript discovery when `sconstruct` sets `cuppa.run(discover_sconscripts=False)` or equivalent.
+- Root `sconscript` owns all `SConscript('test/sconscript', exports=...)`.
+- **Pros:** Matches SCons docs; predictable.
+- **Cons:** Breaks `--scripts=` / default discovery UX; every project must list children.
+
+### Direction B — Export registry on `env`
+
+- Root sconscript: `env.export('capy_libs', [lib_a, lib_b])`.
+- Cuppa merges exported names into `sconscript_exports` for **later** discovered scripts (discovery order = tree walk order).
+- Child: `Import('env', 'capy_libs')` or `env.import_shared('capy_libs')`.
+- **Pros:** Minimal change to discovery; fits cuppa's `env` methods style.
+- **Cons:** Order-dependent; needs clear rules when exports collide.
+
+### Direction C — Scoped discovery roots
+
+- `cuppa.run(projects=['sconscript'])` — only listed entrypoints; entrypoints call nested `SConscript` themselves.
+- Keeps today’s default discovery for legacy repos via opt-out flag.
+- **Pros:** No magic export merging.
+- **Cons:** Two mental models (discovered vs rooted).
+
+## Work slices
+
+| Slice | Deliverable | Depends on |
+|-------|-------------|------------|
+| `scons-export-doc` | Antora: how discovery works; why `Import('capy_libs')` fails today | — |
+| `scons-export-spike` | Choose A/B/C; prototype in a fixture (lib sconscript + test sconscript) | — |
+| `scons-export-dedupe` | Do not double-run a sconscript path (explicit + discovery) | spike |
+| `scons-export-api` | Ship chosen API + integration test | dedupe |
+| `scons-export-capy` | Re-enable Boost.Capy `test/sconscript` split (external validation) | [#213](https://github.com/ja11sop/cuppa/issues/213) |
+
+## Open questions
+
+- Should exports be variant-scoped automatically (they must be — lib nodes are per variant)?
+- Interaction with `--scripts=` filtering: do exports from a skipped parent still exist?
+- How do agents discover the pattern? → tie-in with CMake migration guide.
+
+## Progress snapshot
+
+| Slice | Status |
+|-------|--------|
+| Problem validated on Boost.Capy | done (2026-08-17) |
+| Plan | this document |
+| Implementation | not started |

--- a/design/plans/static-glob-rename.md
+++ b/design/plans/static-glob-rename.md
@@ -1,0 +1,139 @@
+# Plan: StaticGlob — rename source discovery by evaluation model
+
+- **Status:** proposal
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — `static-glob`; [#213](https://github.com/ja11sop/cuppa/issues/213); [`cmake-to-cuppa-migration.md`](cmake-to-cuppa-migration.md)
+- **Updated:** 2026-08-17
+- **Impact:** minor — new names and optional cuppa `Glob` wrapper; existing `RecursiveGlob` / `GlobFiles` remain as deprecated aliases for at least one cycle
+
+## Problem
+
+Cuppa today exposes two **eager** Python helpers whose names describe **shape**, not **when** the file list is fixed:
+
+| Today | Implementation | Name suggests |
+|-------|----------------|---------------|
+| `env.RecursiveGlob` | `os.walk` + fnmatch | “recursive glob” |
+| `env.GlobFiles` | `os.listdir` + fnmatch | “glob files” |
+
+Both snapshot the filesystem **once**, when the sconscript line runs during the initial read phase. New files under the tree do not appear until configure re-runs.
+
+SCons **`env.Glob`** (including `**` since SCons 4) is **lazy**: directory-aware nodes that can be re-evaluated with the build graph. That is a different contract — but the current cuppa names do not help users choose.
+
+`RecursiveGlob` originally filled a hard gap (no `**`, need to skip `_build` / dependency trees). The gap is narrower now; the **evaluation-model** distinction matters more than “recursive vs not”.
+
+## Proposal
+
+Introduce a pair of documented discovery options:
+
+| API | Evaluation | Implementation direction |
+|-----|------------|---------------------------|
+| **`env.Glob(...)`** | Dynamic (SCons) | Document native SCons `env.Glob` / optional thin cuppa wrapper with shared path rules and default exclusions for `**` |
+| **`env.StaticGlob(...)`** | Static (configure-time snapshot) | Rename/refactor today’s `RecursiveGlob` + `GlobFiles`; one method, `recursive=` (or `depth=`) instead of two names |
+
+**Do not** silently change `RecursiveGlob` to delegate to SCons `**` — that alters when new sources appear (subtle breaking change).
+
+### StaticGlob shape (sketch)
+
+```python
+# Was RecursiveGlob('*.cpp', start='src')
+sources = env.StaticGlob('*.cpp', start='src')
+
+# Was GlobFiles('*_test.cpp', start='tests')
+tests = env.StaticGlob('*_test.cpp', start='tests', recursive=False)
+```
+
+Keep cuppa-only knobs on the static side only:
+
+- `start=` — root of walk (see [Path vocabulary](#path-vocabulary))
+- `exclude_dirs=` — directory **name** regex (default skips `_build`, dependencies root)
+- `discard_pattern=` — skip subtree when marker file present
+
+Dynamic side gets `**` and SCons directory dependencies; not `discard_pattern`.
+
+## Path vocabulary
+
+Users must be able to switch between dynamic and static **without rewriting path strings**.
+
+Today path handling is split:
+
+- **Static:** `clean_start()` / `relative_start()` in [`relative_recursive_glob.py`](../../cuppa/methods/relative_recursive_glob.py) — `start=` relative to `sconscript_dir`, optional absolutes, relpath back to `base_path` for `env.File` nodes
+- **Dynamic:** SCons `#/` project-root paths, paths relative to the calling sconscript, and `env.Glob` rules — not centralized with StaticGlob
+
+### Settled direction (proposal)
+
+Extract a shared helper (e.g. `cuppa/paths/glob_roots.py` or extend `cuppa/utility/path.py`) used by **both** StaticGlob and any cuppa Glob wrapper:
+
+| Input style | Meaning | Example |
+|-------------|---------|---------|
+| `#/…` | From project / sconstruct root | `#/src/**/*.cpp` |
+| `start='src'` | Directory relative to `sconscript_dir` | `StaticGlob('*.cpp', start='src')` |
+| Relative file/dir | Relative to sconscript (same as today’s `env.File('src/foo.cpp')`) | `'src/detail/a.cpp'` |
+| Absolute | Allowed; documented as last resort | package / generated paths |
+
+**Acceptance:** for a fixture tree, the **same path string** in `env.Glob('#/src/**/*.cpp')` and `env.StaticGlob('*.cpp', start='#/src')` (or equivalent) yields the same set of project-relative `File` node paths (modulo evaluation time).
+
+Document the mapping in Antora (Methods hub + migration guide).
+
+## Filter() and dynamic Glob
+
+[`env.Filter`](../../cuppa/methods/filter.py) post-selects among **existing nodes** (fnmatch on `str(node)` / existence checks). It was intended to complement broad globs:
+
+```python
+# Dynamic: wide net, then cuppa filter
+candidates = env.Glob('#/src/**/*.cpp')
+tests = env.Filter(candidates, match='*_test.cpp', exclude='**/detail/**')
+```
+
+Follow-on work (same plan, later slice):
+
+1. **Filter + path styles** — matching should behave consistently whether nodes came from SCons Glob or StaticGlob (today `filter_nodes` uses `str(node)`; patterns may need to match project-relative `node.path` as well as absolute `str(node)`).
+2. **Filter + lazy globs** — ensure filtered SCons glob nodes remain valid dependencies (no accidental snapshot/copy).
+3. **Docs** — recipe section: “dynamic Glob + Filter” vs “StaticGlob with pattern/exclude_dirs”.
+
+StaticGlob already embeds exclude/discards; Filter remains the right tool for **dynamic** narrowing without re-walking.
+
+## Migration
+
+| Phase | Deliverable |
+|-------|-------------|
+| `static-glob-helper` | Shared path resolver; unit tests for `#/`, `start=`, sconscript-relative |
+| `static-glob-add` | `env.StaticGlob`; implementation = refactor `RecursiveGlob` + `GlobFiles` |
+| `static-glob-alias` | `RecursiveGlob` / `GlobFiles` call StaticGlob; one configure-time `warn_once` each with replacement hint |
+| `glob-doc` | Antora: evaluation table, path vocabulary, Filter recipes |
+| `glob-wrapper` (optional) | Cuppa `env.Glob` wrapper: shared paths + optional default `**` exclusions |
+| `static-glob-remove` (major) | Drop aliases after deprecation window |
+
+Internal call sites ([`build_with_location.py`](../../cuppa/build_with_location.py), tests, quickstart) migrate to `StaticGlob` in the same release as the alias.
+
+## Settled decisions (confirm before implementation)
+
+| Question | Options | Working bias |
+|----------|---------|--------------|
+| Static API name | `StaticGlob` / `SnapshotGlob` / `GlobAtConfigure` | **`StaticGlob`** — pairs naturally with dynamic `Glob` |
+| Flat vs recursive | Two methods vs one flag | **One method** + `recursive=False` (replaces `GlobFiles`) |
+| Dynamic API | Document SCons only vs cuppa wrapper | **Document SCons first**; add wrapper if `#/` + exclusions need one home |
+| Aliases | Keep forever vs deprecate | **Deprecated aliases** ≥1 minor, remove on major |
+| Path helper location | New module vs extend existing | **Shared module** consumed by StaticGlob + optional Glob wrapper |
+
+## Progress snapshot
+
+| Slice | Status |
+|-------|--------|
+| Plan | this document |
+| Shared path resolver | not started |
+| `StaticGlob` | not started |
+| Deprecated aliases | not started |
+| Filter parity | not started |
+| Antora / migration matrix update | not started |
+
+## Non-goals
+
+- Making StaticGlob lazy (that is what SCons Glob is for).
+- Reimplementing SCons `**` inside Python walk.
+- Changing compile object layout ([#213](https://github.com/ja11sop/cuppa/issues/213)) — prerequisite for honest static glob docs, separate PR.
+
+## References
+
+- [`cuppa/methods/relative_recursive_glob.py`](../../cuppa/methods/relative_recursive_glob.py)
+- [`cuppa/recursive_glob.py`](../../cuppa/recursive_glob.py)
+- [`cuppa/methods/filter.py`](../../cuppa/methods/filter.py)
+- Integration: [`test_glob.py`](../../tests/integration/methods/test_glob.py), [`test_flags.py`](../../tests/integration/methods/test_flags.py)

--- a/tests/integration/methods/test_compile_object_paths.py
+++ b/tests/integration/methods/test_compile_object_paths.py
@@ -45,13 +45,27 @@ def _objects_under_working(project):
     return by_working
 
 
+def _object_suffix(by_working):
+    for objects in by_working.values():
+        for path in objects:
+            if path.suffix in (".o", ".obj"):
+                return path.suffix
+    return None
+
+
 def _assert_working_layout(by_working):
     assert by_working, "expected object files under working/"
+    obj_suffix = _object_suffix(by_working)
+    assert obj_suffix is not None, "expected object files under working/"
+    expected = [
+        f"src/buffers/detail/except{obj_suffix}",
+        f"src/detail/except{obj_suffix}",
+        f"src/detail/router/test{obj_suffix}",
+    ]
     for working_rel, objects in by_working.items():
         rel_paths = [str(path).replace("\\", "/") for path in objects]
-        assert "src/buffers/detail/except.o" in rel_paths, working_rel
-        assert "src/detail/except.o" in rel_paths, working_rel
-        assert "src/detail/router/test.o" in rel_paths, working_rel
+        for expected_path in expected:
+            assert expected_path in rel_paths, working_rel
         for rel_posix in rel_paths:
             assert not rel_posix.startswith("_build/"), (
                 "object path must be relative to working/, not prefixed with build_root: "
@@ -60,8 +74,8 @@ def _assert_working_layout(by_working):
             assert "/working/" not in rel_posix, (
                 "working_dir must not repeat inside working/: " + rel_posix
             )
-            assert rel_posix != "except.o", "flat basename collision layout"
-            assert rel_posix != "test.o", "flat basename collision layout"
+            assert rel_posix != f"except{obj_suffix}", "flat basename collision layout"
+            assert rel_posix != f"test{obj_suffix}", "flat basename collision layout"
 
 
 def test_compile_nested_same_basename_sources_dbg_and_rel(tmp_path):

--- a/tests/integration/methods/test_compile_object_paths.py
+++ b/tests/integration/methods/test_compile_object_paths.py
@@ -1,0 +1,102 @@
+import pytest
+
+from tests.helpers.cuppa_runner import assert_success, run_cuppa
+from tests.helpers.project import copy_dummy_project, write_sconstruct, write_sconscript
+
+
+pytestmark = pytest.mark.integration
+
+
+def _write_collision_fixture(project):
+    (project / "src" / "detail" / "router").mkdir(parents=True, exist_ok=True)
+    (project / "src" / "buffers" / "detail").mkdir(parents=True, exist_ok=True)
+    (project / "src" / "detail" / "router" / "test.cpp").write_text(
+        "namespace detail { int test() { return 1; } }\n",
+        encoding="utf-8",
+    )
+    (project / "src" / "detail" / "except.cpp").write_text(
+        "namespace detail { int except() { return 1; } }\n",
+        encoding="utf-8",
+    )
+    (project / "src" / "buffers" / "detail" / "except.cpp").write_text(
+        "namespace buffers { namespace detail { int except() { return 2; } } }\n",
+        encoding="utf-8",
+    )
+    write_sconstruct(project)
+    write_sconscript(
+        project,
+        "Import('env')\n"
+        "sources = env.RecursiveGlob('except.cpp', start='src')\n"
+        "assert len(sources) == 2\n"
+        "env.BuildStaticLib('excepts', sources)\n"
+        "env.Compile('src/detail/router/test.cpp')\n",
+    )
+
+
+def _objects_under_working(project):
+    by_working = {}
+    for working in sorted(project.glob("_build/**/working")):
+        objects = sorted(
+            path.relative_to(working)
+            for path in working.rglob("*")
+            if path.is_file() and path.suffix in (".o", ".obj")
+        )
+        by_working[str(working.relative_to(project))] = objects
+    return by_working
+
+
+def _assert_working_layout(by_working):
+    assert by_working, "expected object files under working/"
+    for working_rel, objects in by_working.items():
+        rel_paths = [str(path).replace("\\", "/") for path in objects]
+        assert "src/buffers/detail/except.o" in rel_paths, working_rel
+        assert "src/detail/except.o" in rel_paths, working_rel
+        assert "src/detail/router/test.o" in rel_paths, working_rel
+        for rel_posix in rel_paths:
+            assert not rel_posix.startswith("_build/"), (
+                "object path must be relative to working/, not prefixed with build_root: "
+                + rel_posix
+            )
+            assert "/working/" not in rel_posix, (
+                "working_dir must not repeat inside working/: " + rel_posix
+            )
+            assert rel_posix != "except.o", "flat basename collision layout"
+            assert rel_posix != "test.o", "flat basename collision layout"
+
+
+def test_compile_nested_same_basename_sources_dbg_and_rel(tmp_path):
+    project = copy_dummy_project(tmp_path)
+    _write_collision_fixture(project)
+
+    result = run_cuppa(project, "--dbg", "--rel", "--offline")
+    assert_success(result)
+
+    by_working = _objects_under_working(project)
+    assert len(by_working) == 2, "expected dbg and rel working trees"
+    _assert_working_layout(by_working)
+
+
+def test_compile_object_paths_stable_from_nested_launch(tmp_path):
+    project = copy_dummy_project(tmp_path)
+    _write_collision_fixture(project)
+    nested = project / "nested" / "pkg"
+    nested.mkdir(parents=True)
+
+    root_result = run_cuppa(project, "--dbg", "--rel", "--offline")
+    assert_success(root_result)
+    root_layout = _objects_under_working(project)
+
+    import shutil
+    shutil.rmtree(project / "_build")
+
+    nested_result = run_cuppa(
+        nested,
+        "--dbg",
+        "--rel",
+        "--offline",
+        "--scripts=../../sconscript",
+    )
+    assert_success(nested_result)
+    nested_layout = _objects_under_working(project)
+
+    assert nested_layout == root_layout

--- a/tests/unit/test_cxx_profiles_report.py
+++ b/tests/unit/test_cxx_profiles_report.py
@@ -238,6 +238,9 @@ def test_parse_variant_scope_fields():
     assert parse_variant_scope_fields(
         '_build/test/sample_app/clang24_profiles_2026_08_07_27/dbg/x86_64/cxx2c',
     ) == ( 'clang24_profiles_2026_08_07_27', 'dbg' )
+    assert parse_variant_scope_fields(
+        '_build/clang24_profiles_2026_08_07_27/dbg/x86_64/cxx2c',
+    ) == ( 'clang24_profiles_2026_08_07_27', 'dbg' )
 
 
 def test_profiles_scope_from_construction_env_matches_notify_progress_variant():

--- a/tests/unit/test_modules_toolchain.py
+++ b/tests/unit/test_modules_toolchain.py
@@ -39,8 +39,8 @@ def test_object_target_keeps_interface_suffix(tmp_path):
     })
     cppm = object_target_for( env, _Src( "calc/calc.cppm" ), "", ".o" )
     cpp = object_target_for( env, _Src( "calc/calc.cpp" ), "", ".o" )
-    assert cppm.replace( "\\", "/" ).endswith( "calc.cppm.o" )
-    assert cpp.replace( "\\", "/" ).endswith( "calc.o" )
+    assert cppm.replace( "\\", "/" ).endswith( "calc/calc.cppm.o" )
+    assert cpp.replace( "\\", "/" ).endswith( "calc/calc.o" )
     assert cppm != cpp
 
 

--- a/tests/unit/test_object_target.py
+++ b/tests/unit/test_object_target.py
@@ -1,0 +1,55 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+import pytest
+
+from cuppa.utility.object_target import object_target_for
+
+
+pytestmark = pytest.mark.unit
+
+
+class _Source:
+    def __init__( self, path ):
+        self.path = path
+
+    def __str__( self ):
+        return self.path
+
+
+class _Env( dict ):
+    def File( self, path ):
+        return path.replace( '\\', '/' )
+
+
+def _env( tmp_path ):
+    working = tmp_path / '_build' / 'gcc' / 'dbg' / 'working'
+    return _Env({
+        'build_root': str( tmp_path / '_build' ),
+        'build_dir': str( working ),
+    })
+
+
+def test_nested_same_basename_objects_are_distinct( tmp_path ):
+    env = _env( tmp_path )
+    first = object_target_for( env, _Source( 'src/detail/except.cpp' ), '', '.o' )
+    second = object_target_for( env, _Source( 'src/buffers/detail/except.cpp' ), '', '.o' )
+    assert first != second
+    assert first.endswith( 'src/detail/except.o' )
+    assert second.endswith( 'src/buffers/detail/except.o' )
+
+
+def test_flat_source_stays_directly_under_working( tmp_path ):
+    env = _env( tmp_path )
+    target = object_target_for( env, _Source( 'hello.cpp' ), '', '.o' )
+    assert target.endswith( 'hello.o' )
+
+
+def test_build_root_source_keeps_offset_from_working( tmp_path ):
+    env = _env( tmp_path )
+    build_dir = env['build_dir']
+    source_path = build_dir + '/src/nested/deep.cpp'
+    target = object_target_for( env, _Source( source_path ), '', '.o' )
+    assert target.endswith( 'src/nested/deep.o' )

--- a/tests/unit/test_profiles_report_collector.py
+++ b/tests/unit/test_profiles_report_collector.py
@@ -172,6 +172,43 @@ def test_diagnostic_collector_flush_pending_uses_report_env( monkeypatch, tmp_pa
     assert calls == [ ( env, True ) ]
 
 
+def test_sconstruct_end_uses_report_env_for_session_write( monkeypatch, tmp_path ):
+    report_env = {
+        'sconstruct_dir': str( tmp_path ),
+        'cxx_profiles_report': True,
+        'reports_link_style': 'github',
+        'artefacts_root': '_artefacts',
+    }
+    progress_env = { 'sconstruct_dir': str( tmp_path ) }
+    session = ProfilesDiagnosticCollector.activate( report_env=report_env )
+    ProfilesDiagnosticCollector.record_line( _SAMPLE_SCOPE, _PROFILE_LINE )
+
+    writes = []
+
+    def fake_write( inventory, write_env, **kwargs ):
+        writes.append( write_env )
+        return {
+            'model': {},
+            'session_paths': [ 'index.html' ],
+            'scope_paths': [],
+        }
+
+    monkeypatch.setattr(
+        'cuppa.cpp.profiles_report.report_html.write_profiles_reports',
+        fake_write,
+    )
+    monkeypatch.setattr(
+        'cuppa.reports.manifest.append_cxx_profiles_entry',
+        lambda *args, **kwargs: None,
+    )
+
+    session.on_progress( 'sconstruct_end', None, None, progress_env, None, None )
+
+    assert len( writes ) == 1
+    assert writes[ 0 ] is report_env
+    assert writes[ 0 ][ 'reports_link_style' ] == 'github'
+
+
 def test_inventory_process_exit_status_after_non_profile_tally():
     NotifyProgress.set_inventory_report_mode( True )
     ProfilesDiagnosticCollector.activate()

--- a/tests/unit/test_profiles_source_pages.py
+++ b/tests/unit/test_profiles_source_pages.py
@@ -17,10 +17,13 @@ from cuppa.cpp.profiles_report.source_pages import (
     display_path_on_disk,
     format_rule_label_html,
     format_violation_message_html,
+    remote_href_display_path,
     sanitized_source_filename,
     source_page_relpath,
+    source_path_link_label,
     write_source_pages,
 )
+from cuppa.reports.link_style import initialise_report_linking
 from cuppa.cpp.cxx_profiles_report import (
     ProfilesInventory,
     ProfilesScope,
@@ -382,8 +385,15 @@ def test_write_source_pages_emits_markup( tmp_path ):
     assert 'prof-stat-value--alert' in html
 
 
+def test_remote_href_display_path_strips_working_dir( tmp_path ):
+    source = tmp_path / '_build' / 'clang' / 'dbg' / 'x86_64' / 'cxx2c' / 'working' / 'include' / 'widget.hpp'
+    source.parent.mkdir( parents=True )
+    env = { 'sconstruct_dir': str( tmp_path ) }
+    assert remote_href_display_path( str( source ), env ) == 'include/widget.hpp'
+
+
 def test_write_source_pages_github_source_link( tmp_path, monkeypatch ):
-    source = tmp_path / 'include' / 'widget.hpp'
+    source = tmp_path / '_build' / 'clang' / 'dbg' / 'x86_64' / 'cxx2c' / 'working' / 'include' / 'widget.hpp'
     source.parent.mkdir( parents=True )
     source.write_text( 'int* p;\n', encoding='utf-8' )
 
@@ -394,7 +404,7 @@ def test_write_source_pages_github_source_link( tmp_path, monkeypatch ):
         'cuppa.test_report.html_report.vcs_info_from_location',
         lambda *args: (
             'git@github.com:cppalliance/capy.git',
-            'https://github.com/cppalliance/capy',
+            'git@github.com:cppalliance/capy.git',
             'develop',
             'origin',
             'abc123',
@@ -406,13 +416,14 @@ def test_write_source_pages_github_source_link( tmp_path, monkeypatch ):
         'reports_link_style': 'github',
         'current_branch': 'develop',
     }
+    link_base = initialise_report_linking( env, link_style='github' )
     destination = tmp_path / 'report'
     page_map, written = write_source_pages(
         inventory,
         str( destination ),
         env,
         'github',
-        'https://github.com/cppalliance/capy/blob/develop',
+        link_base,
         'cxx-profiles-index.html',
         lambda: __import__( 'jinja2' ).Environment(
             loader=__import__( 'jinja2' ).PackageLoader( 'cuppa', 'cpp/templates' ),
@@ -420,5 +431,39 @@ def test_write_source_pages_github_source_link( tmp_path, monkeypatch ):
         ).get_template( 'cxx_profiles_source_file.html' ),
     )
     html = open( written[ 0 ], encoding='utf-8' ).read()
-    assert 'https://github.com/cppalliance/capy/blob/develop/include/widget.hpp' in html
+    expected = 'https://github.com/cppalliance/capy/blob/develop/include/widget.hpp'
+    assert link_base == 'https://github.com/cppalliance/capy/blob/develop'
+    assert expected in html
+    assert 'href="{}"'.format( expected ) in html
+    assert '>{0}</a>'.format( expected ) in html
     assert 'file://' not in html
+    assert '~/' not in html
+
+
+def test_source_path_link_label_local_uses_disk_path( tmp_path ):
+    source = tmp_path / 'src' / 'widget.cpp'
+    source.parent.mkdir()
+    env = { 'sconstruct_dir': str( tmp_path ) }
+    label = source_path_link_label(
+        str( source ),
+        env,
+        'local',
+        'file://' + str( tmp_path ),
+        'src/widget.cpp',
+    )
+    assert label == display_path_on_disk( str( source ) )
+
+
+def test_source_path_link_label_github_matches_href( tmp_path ):
+    source = tmp_path / 'include' / 'widget.hpp'
+    source.parent.mkdir()
+    env = { 'sconstruct_dir': str( tmp_path ) }
+    link_base = 'https://github.com/org/repo/blob/main'
+    label = source_path_link_label(
+        str( source ),
+        env,
+        'github',
+        link_base,
+        'include/widget.hpp',
+    )
+    assert label == 'https://github.com/org/repo/blob/main/include/widget.hpp'

--- a/tests/unit/test_profiles_source_pages.py
+++ b/tests/unit/test_profiles_source_pages.py
@@ -370,6 +370,8 @@ def test_write_source_pages_emits_markup( tmp_path ):
     assert 'ref_to_uninit' in html
     assert 'prof-summary-table' in html
     assert 'Violation Message' in html
+    assert '>Violations</th>' in html
+    assert 'Distinct/Unique' not in html
     assert 'violation of' in html
     assert 'distinct rule' in html
     assert 'violation detected through' not in html
@@ -378,3 +380,45 @@ def test_write_source_pages_emits_markup( tmp_path ):
     assert 'breadcrumb' in html
     assert 'By source' in html
     assert 'prof-stat-value--alert' in html
+
+
+def test_write_source_pages_github_source_link( tmp_path, monkeypatch ):
+    source = tmp_path / 'include' / 'widget.hpp'
+    source.parent.mkdir( parents=True )
+    source.write_text( 'int* p;\n', encoding='utf-8' )
+
+    inventory = ProfilesInventory()
+    _record_line( inventory, str( source ), line=1, column=6 )
+
+    monkeypatch.setattr(
+        'cuppa.test_report.html_report.vcs_info_from_location',
+        lambda *args: (
+            'git@github.com:cppalliance/capy.git',
+            'https://github.com/cppalliance/capy',
+            'develop',
+            'origin',
+            'abc123',
+        ),
+    )
+
+    env = {
+        'sconstruct_dir': str( tmp_path ),
+        'reports_link_style': 'github',
+        'current_branch': 'develop',
+    }
+    destination = tmp_path / 'report'
+    page_map, written = write_source_pages(
+        inventory,
+        str( destination ),
+        env,
+        'github',
+        'https://github.com/cppalliance/capy/blob/develop',
+        'cxx-profiles-index.html',
+        lambda: __import__( 'jinja2' ).Environment(
+            loader=__import__( 'jinja2' ).PackageLoader( 'cuppa', 'cpp/templates' ),
+            autoescape=__import__( 'jinja2' ).select_autoescape( [ 'html', 'xml' ] ),
+        ).get_template( 'cxx_profiles_source_file.html' ),
+    )
+    html = open( written[ 0 ], encoding='utf-8' ).read()
+    assert 'https://github.com/cppalliance/capy/blob/develop/include/widget.hpp' in html
+    assert 'file://' not in html

--- a/tests/unit/test_progress.py
+++ b/tests/unit/test_progress.py
@@ -112,20 +112,21 @@ def test_add_reuses_started_finished_for_same_variant_path():
     assert "_build/test/dbg" in NotifyProgress._started
 
 
-def test_add_inventory_mode_uses_requires_not_depends_on_targets():
+def test_add_inventory_mode_depends_on_targets_and_sconscript_files():
     env = _make_env("test/sconscript", "_build/test/dbg/working")
     NotifyProgress.set_inventory_report_mode(True)
 
     NotifyProgress.add(env, ["node"])
 
-    assert env.depends_calls == [
-        (
-            NotifyProgress._finished["_build/test/dbg"],
-            ["#test/sconscript", "#sconstruct"],
-        )
-    ]
     finished = NotifyProgress._finished["_build/test/dbg"]
-    assert ( finished, [ "node" ] ) in env.requires_calls
+    assert env.depends_calls == [
+        ( finished, [ "#test/sconscript", "#sconstruct" ] ),
+        ( finished, [ "node" ] ),
+    ]
+    assert not any(
+        call[0] == finished and call[1] == [ "node" ]
+        for call in env.requires_calls
+    ), "Finished variant must depend on targets via Depends, not Requires"
 
 
 def test_cuppa_layout_gives_distinct_variant_keys_per_sconscript():

--- a/tests/unit/test_reports_link_style.py
+++ b/tests/unit/test_reports_link_style.py
@@ -6,6 +6,7 @@
 import pytest
 
 from cuppa.reports.link_style import (
+    normalize_repository_browse_url,
     repository_blob_base,
     resolve_report_link_style,
     source_file_href,
@@ -21,6 +22,24 @@ def test_repository_blob_base_github():
         'github',
     )
     assert base == 'https://github.com/org/repo/blob/main'
+
+
+def test_repository_blob_base_github_git_ssh():
+    base = repository_blob_base(
+        'git@github.com:org/repo.git',
+        'main',
+        'github',
+    )
+    assert base == 'https://github.com/org/repo/blob/main'
+
+
+def test_normalize_repository_browse_url():
+    assert normalize_repository_browse_url(
+        'git@github.com:cppalliance/capy.git',
+    ) == 'https://github.com/cppalliance/capy'
+    assert normalize_repository_browse_url(
+        'https://gitlab.com/group/repo.git',
+    ) == 'https://gitlab.com/group/repo'
 
 
 def test_repository_blob_base_gitlab():


### PR DESCRIPTION
## Summary

Fixes #213: `Compile` and modules now share `object_target_for`, placing object files at `{working_dir}/<source-path>.o` via variant-relative targets (for example `src/detail/except.o`). This removes same-basename collisions when using `RecursiveGlob` or SCons `env.Glob('**')` on nested trees such as Boost.Capy.

Also adds design plans from the CMake/Capy migration experiment: sconscript exports, CMake→Cuppa migration matrix, StaticGlob rename, method behaviour audit, and an updated Methods doc split plan gated on behaviour fixes.

Fixes #215 (landed on this branch): profiles inventory Progress mode now `Depends` on build targets before `Finished variant`, so long `Run`/`Test` actions complete before the process test suite summary runs (avoids `KeyError: 'status'` under `--cxx-profiles-report --test`).

## Test plan

- [x] `pytest tests/unit/test_object_target.py`
- [x] `pytest tests/integration/methods/test_compile_object_paths.py` (includes `--dbg --rel` and nested launch; `.obj` on MSVC)
- [x] `pytest tests/integration/methods/test_glob.py tests/integration/methods/test_compile.py tests/integration/methods/test_modules.py`
- [x] `pytest tests/unit/test_progress.py` (inventory Depends ordering)
- [x] CI green on the matrix
