### PR TITLE
Create collate report destinations before writing indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ``CollateTestReportIndex()`` creates the destination directory before writing
+  ``test-report-index.json`` / ``.html`` at ``#SconstructEnd`` (and before
+  ``Copy`` of per-test reports). A missing ``_artefacts/test`` (or
+  ``_artifacts/test``) no longer fails the build under ``--parallel``.
+  ``CollateCoverageIndex()`` creates its destination the same way for
+  ``coverage-index.html``.
 - ``MarkdownToHtml()``, ``AsciidocToHtml()`` (default targets), ``CompileScss()`` (default
   targets), and ``RunAndRedirectToFile()`` mirror nested source paths under ``final/`` so
   same-basename inputs no longer collide ([#233](https://github.com/ja11sop/cuppa/issues/233)).

--- a/cuppa/cpp/run_gcov_coverage.py
+++ b/cuppa/cpp/run_gcov_coverage.py
@@ -1149,6 +1149,8 @@ class CoverageIndexBuilder(object):
 
                 source_groups = build_source_groups( source_entries_by_toolchain )
 
+                os.makedirs( destination_dir, exist_ok=True )
+
                 with open( master_index_path, 'w', encoding='utf-8' ) as master_index_file:
 
                     master_index_file.write(

--- a/cuppa/test_report/html_report.py
+++ b/cuppa/test_report/html_report.py
@@ -570,6 +570,11 @@ class CollateReportIndexAction(object):
 
             logger.trace( "report_summary = {}".format( str( self._read( str(json_report) ) ) ) )
 
+            for node in ( html_target, json_target ):
+                parent = os.path.dirname( str( node ) )
+                if parent:
+                    os.makedirs( parent, exist_ok=True )
+
             env.Execute( Copy( html_target, html_report ) )
             env.Execute( Copy( json_target, json_report ) )
 
@@ -728,6 +733,8 @@ class ReportIndexBuilder(object):
                 )
 
                 logger.trace( "summaries = \n{}".format( summaries_json_report ) )
+
+                os.makedirs( destination_dir, exist_ok=True )
 
                 with open( master_report_path, 'w', encoding='utf-8' ) as master_report_file:
                     master_report_file.write( summaries_json_report )

--- a/docs/modules/ROOT/pages/integration/test-test-reports.adoc
+++ b/docs/modules/ROOT/pages/integration/test-test-reports.adoc
@@ -8,7 +8,8 @@
 2. *`GenerateHtmlTestReport` with `--cov`* — build succeeds with both `*.report.html` and `coverage--*.json` present (regression: coverage JSON must not break HTML report generation).
 3. *`CollateTestReportIndex`* — copies reports into `#_artefacts/test/` and writes `test-report-index.html` / `.json` at sconstruct end (including outside a VCS checkout).
 4. *Shared-destination collate* — two sibling sconscripts collating into the same artifacts folder.
-5. *`GenerateBittenReport`* — Bitten XML from the same test run.
+5. *Collate destination mkdir* — ``CollateTestReportIndex`` with ``--parallel`` succeeds when ``_artefacts/test`` does not already exist (master index is written at ``#SconstructEnd``, not by a SCons ``Copy``).
+6. *`GenerateBittenReport`* — Bitten XML from the same test run.
 
 == Generated files
 
@@ -68,6 +69,7 @@ cuppa -D --offline --toolchains=gcc --cov --test
 * With `--cov`: exit 0; `*.report.html` and `coverage--*.json` both exist.
 * Collate (single): reports under `_artefacts/test/`, plus master `test-report-index.html` / `test-report-index.json` (index mentions `hello_test`).
 * Collate (shared destination): both `alpha_test` and `beta_test` report HTML under `_artefacts/test/` (Windows may use `*.exe.report.html`), plus master index mentioning both names.
+* Collate (parallel, missing destination): exit 0; `_artefacts/test/test-report-index.json` exists without a prior `mkdir`.
 * Bitten: `*bitten*.xml` under `_build`.
 
 '''

--- a/docs/modules/ROOT/pages/methods/test-reporting.adoc
+++ b/docs/modules/ROOT/pages/methods/test-reporting.adoc
@@ -13,7 +13,10 @@ They activate with `--test` / `--force-test` and usually sit in the same sconscr
 
 | Returns | Report / index nodes (empty list when the test action is inactive)
 | Evaluation | Build / post-build (gated on the `test` variant action)
-| Output paths | HTML/JSON under `final/` or a chosen destination; Bitten XML beside the run
+| Output paths | HTML/JSON under `final/` or a chosen destination; Bitten XML beside the run.
+  The collate destination directory is created if missing (the master index is written at
+  `#SconstructEnd`, so SCons `Copy` may not have created the tree yet — especially with
+  `--parallel`).
 | Progress | Yes — `NotifyProgress.add` on emitted report nodes
 |===
 

--- a/tests/integration/methods/test_test_reports.py
+++ b/tests/integration/methods/test_test_reports.py
@@ -91,6 +91,25 @@ def test_collate_test_report_index(tmp_path):
     assert "hello_test" in index_html.read_text(encoding="utf-8")
 
 
+def test_collate_test_report_index_creates_destination_with_parallel(tmp_path):
+    """Master index is written at #SconstructEnd; create destination even if SCons Copy has not."""
+    project = copy_dummy_project(tmp_path)
+    write_sconstruct(project)
+    write_sconscript(
+        project,
+        "Import('env')\n"
+        "prog = env.BuildTest('hello_test', 'tests/hello_test.cpp')\n"
+        "reports = env.GenerateHtmlTestReport(prog)\n"
+        "env.CollateTestReportIndex(reports, destination='#_artefacts/test/')\n",
+    )
+    artefacts = Path(project) / "_artefacts"
+    assert not artefacts.exists()
+    result = run_cuppa(project, "--dbg", "--test", "--parallel")
+    assert_success(result)
+    index_json = artefacts / "test" / "test-report-index.json"
+    assert index_json.is_file(), "expected master test-report-index.json without pre-created _artefacts/test"
+
+
 def test_collate_test_report_index_shared_destination(tmp_path):
     """Sibling sconscripts can collate into the same artifacts test-report destination."""
     project = copy_dummy_project(tmp_path)


### PR DESCRIPTION
## Summary

- `CollateTestReportIndex()` creates the destination directory before writing the master index at `#SconstructEnd` (and before per-test `Copy`), so a missing `_artefacts/test` / `_artifacts/test` no longer fails under `--parallel`.
- `CollateCoverageIndex()` does the same for `coverage-index.html`.
- Integration coverage: collate with `--parallel` when `_artefacts` does not exist yet.

Fixes #240

## Test plan

- [x] Local `flake8` / `pylint -E` / `pytest -m unit` / `pytest -m integration`
- [x] Focused: `test_collate_test_report_index` and `test_collate_test_report_index_creates_destination_with_parallel`
- [x] CI green on the matrix
