### PR TITLE
Add create-issue and show-issue GitHub helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,12 +226,13 @@ work on a machine with no TPM.
 ### Using it
 
 **Reads** go through the public API — no sealed token. Prefer `scripts.github_helpers`
-(`show-pr` / `pr-status` / `watch-pr`) for pull-request metadata and CI, or an anonymous client
-for other ad-hoc GETs:
+(`show-pr` / `show-issue` / `pr-status` / `watch-pr`) for pull-request and issue metadata
+and CI, or an anonymous client for other ad-hoc GETs:
 
 ```sh
 python -m scripts.github_helpers show-pr --pr 165          # title, labels, body (alias: fetch-pr)
 python -m scripts.github_helpers show-pr --pr 165 --json
+python -m scripts.github_helpers show-issue --issue 240    # alias: fetch-issue
 python -m scripts.github_helpers pr-status --pr 140
 python -m scripts.github_api GET /repos/ja11sop/cuppa/issues/132
 ```
@@ -269,6 +270,9 @@ for a one-off. Opening a pull request for the current branch **must** include ex
 python -m scripts.github_helpers create-pr \
   --title "…" --body-file /tmp/pr.md --label impact:minor
 
+python -m scripts.github_helpers create-issue \
+  --title "…" --body-file /tmp/issue.md
+
 python -m scripts.github_helpers update-pr \
   --pr 154 --title "…" --body-file /tmp/pr.md
 ```
@@ -281,8 +285,9 @@ event can still see an empty label list; the standalone `version` workflow also 
 `labeled` so the gate recovers without a no-op push.
 
 ```python
-from scripts.github_helpers import create_pull_request, update_pull_request
+from scripts.github_helpers import create_issue, create_pull_request, update_pull_request
 create_pull_request( title='…', body='…', labels=['impact:minor'] )
+create_issue( title='…', body='…' )
 update_pull_request( number=154, title='…', body='…' )
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ``env.Filter`` matches and excludes against both project-relative ``node.path``
   and absolute ``str`` / ``abspath`` forms, so the same patterns work for nodes
   from Cuppa snapshot discovery and from SCons ``Glob``.
+- ``scripts.github_helpers create-issue`` (and ``show-issue`` / ``fetch-issue``)
+  file and read GitHub issues the same way ``create-pr`` / ``show-pr`` do for
+  pull requests: sealed token for writes, public API for reads.
 
 ### Changed
 
@@ -155,7 +158,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``Copy`` of per-test reports). A missing ``_artefacts/test`` (or
   ``_artifacts/test``) no longer fails the build under ``--parallel``.
   ``CollateCoverageIndex()`` creates its destination the same way for
-  ``coverage-index.html``.
+  ``coverage-index.html``
+  ([#240](https://github.com/ja11sop/cuppa/issues/240)).
 - ``MarkdownToHtml()``, ``AsciidocToHtml()`` (default targets), ``CompileScss()`` (default
   targets), and ``RunAndRedirectToFile()`` mirror nested source paths under ``final/`` so
   same-basename inputs no longer collide ([#233](https://github.com/ja11sop/cuppa/issues/233)).

--- a/design/process/agent-workflow-journey.md
+++ b/design/process/agent-workflow-journey.md
@@ -2,7 +2,7 @@
 
 - **Status:** living
 - **Related:** [`AGENTS.md`](../../AGENTS.md) (agent ops); Antora Contributing (human versioning/release)
-- **Updated:** 2026-08-28
+- **Updated:** 2026-09-01
 - **Maintainer:** primary author of this journey; others append only (see `AGENTS.md`)
 - **Privacy:** obey the private-projects rule; never copy names from `INTERNAL_PROJECTS.local.md`
 - **Source:** Cursor sessions spanning roughly mid-July → 2026-08-07 on cuppa
@@ -75,7 +75,7 @@ Grew from build tips into an operating manual:
 - Where design docs live vs Antora docs (including **Contributing** for humans).
 - Private projects: never name them in tracked files; use labels + `INTERNAL_PROJECTS.local.md`.
 - GitHub: no `gh`; public reads vs sealed writes; `watch-pr` / `fetch-ci-logs` / `create-pr` /
-  `update-pr`.
+  `update-pr` / `create-issue` / `show-issue`.
 - Protected `master`: every tree change — including release prep — is a PR branch.
 - Before push: full local unit + integration gate.
 - Before merge: documentation + ROADMAP + CHANGELOG + plan housekeeping + PR test-plan ticks +
@@ -93,6 +93,7 @@ we added a helper:
 - `pr-status` / `watch-pr` (sparse poll schedule to spare the API)
 - `fetch-ci-logs` (Actions logs need auth even on public repos; pass `--pr` or `--run-id`)
 - `create-pr` / `update-pr` (title/body/labels without hand-rolled PATCH)
+- `create-issue` / `show-issue` (alias `fetch-issue`; same public-read / sealed-write split)
 
 **Teaching point:** the second time you debug the same API footgun, stop and write the script.
 
@@ -322,6 +323,7 @@ These are recommendations for the next project, not self-flagellation.
 | Housekeeping ritual before merge | Prevents “green CI, stale ROADMAP” |
 | Sealed token + public reads by default | Safer defaults for agents |
 | `show-pr` / `fetch-pr` for PR metadata | Prefer helpers over ad-hoc `GET /pulls/{n}` (and never `gh`) |
+| `create-issue` / `show-issue` | Same helper pattern for issues; do not reach for `gh` to file a bug |
 | `*.local.md` for secrets of context | Public repo stays clean |
 | `check_release` before build/publish | Catches `.dev` / unreleased before PyPI |
 | prepare / publish `workflow_dispatch` | Removes hand-tag ordering mistakes |
@@ -421,7 +423,7 @@ This is a process rule, not a product plan. Day-to-day wording lives in `AGENTS.
 | [`docs/.../contributing.adoc`](../../docs/modules/ROOT/pages/contributing.adoc) | Human Contributing hub (diagrams on children) |
 | [`design/README.md`](../README.md) | Index of plans / process / archive |
 | [`design/plans/removal-options.md`](../plans/removal-options.md) | Example of a living multi-PR plan |
-| [`scripts/github_helpers.py`](../../scripts/github_helpers.py) | PR/CI agent helpers |
+| [`scripts/github_helpers.py`](../../scripts/github_helpers.py) | PR/CI/issue agent helpers |
 | [`scripts/github_api.py`](../../scripts/github_api.py) | Sealed credential transport |
 | Antora `docs/` | Published truth for users |
 | Integration pages under `docs/.../integration/` | Executable scenarios as docs |

--- a/scripts/github_helpers.py
+++ b/scripts/github_helpers.py
@@ -10,8 +10,9 @@ Owner and repository always come from the local ``origin`` remote (or explicit `
 wrong repository.
 
 Reads on a public repository use the anonymous API. ``show-pr`` (alias ``fetch-pr``),
-``pr-status``, and ``watch-pr`` do not unseal the token. Writes (``create-pr``, ``update-pr``,
-labelling) and CI log downloads (``fetch-ci-logs``) still go through the sealed credential.
+``show-issue`` (alias ``fetch-issue``), ``pr-status``, and ``watch-pr`` do not unseal the token.
+Writes (``create-pr``, ``update-pr``, ``create-issue``, labelling) and CI log downloads
+(``fetch-ci-logs``) still go through the sealed credential.
 
 Pushing a branch is still ``git push -u origin HEAD``.
 
@@ -24,6 +25,13 @@ Create a pull request from the current branch:
 
     python -m scripts.github_helpers create-pr \\
         --title "…" --body-file /tmp/pr.md --label impact:minor
+
+File an issue (sealed token):
+
+    python -m scripts.github_helpers create-issue \\
+        --title "…" --body-file /tmp/issue.md --label bug
+
+    python -m scripts.github_helpers show-issue --issue 240
 
 Update an open pull request's title and/or body (current branch's PR, or ``--pr``):
 
@@ -49,10 +57,13 @@ public even on a public repository):
     Or from Python:
 
     from scripts.github_helpers import (
-        create_pull_request, show_pull_request, update_pull_request, watch_pull_request,
+        create_issue, create_pull_request, show_issue, show_pull_request,
+        update_pull_request, watch_pull_request,
     )
     create_pull_request( title='…', body='…', labels=['impact:minor'] )
+    create_issue( title='…', body='…', labels=['bug'] )
     show_pull_request( number=165 )
+    show_issue( number=240 )
     update_pull_request( number=154, title='…', body='…' )
     watch_pull_request( number=139 )
 """
@@ -231,6 +242,78 @@ def create_pull_request(
             )
 
     return pull
+
+
+def create_issue(
+        title,
+        body,
+        labels=None,
+        owner=None,
+        repo=None,
+        github=None,
+):
+    """Open an issue and optionally label it. Returns the issue dict from GitHub."""
+    owner, repo = repository( owner, repo )
+    client = github or GitHub()
+    payload = { 'title': title, 'body': body }
+    if labels:
+        payload['labels'] = list( labels )
+
+    status, issue = client.request(
+        'POST',
+        '/repos/{}/{}/issues'.format( owner, repo ),
+        payload,
+    )
+    if status >= 400:
+        raise GitHubHelperError( "creating the issue failed ({}): {}".format(
+            status, json.dumps( issue ) ) )
+    return issue
+
+
+def show_issue( number, owner=None, repo=None, github=None ):
+    """Public issue metadata (title, labels, body, state)."""
+    owner, repo = repository( owner, repo )
+    client = public_github( github )
+    status, issue = client.request(
+        'GET',
+        '/repos/{}/{}/issues/{}'.format( owner, repo, number ),
+    )
+    if is_rate_limit_response( status, issue ):
+        raise RateLimited( "reading issue {} rate-limited ({}): {}".format(
+            number, status, json.dumps( issue ) ) )
+    if status >= 400:
+        raise GitHubHelperError( "reading issue {} failed ({}): {}".format(
+            number, status, json.dumps( issue ) ) )
+    if issue.get( 'pull_request' ):
+        raise GitHubHelperError(
+            "issue {} is a pull request; use show-pr --pr {}".format( number, number )
+        )
+    return {
+        'number': issue['number'],
+        'url': issue.get( 'html_url' ),
+        'title': issue.get( 'title' ) or '',
+        'state': issue.get( 'state' ),
+        'labels': [
+            label.get( 'name' )
+            for label in ( issue.get( 'labels' ) or [] )
+            if label.get( 'name' )
+        ],
+        'body': issue.get( 'body' ) or '',
+    }
+
+
+def format_issue( summary ):
+    labels = summary.get( 'labels' ) or []
+    label_text = ', '.join( labels ) if labels else '-'
+    return "\n".join( [
+        "Issue #{} {}".format( summary['number'], summary.get( 'url' ) or '' ),
+        "title: {}".format( summary.get( 'title' ) or '' ),
+        "state={}".format( summary.get( 'state' ) ),
+        "labels: {}".format( label_text ),
+        "---",
+        ( summary.get( 'body' ) or '' ).rstrip(),
+        "",
+    ] )
 
 
 def update_pull_request(
@@ -828,6 +911,44 @@ def create_pr_command( arguments ):
     return 0
 
 
+def create_issue_command( arguments ):
+    issue = create_issue(
+        title = arguments.title,
+        body = _read_body( arguments ),
+        labels = arguments.label or None,
+        owner = arguments.owner,
+        repo = arguments.repo,
+    )
+    print( issue['html_url'] )
+    return 0
+
+
+def show_issue_command( arguments ):
+    github = GitHub() if arguments.auth else None
+    try:
+        summary = show_issue(
+            number = arguments.issue,
+            owner = arguments.owner,
+            repo = arguments.repo,
+            github = github,
+        )
+    except RateLimited:
+        if github is None:
+            summary = show_issue(
+                number = arguments.issue,
+                owner = arguments.owner,
+                repo = arguments.repo,
+                github = GitHub(),
+            )
+        else:
+            raise
+    if arguments.json:
+        print( json.dumps( summary, indent=2, sort_keys=True ) )
+    else:
+        print( format_issue( summary ) )
+    return 0
+
+
 def update_pr_command( arguments ):
     pull = update_pull_request(
         number = arguments.pr,
@@ -928,6 +1049,34 @@ def main( argv=None ):
     create.add_argument( '--owner' )
     create.add_argument( '--repo' )
 
+    issue = commands.add_parser( 'create-issue', help="open a GitHub issue (sealed token)" )
+    issue.add_argument( '--title', required=True )
+    issue.add_argument( '--body', default=None, help="issue body text" )
+    issue.add_argument( '--body-file', help="read the body from this file instead" )
+    issue.add_argument(
+        '--label', action='append', default=[],
+        help="label to apply; repeat for more than one",
+    )
+    issue.add_argument( '--owner' )
+    issue.add_argument( '--repo' )
+
+    show_issue_p = commands.add_parser(
+        'show-issue',
+        aliases=[ 'fetch-issue' ],
+        help="show issue title, labels, and body (public API)",
+    )
+    show_issue_p.add_argument( '--issue', type=int, required=True, help="issue number" )
+    show_issue_p.add_argument( '--owner' )
+    show_issue_p.add_argument( '--repo' )
+    show_issue_p.add_argument(
+        '--auth', action='store_true',
+        help="use the sealed credential instead of the public API",
+    )
+    show_issue_p.add_argument(
+        '--json', action='store_true',
+        help="print a JSON summary instead of the human-readable form",
+    )
+
     update = commands.add_parser(
         'update-pr',
         help="update title and/or body on an open pull request (sealed token)",
@@ -999,6 +1148,10 @@ def main( argv=None ):
     try:
         if arguments.command == 'create-pr':
             return create_pr_command( arguments )
+        if arguments.command == 'create-issue':
+            return create_issue_command( arguments )
+        if arguments.command in ( 'show-issue', 'fetch-issue' ):
+            return show_issue_command( arguments )
         if arguments.command == 'update-pr':
             return update_pr_command( arguments )
         if arguments.command == 'pr-status':

--- a/tests/unit/test_github_helpers.py
+++ b/tests/unit/test_github_helpers.py
@@ -21,6 +21,8 @@ class FakeGitHub( object ):
             return self.responses.pop( 0 )
         if path.endswith( '/pulls' ) and method == 'POST':
             return 201, { 'number': 42, 'html_url': 'https://example.com/pr/42' }
+        if path.endswith( '/issues' ) and method == 'POST':
+            return 201, { 'number': 240, 'html_url': 'https://example.com/issues/240' }
         if path.endswith( '/labels' ):
             return 200, [ { 'name': label } for label in payload['labels'] ]
         return 404, {}
@@ -204,6 +206,124 @@ def test_create_pr_command_requires_impact_label():
     )
     with pytest.raises( github_helpers.GitHubHelperError, match='impact: label' ):
         github_helpers.create_pr_command( arguments )
+
+
+def test_create_issue_posts_title_body_and_labels():
+    client = FakeGitHub()
+
+    issue = github_helpers.create_issue(
+        title = 'Index write races mkdir',
+        body = 'ENOENT at SconstructEnd',
+        labels = [ 'bug' ],
+        github = client,
+    )
+
+    assert issue['html_url'] == 'https://example.com/issues/240'
+    assert client.calls[0][0] == 'POST'
+    assert client.calls[0][1].endswith( '/issues' )
+    assert client.calls[0][2] == {
+        'title': 'Index write races mkdir',
+        'body': 'ENOENT at SconstructEnd',
+        'labels': [ 'bug' ],
+    }
+
+
+def test_create_issue_omits_labels_when_none():
+    client = FakeGitHub()
+    github_helpers.create_issue(
+        title = 'Untitled',
+        body = 'Body',
+        github = client,
+    )
+    assert 'labels' not in client.calls[0][2]
+
+
+def test_create_issue_reports_api_failure():
+    class Failing( object ):
+        def request( self, method, path, payload=None ):
+            return 422, { 'message': 'Validation Failed' }
+
+    with pytest.raises( github_helpers.GitHubHelperError, match='422' ):
+        github_helpers.create_issue(
+            title = 'Untitled',
+            body = 'Body',
+            github = Failing(),
+        )
+
+
+def test_show_issue_uses_public_api_and_summarises( monkeypatch ):
+    created = []
+
+    class CapturingPublic( object ):
+        @classmethod
+        def public( cls ):
+            client = FakeGitHub( responses=[
+                ( 200, {
+                    'number': 240,
+                    'html_url': 'https://example.com/issues/240',
+                    'title': 'Collate index mkdir',
+                    'body': 'Missing _artifacts/test\n',
+                    'state': 'open',
+                    'labels': [ { 'name': 'bug' } ],
+                } ),
+            ] )
+            created.append( client )
+            return client
+
+    monkeypatch.setattr( github_helpers, 'GitHub', CapturingPublic )
+    monkeypatch.setattr(
+        github_helpers, 'repository',
+        lambda owner=None, repo=None: ( 'ja11sop', 'cuppa' ),
+    )
+
+    summary = github_helpers.show_issue( number=240 )
+    assert created, "show-issue must use GitHub.public(), not the sealed client"
+    assert summary['number'] == 240
+    assert summary['labels'] == [ 'bug' ]
+    assert 'Missing _artifacts/test' in summary['body']
+
+    rendered = github_helpers.format_issue( summary )
+    assert 'Issue #240' in rendered
+    assert 'title: Collate index mkdir' in rendered
+    assert 'labels: bug' in rendered
+    assert 'Missing _artifacts/test' in rendered
+
+
+def test_show_issue_rejects_pull_requests( monkeypatch ):
+    monkeypatch.setattr(
+        github_helpers, 'repository',
+        lambda owner=None, repo=None: ( 'ja11sop', 'cuppa' ),
+    )
+    client = FakeGitHub( responses=[
+        ( 200, {
+            'number': 239,
+            'html_url': 'https://example.com/issues/239',
+            'title': 'A PR',
+            'body': '',
+            'state': 'open',
+            'labels': [],
+            'pull_request': { 'url': 'https://example.com/pulls/239' },
+        } ),
+    ] )
+    with pytest.raises( github_helpers.GitHubHelperError, match='show-pr' ):
+        github_helpers.show_issue( number=239, github=client )
+
+
+def test_fetch_issue_alias_dispatches( monkeypatch, capsys ):
+    monkeypatch.setattr(
+        github_helpers, 'show_issue',
+        lambda **kwargs: {
+            'number': 1,
+            'url': 'https://example.com/issues/1',
+            'title': 'T',
+            'state': 'open',
+            'labels': [],
+            'body': '',
+        },
+    )
+    code = github_helpers.main( [ 'fetch-issue', '--issue', '1' ] )
+    assert code == 0
+    assert 'Issue #1' in capsys.readouterr().out
 
 
 def test_create_pull_request_reports_api_failure():


### PR DESCRIPTION
## Summary

- Add `scripts.github_helpers create-issue` (sealed token) and `show-issue` / `fetch-issue` (public API), matching `create-pr` / `show-pr`.
- Document in `AGENTS.md` and the agent-workflow journey; unit tests cover create, show, PR-number rejection, and CLI dispatch.
- Cite #240 on the collate-index changelog entry now that the issue exists.

## Test plan

- [x] Local `flake8` / `pylint -E` / `pytest -m unit` / `pytest -m integration`
- [x] Focused: `tests/unit/test_github_helpers.py`
- [x] CI green on the matrix
