### PR TITLE
Add --toolchain-identity full or major for layout and packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,12 @@ That means `git commit` is never invoked with `--trailer`, and a `Co-authored-by
 never written into the message body either. An agent committing here passes the message with
 `-m` or `-F` and nothing else.
 
+GitHub's squash-merge box **pre-fills** `Co-authored-by:` for each branch-commit author whose
+email differs from the GitHub account's commit identity (for example a local
+`user@example.com` versus `user@users.noreply.github.com`). That line is not from
+`scripts.github_helpers`. Delete it before merging. Aligning local `user.email` with the
+account's GitHub noreply address stops the suggestion on later PRs.
+
 Otherwise, follow the shape already in the log:
 
 - A subject line that names the change, in the imperative, without a full stop.
@@ -696,6 +702,7 @@ In a project that *uses* cuppa (not this repo):
 
 ```sh
 cuppa -D --dbg --develop --offline --test
+cuppa -D --toolchain-identity=major
 cuppa -D --list-develop
 cuppa -D --update-develop
 cuppa -D --cov --test --toolchains=gcc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ``scripts.github_helpers create-issue`` (and ``show-issue`` / ``fetch-issue``)
   file and read GitHub issues the same way ``create-pr`` / ``show-pr`` do for
   pull requests: sealed token for writes, public API for reads.
+- ``--toolchain-identity=full|major`` (``toolchain_identity`` in ``cuppa.run`` /
+  ``configure.conf`` / ``~/.cuppaconfig``) selects whether ``toolchain.name()``
+  and ``package_name()`` keep the point-release token (``gcc153``) or the major
+  line (``gcc15``). Stdlib tags and registered archive qualifiers are unchanged.
+  Missing ``~/.cuppaconfig`` creates the file with ``major``; an existing global
+  file without the key is grandfathered to ``full``. ``--list-toolchains`` still
+  reports the real compiler version. Cuppa 2.0 may make ``major`` the silent
+  built-in default; 1.x does not flip existing globals.
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -424,7 +424,7 @@ C++ Profiles are a separate roadmap section — see [C++ Profiles](#c-profiles).
 | `tc-dep-url-sugar` | Optional URL token in `--toolchains=` | Low | Keep `--toolchain-archive=` as explicit supply |
 | `tc-dep-actions` | Authenticated Actions artifact URLs | Low | After public HTTPS / file path is solid |
 | `tc-dep-msvc` | MSVC archive / layout as toolchain dep | Low | Separate driver; not gcc-snapshot |
-| `tc-identity-coarsen` | Opt-in ignore toolchain point-release digits in `_build` / package stems (`gcc153`→`gcc15`) | High | Usability for package fleets; default stays full identity — [`ignore-toolchain-point-release.md`](design/plans/ignore-toolchain-point-release.md) |
+| `tc-identity-coarsen` | Major toolchain identity for `_build` / package stems (`gcc153`→`gcc15`); optional OS omit and consume overrides | High | New-install `major` via absent `~/.cuppaconfig`; grandfather `full` — [`build-and-package-identity.md`](design/plans/build-and-package-identity.md), encoding [`ignore-toolchain-point-release.md`](design/plans/ignore-toolchain-point-release.md) |
 
 ### Out of scope (toolchains-as-deps)
 

--- a/cuppa/configure.py
+++ b/cuppa/configure.py
@@ -126,6 +126,7 @@ class Configure(object):
             logger.info( "{}".format( as_notice( "Update configuration requested..." ) ) )
 
         if not self._save and not self._save_global:
+            self._migrate_toolchain_identity()
             self._loaded_options = self._load_conf()
         else:
             self._loaded_options = {}
@@ -216,6 +217,16 @@ class Configure(object):
                 pass
             self._print_setting( 'loading', name, value )
             settings[name] = value
+
+
+    def _migrate_toolchain_identity( self ):
+        from cuppa.toolchains.identity import (
+            migrate_global_toolchain_identity,
+            should_migrate_global_identity,
+        )
+        if not should_migrate_global_identity():
+            return
+        migrate_global_toolchain_identity( self._global_conf_path )
 
 
     def _load_conf( self ):

--- a/cuppa/toolchains/cl.py
+++ b/cuppa/toolchains/cl.py
@@ -397,7 +397,8 @@ class Cl(object):
 
 
     def name( self ):
-        return self._name
+        from cuppa.toolchains.identity import current_identity, msvc_layout_name
+        return msvc_layout_name( self._toolset, policy=current_identity() )
 
 
     def package_name( self ):

--- a/cuppa/toolchains/clang.py
+++ b/cuppa/toolchains/clang.py
@@ -380,9 +380,23 @@ class Clang(object):
         # Build/ABI identity: platform default stdlib (libstdc++ on Linux) keeps the
         # bare reported name so existing paths stay stable; only a non-default
         # choice is tagged (e.g. clang21-libc++). Compiler commands use binary()/CXX.
+        from cuppa.toolchains.identity import current_identity, gnu_layout_name
+        tag = None
         if self._stdlib and self._stdlib != self.default_stdlib():
-            return "{}-{}".format( self._name, self._stdlib )
-        return self._name
+            tag = self._stdlib
+        reported = getattr( self, '_reported_version', None )
+        if not reported:
+            if tag:
+                return "{}-{}".format( self._name, tag )
+            return self._name
+        return gnu_layout_name(
+            'clang',
+            reported['major'],
+            reported['minor'],
+            policy=current_identity(),
+            encoded_name=self._name,
+            tag=tag,
+        )
 
 
     def package_name( self ):

--- a/cuppa/toolchains/gcc.py
+++ b/cuppa/toolchains/gcc.py
@@ -283,7 +283,15 @@ class Gcc(object):
 
 
     def name( self ):
-        return self._name
+        from cuppa.toolchains.identity import current_identity, gnu_layout_name
+        reported = self._reported_version
+        return gnu_layout_name(
+            'gcc',
+            reported['major'],
+            reported['minor'],
+            policy=current_identity(),
+            encoded_name=self._name,
+        )
 
 
     def package_name( self ):

--- a/cuppa/toolchains/identity.py
+++ b/cuppa/toolchains/identity.py
@@ -1,0 +1,166 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   Toolchain identity — full vs major layout / package tokens
+#-------------------------------------------------------------------------------
+
+"""Policy for ``toolchain.name()`` / ``package_name()``.
+
+``full`` keeps today's encoded major.minor token (``gcc153``, ``clang211``, ``vc145``).
+``major`` drops the point-release digits (``gcc15``, ``clang21``, ``vc14``) while leaving
+stdlib tags and registered archive qualifiers (``gcc17_gcc_snapshot_…``) intact.
+
+Selection aliases (``--toolchains=gcc153``) and ``--list-toolchains`` version fields are
+unchanged. This module only names *layout and package* identity.
+"""
+
+import os
+
+from cuppa.log import logger
+from cuppa.colourise import as_info, as_notice
+
+
+IDENTITY_FULL = 'full'
+IDENTITY_MAJOR = 'major'
+IDENTITY_CHOICES = ( IDENTITY_FULL, IDENTITY_MAJOR )
+
+TOOLCHAIN_IDENTITY_KEY = 'toolchain_identity'
+
+
+class ToolchainIdentity( object ):
+    """Registers ``--toolchain-identity=``; not itself a compiler toolchain."""
+
+    @classmethod
+    def add_options( cls, add_option ):
+        add_option(
+            '--toolchain-identity',
+            dest='toolchain_identity',
+            choices=list( IDENTITY_CHOICES ),
+            nargs=1,
+            action='store',
+            help="How toolchain tokens are encoded in _build paths and package stems: "
+                 "'full' (gcc153) or 'major' (gcc15). Does not change --list-toolchains "
+                 "reported compiler versions. New installs persist major in ~/.cuppaconfig; "
+                 "existing global files without the key are grandfathered to full.",
+        )
+
+    @classmethod
+    def add_to_env( cls, env, add_toolchain, add_to_supported ):
+        # Option-only helper; do not register a compiler.
+        pass
+
+
+def normalised_identity( value ):
+    """Return ``full`` or ``major``, or ``None`` when unset."""
+    if value is None or value == '':
+        return None
+    if isinstance( value, ( list, tuple ) ):
+        if not value:
+            return None
+        value = value[0]
+    text = str( value ).strip().lower()
+    if text not in IDENTITY_CHOICES:
+        raise ValueError(
+            "toolchain_identity must be 'full' or 'major', not {!r}".format( value )
+        )
+    return text
+
+
+def current_identity():
+    """Effective policy for this process, defaulting to ``full`` when unset."""
+    try:
+        from cuppa.core.environment import CuppaEnvironment
+        raw = CuppaEnvironment.get_option( TOOLCHAIN_IDENTITY_KEY )
+    except Exception:
+        raw = None
+    try:
+        parsed = normalised_identity( raw )
+    except ValueError:
+        parsed = None
+    return parsed or IDENTITY_FULL
+
+
+def gnu_numeric_token( prefix, major, minor, policy ):
+    """``gcc`` / ``clang`` + digits for the requested policy."""
+    prefix = str( prefix )
+    major = int( major )
+    minor = int( minor )
+    if policy == IDENTITY_MAJOR:
+        return '{}{}'.format( prefix, major )
+    return '{}{}{}'.format( prefix, major, minor )
+
+
+def is_plain_gnu_token( encoded, prefix, major, minor ):
+    """True when ``encoded`` is prefix+major or prefix+major+minor (optional ``-tag``)."""
+    if not encoded:
+        return True
+    major_token = gnu_numeric_token( prefix, major, minor, IDENTITY_MAJOR )
+    full_token = gnu_numeric_token( prefix, major, minor, IDENTITY_FULL )
+    base = encoded.split( '-', 1 )[0]
+    return base in ( major_token, full_token )
+
+
+def gnu_layout_name( prefix, major, minor, policy=None, encoded_name=None, tag=None ):
+    """Layout / package token for GCC or Clang.
+
+    Registered archive names (``gcc17_qualifier``) already use the major line plus a
+    unique qualifier; they are returned unchanged so two snapshots cannot collide.
+    """
+    policy = policy or IDENTITY_FULL
+    if encoded_name and not is_plain_gnu_token( encoded_name, prefix, major, minor ):
+        token = encoded_name
+    else:
+        token = gnu_numeric_token( prefix, major, minor, policy )
+    if tag:
+        suffix = '-{}'.format( tag )
+        if not token.endswith( suffix ):
+            return token + suffix
+    return token
+
+
+def msvc_layout_name( toolset, policy=None ):
+    """Layout / package token for MSVC.
+
+    ``full`` is the usual alias (``vc145``). ``major`` keeps the toolset major only
+    (``vc14``, plus ``e`` when the toolset is experimental).
+    """
+    policy = policy or IDENTITY_FULL
+    if policy == IDENTITY_MAJOR:
+        suffix = 'e' if getattr( toolset, 'experimental', False ) else ''
+        return 'vc{}{}'.format( int( toolset.major ), suffix )
+    return toolset.alias
+
+
+def should_migrate_global_identity():
+    """Skip rewriting the developer's ``~/.cuppaconfig`` during pytest unless opted in."""
+    if os.environ.get( 'CUPPA_TEST_IDENTITY_MIGRATE' ) == '1':
+        return True
+    if os.environ.get( 'PYTEST_CURRENT_TEST' ):
+        return False
+    return True
+
+
+def migrate_global_toolchain_identity( conf_path ):
+    """Persist identity into the global conf file.
+
+    Missing file → create ``toolchain_identity=major``. Existing file without the key →
+    write ``full``. Existing key is left unchanged.
+    """
+    from cuppa.configure import load_settings_file, upsert_setting
+
+    existed = bool( conf_path ) and os.path.exists( conf_path )
+    settings = load_settings_file( conf_path )
+    if TOOLCHAIN_IDENTITY_KEY in settings:
+        return normalised_identity( settings[TOOLCHAIN_IDENTITY_KEY] )
+
+    value = IDENTITY_FULL if existed else IDENTITY_MAJOR
+    upsert_setting( conf_path, TOOLCHAIN_IDENTITY_KEY, value )
+    logger.info( "Persisted [{}] = [{}] in [{}]".format(
+            as_notice( TOOLCHAIN_IDENTITY_KEY ),
+            as_info( value ),
+            as_notice( conf_path ),
+    ) )
+    return value

--- a/design/README.md
+++ b/design/README.md
@@ -52,7 +52,8 @@ maintainer workflow evolved.
 | [`archive/recursive-glob-parity.md`](archive/recursive-glob-parity.md) | shipped | RecursiveGlob / GlobFiles / Filter parity — ROADMAP `static-glob`; [#232](https://github.com/ja11sop/cuppa/issues/232) / [#231](https://github.com/ja11sop/cuppa/pull/231) |
 | [`archive/method-behaviour-audit.md`](archive/method-behaviour-audit.md) | shipped | Method returns, evaluation, paths; #213 + glob + #233 + cov nested-path; hub classification — ROADMAP `method-behaviour-audit` |
 | [`plans/path-vocabulary-and-scons-nodes.md`](plans/path-vocabulary-and-scons-nodes.md) | proposal | Reuse `#/` path roots + VariantDir node helpers outside discovery — follow-on to `static-glob` |
-| [`plans/ignore-toolchain-point-release.md`](plans/ignore-toolchain-point-release.md) | proposal | Opt-in coarse toolchain identity for `_build` / package stems (drop point-release digits) — ROADMAP `tc-identity-coarsen` |
+| [`plans/ignore-toolchain-point-release.md`](plans/ignore-toolchain-point-release.md) | in progress | Point-release encoding problem (`gcc153`→`gcc15`); product shape in [`build-and-package-identity.md`](plans/build-and-package-identity.md) — ROADMAP `tc-identity-coarsen` |
+| [`plans/build-and-package-identity.md`](plans/build-and-package-identity.md) | in progress | Toolchain major identity (new-install default), consume matching, OS omit at publish — ROADMAP `tc-identity-coarsen` |
 | [`plans/docs-site-release-default.md`](plans/docs-site-release-default.md) | in progress | Public Antora site defaults to `/latest/` (release), `next` prerelease — ROADMAP `doc-site-release-default`; same PR as llms |
 | [`plans/docs-llms-txt.md`](plans/docs-llms-txt.md) | in progress | Agent Markdown from Antora HTML (`llms.txt` / pages / `llms-full.txt`, Pandoc); default corpus `/latest/` — ROADMAP `doc-llms-txt` |
 

--- a/design/plans/build-and-package-identity.md
+++ b/design/plans/build-and-package-identity.md
@@ -1,0 +1,148 @@
+# Plan: build and package identity (toolchain major, OS omit, consume matching)
+
+- **Status:** in progress
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — `tc-identity-coarsen`; original point-release problem [`ignore-toolchain-point-release.md`](ignore-toolchain-point-release.md); package stems [`cuppa/package_managers/gitlab.py`](../../cuppa/package_managers/gitlab.py); layout [`cuppa/core/build_layout.py`](../../cuppa/core/build_layout.py) / [`cuppa/construct.py`](../../cuppa/construct.py); global conf [`cuppa/configure.py`](../../cuppa/configure.py)
+- **Updated:** 2026-09-01
+- **Impact:** minor — new identity policy and GitLab lookup overrides; existing globals grandfather `full`
+
+This document is the **settled product shape** for 1.9. Point-release encoding, vocabulary, and code hooks stay in [`ignore-toolchain-point-release.md`](ignore-toolchain-point-release.md); do not duplicate that problem statement here.
+
+**Priority:** toolchain **major** identity is the key win (layout churn + package fleets). OS omit and consume overrides are secondary slices.
+
+**Sequencing:** toolchain identity + global-config migration → consume overrides / dual lookup → OS omit at publish + OS consume override.
+
+## Two concerns (keep distinct)
+
+| Concern | Surfaces | User need |
+|---------|----------|-----------|
+| **A. Identity policy** | What we *key* as (layout + publish stems) | **Major** toolchain token so 15.2/15.3 share trees; optional OS omit when the **package builder** is confident |
+| **B. Consume matching** | What we *look up* in the registry | Try a **similar** or **specific** archive when host identity differs (ubuntu → debian package; gcc154 → gcc152 or gcc15 stem) |
+
+B is not the same as A: a project can keep full layout identity locally and still override package lookup for one dependency.
+
+## How identity works today
+
+GitLab archive stem is `{package}_{os}_{tool_variant}` (`tool_variant` = `{package_name}_{variant}_{arch}_{abi}`). OS appears **only in archive filenames**, not in `_build/` or extract dirs. `toolchain.package_name()` currently equals `name()`.
+
+## Settled decisions
+
+### Toolchain identity (layout + default package stems)
+
+| Decision | Choice |
+|----------|--------|
+| Values | `full` \| `major` (`gcc153`→`gcc15`; keep stdlib tags e.g. `clang21-libc++`) |
+| CLI / project config | `--toolchain-identity=` / `toolchain_identity=` in `cuppa.run` and project `configure.conf` (explicit project pin OK) |
+| Scope (v1) | One switch coarsens **both** `name()` and `package_name()` |
+| Reporting | `--list-toolchains` / describe still show the **real** compiler |
+| MSVC | `full` = toolset alias (`vc145`); `major` = `vc` + toolset major (`vc14`, plus `e` if experimental) |
+
+### Defaulting and global `~/.cuppaconfig` only
+
+Intent: **major is the default for new installs**; existing machines with a global conf stay on **full** until they opt in. Do **not** put the grandfather flag in project `configure.conf`.
+
+**Detecting a new install:** absence of `~/.cuppaconfig` ([`Configure.global_config_path()`](../../cuppa/configure.py)). That is **not** “never ran Cuppa.” Cuppa does not create the file on first run; it only loads it if present. Writes today: `--save-global-conf` / `--update-global-conf`, Boost latest persistence when downloads are not under the project, `--clear-global-conf` (delete).
+
+So “file missing” means **this home has no persisted global settings**. That is still the right 1.9 signal:
+
+| Reality | File missing? | Desired identity |
+|---------|---------------|------------------|
+| Fresh machine / new `$HOME` | Yes | `major` |
+| Long-time user who never saved global conf | Yes | `major` — they already live on Cuppa *built-in* defaults |
+| User with `~/.cuppaconfig` (any keys) | No | Grandfather `full` if `toolchain_identity` absent; else honour stored value |
+| `--clear-global-conf` | Yes again | Treated as new → `major`. Document: clearing global conf opts into the current product default |
+| CI / empty `$HOME` | Usually yes | `major` — desirable for new images |
+
+Worse proxies: project `configure.conf` (most trees have one); presence of `~/.cuppa/` storage (would keep veterans who never saved global conf on `full` forever).
+
+**Implementation:** on first 1.9 configure load, if the global file is missing, **create** `~/.cuppaconfig` with at least `toolchain_identity=major` (merge; do not clobber). If the file exists and the key is missing, backfill `full`. The heuristic runs once; the file becomes the source of truth.
+
+| Situation | Effective policy | Config write |
+|-----------|------------------|--------------|
+| Global file **does not exist** | `major` | Create `~/.cuppaconfig` with `toolchain_identity=major` |
+| Existing global file, key absent | Grandfather `full` | Write `toolchain_identity=full` into `~/.cuppaconfig` only |
+| Key already present | Honour stored value | Unchanged unless CLI / project / `cuppa.run` overrides |
+| Explicit CLI / `cuppa.run` / project conf | Wins per existing precedence | Project pin is **not** the grandfather mechanism |
+
+Notes:
+
+- Store a real value (`toolchain_identity=full|major`), not a separate boolean.
+- Precedence: CLI > project conf > global conf > built-in.
+- **Cuppa 2.0 (later):** may make `major` the silent built-in default for everyone. By then new installs will already have lived on `major`; grandfathered globals holding `full` are an explicit choice. Do not flip existing globals in 1.x.
+
+### Package OS identity (publish-time opt-in)
+
+| Decision | Choice |
+|----------|--------|
+| Values | `include` (default) \| `omit` |
+| When chosen | **At package build/publish time** when the builder is confident the artefact is not OS-scoped (or consumers will override OS on lookup) |
+| CLI / config | `--package-os-identity=` / `package_os_identity=` (and/or `PublishPackage` argument — settle in PR C) |
+| Omit stem | `{package}_{tool_variant}` (no empty OS segment) |
+
+**Often workable:** ABI-stable static lib / headers; controlled fleets; ubuntu↔debian via **explicit** consume override; Windows/macOS already coarse.
+
+**Risky:** silent cross-distro or glibc↔musl; omit as product-wide default.
+
+### Consume overrides and “try similar”
+
+Per-dependency GitLab options (same style as `--<name>-gitlab-variant`):
+
+| Option (sketch) | Role |
+|-----------------|------|
+| `--<name>-gitlab-os=<id>` | Force OS segment for **lookup** (e.g. `debian` while host is `ubuntu`) |
+| `--<name>-gitlab-toolchain=<token>` | Force toolchain token for **lookup** (e.g. `gcc152` or `gcc15`) |
+
+Optional project-level `--package-os-override=<id>`. Dual-lookup during toolchain transition: if preferred stem 404s, try the other toolchain identity (full ↔ major) before failing — on by default during transition, with a switch to disable.
+
+**Resolution order:**
+
+1. Explicit `--<name>-gitlab-toolchain=` / `--<name>-gitlab-os=` (and project OS override if set)
+2. Stem from current effective toolchain identity + host OS (or omitted OS if that is the published shape)
+3. Fallback: alternate toolchain token (full ↔ major) with same OS choice
+4. Fail listing stems tried
+
+Publish emits **one** stem. Dual-try is **consume-only**. Success is an ABI bet the project owns.
+
+## Work slices
+
+| ID | Deliverable | Notes |
+|----|-------------|-------|
+| `tc-id-vocab` | CLI / config names as in settled table | Done |
+| `tc-id-helper` | Reported version → full vs major token (GCC/Clang/MSVC) | Shipped in PR A |
+| `tc-id-apply` | Wire into `name()` / `package_name()` | Shipped in PR A |
+| `tc-id-config-migrate` | Absent `~/.cuppaconfig` → create `major`; existing missing key → backfill `full` | Shipped in PR A |
+| `tc-id-tests` | Unit + integration: full vs major; conf cases | Shipped in PR A |
+| `tc-id-docs` | Toolchains + Packages; CHANGELOG; 2.0 outlook one sentence | Shipped in PR A |
+| `pkg-consume-override` | Per-dep OS/toolchain lookup; dual-stem 404 fallback | Next (PR B) |
+| `pkg-os-apply` | Publish-time include \| omit; parsers accept both shapes | After consume overrides |
+| `pkg-os-docs` | Builder confidence; when omit/cross-OS is sane | Antora |
+
+## Implementation PRs
+
+**PR A** (`minor`) — toolchain identity + global config migration (primary win). **This PR.**
+
+**PR B** (`minor`) — consume overrides + dual-stem lookup.
+
+**PR C** (`minor`) — package OS omit at publish; align with OS override from B.
+
+## Refusal rules
+
+| Request | Response |
+|---------|----------|
+| Silent `major` for existing globals without backfill | Refuse in 1.x |
+| Auto-grandfather in project `configure.conf` | Refuse |
+| Auto-rewrite registry archives or `_build` trees | Refuse |
+| OS `omit` as 1.x product default | Refuse |
+| Coarsen without documenting ABI risk | Refuse |
+
+## Out of scope
+
+- Encoding musl/glibc explicitly
+- Changing Conan package identity
+- Making `major` the silent built-in default for **existing** globals in 1.x (2.0 candidate)
+
+## Acceptance (PR A)
+
+1. Missing `~/.cuppaconfig` → `major` and the file is created with that key.
+2. Existing global file without the key → `full` and the key is written.
+3. `--list-toolchains` / describe still expose the real compiler version.
+4. Docs: new-install major, grandfather full, not Boost patched/clean or product SemVer.

--- a/design/plans/ignore-toolchain-point-release.md
+++ b/design/plans/ignore-toolchain-point-release.md
@@ -1,9 +1,9 @@
 # Plan: optional toolchain point-release coarsening (variants and packages)
 
-- **Status:** proposal
-- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — `tc-identity-coarsen`; package stems in [`cuppa/package_managers/gitlab.py`](../../cuppa/package_managers/gitlab.py); layout in [`cuppa/core/build_layout.py`](../../cuppa/core/build_layout.py) / [`cuppa/construct.py`](../../cuppa/construct.py) (`tool_variant_dir` vs `package_tool_variant_dir`); list-toolchains identity [`list-toolchains.md`](../archive/list-toolchains.md)
-- **Updated:** 2026-08-30
-- **Impact:** minor — new opt-in CLI / `cuppa.run` / configure keys; default keeps today's full toolchain identity
+- **Status:** in progress
+- **Related:** product shape and 1.9 slices [`build-and-package-identity.md`](build-and-package-identity.md); [`ROADMAP.md`](../../ROADMAP.md) — `tc-identity-coarsen`; package stems in [`cuppa/package_managers/gitlab.py`](../../cuppa/package_managers/gitlab.py); layout in [`cuppa/core/build_layout.py`](../../cuppa/core/build_layout.py) / [`cuppa/construct.py`](../../cuppa/construct.py) (`tool_variant_dir` vs `package_tool_variant_dir`); list-toolchains identity [`list-toolchains.md`](../archive/list-toolchains.md)
+- **Updated:** 2026-09-01
+- **Impact:** minor — see [`build-and-package-identity.md`](build-and-package-identity.md) (new-install `major`; grandfather `full` in `~/.cuppaconfig`)
 
 ## Problem
 
@@ -42,13 +42,14 @@ a correctness bug — the full identity is the safer default for reproducibility
 
 ## Goals
 
-1. Let a project **opt in** to ignore point-release digits when forming **variant** paths,
-   **package** identities, or **both**.
-2. Keep **full identity as the default** (no behaviour change until enabled).
-3. Keep **selection** and **reporting** honest: `--list-toolchains`, logs, and describe output still
+1. Let a project choose to ignore point-release digits when forming **variant** paths and
+   **package** identities (one switch — see umbrella plan).
+2. Keep **selection** and **reporting** honest: `--list-toolchains`, logs, and describe output still
    show what compiler was actually found (15.3), even when layout keys as `gcc15`.
-4. Document the **compatibility risk**: coarsening asserts that point releases are interchangeable
+3. Document the **compatibility risk**: coarsening asserts that point releases are interchangeable
    for that project's binaries and packages.
+4. Default / grandfather rules live in [`build-and-package-identity.md`](build-and-package-identity.md)
+   (not “full forever for everyone”).
 
 ## Non-goals
 
@@ -68,27 +69,14 @@ Worth preserving in any design:
   path vocabulary — by teaching `name()` and/or `package_name()` (or a shared identity helper)
   about a project policy.
 
-## Proposed product shape (open options)
+## Proposed product shape
 
-Prefer one clear policy object, applied in two places:
+**Settled in [`build-and-package-identity.md`](build-and-package-identity.md)** (do not re-open
+here): `--toolchain-identity=full|major` coarsens both `name()` and `package_name()`; new installs
+(no `~/.cuppaconfig`) default to `major`; existing globals without the key grandfather `full`.
+That document also covers OS omit at publish and consume-time “similar package” overrides.
 
-```text
-toolchain identity policy:
-  full          — today's behaviour (default)
-  major         — drop point release in encoded names (gcc153 → gcc15)
-```
-
-### Controls (sketch — settle before implementation)
-
-| Mechanism | Sketch |
-|-----------|--------|
-| CLI | `--toolchain-identity=full\|major` (name TBD) |
-| `cuppa.run` / `configure.conf` | Same key; project-default for all developers |
-| Scope flags (if both axes needed) | Either one switch affecting **both** variants and packages, or `--toolchain-identity-variants=` / `--toolchain-identity-packages=` (or a single enum: `full`, `major`, `major-packages-only`, …) |
-
-**Recommendation to validate in implementation spike:** start with **one switch that coarsens both
-`name()` and `package_name()` together** (simplest mental model). Add split axes only if fleets
-need “coarse packages, fine-grained local `_build`” (or the reverse).
+This file remains the **point-release encoding** problem, vocabulary, and code-hook notes.
 
 ### What must stay precise
 
@@ -108,37 +96,28 @@ need “coarse packages, fine-grained local `_build`” (or the reverse).
 
 | Request | Response |
 |---------|----------|
-| Default to coarse identity | Refuse for 1.x — opt-in only |
+| Silent `major` for existing `~/.cuppaconfig` without backfill | Refuse in 1.x — see umbrella plan |
 | Coarsen without documenting ABI risk | Refuse |
-| Versioned SCons-style churn of option names mid-cycle | Settle CLI vocabulary in this plan before the first PR |
+| Versioned SCons-style churn of option names mid-cycle | Refuse — names settled in [`build-and-package-identity.md`](build-and-package-identity.md) |
 
-## Work slices (later)
+## Work slices
 
-| ID | Deliverable | Notes |
-|----|-------------|-------|
-| `tc-id-vocab` | Settle CLI / config names and whether variants+packages share one switch | Short settled-decisions table |
-| `tc-id-helper` | Shared helper: reported version → full vs coarse token (GCC/Clang/MSVC) | Unit-tested encoding |
-| `tc-id-apply` | Wire into `name()` / `package_name()` or construct path composition | Honour existing `package_tool_variant_dir` split |
-| `tc-id-tests` | Unit + integration: same project, full vs major, package stem + `_build` path | Multi-toolchain cell |
-| `tc-id-docs` | Toolchains + Packages pages; CHANGELOG; warn about republish | Antora |
-| `tc-id-migrate` | Optional notes / helpers for renaming stems (doc-only first) | Not automatic rewrite |
+Slice IDs and PR split live in [`build-and-package-identity.md`](build-and-package-identity.md)
+(`tc-id-*`, consume overrides, OS omit). This document does not keep a second slice table.
 
 ## Acceptance criteria
 
-1. Default builds and package names **unchanged** without the new option.
-2. With coarsening enabled, `_build` and/or package stems use major-line tokens; selecting `gcc15`
-   on 15.2 and 15.3 machines can share those keys.
-3. `--list-toolchains` / describe still expose the **real** compiler version.
-4. Docs state the trade-off and that this is **not** Boost patched/clean or product SemVer.
-5. Integration coverage for at least GCC or Clang on Linux.
+See [`build-and-package-identity.md`](build-and-package-identity.md) (PR A). Encoding-specific:
+`--list-toolchains` / describe still expose the **real** compiler version; coarsening only
+touches version digits in the toolchain token, not variant/arch/abi/stdlib tags.
 
 ## Candidacy
 
 | Factor | Assessment |
 |--------|------------|
 | User value | **High** for package fleets and shared CI caches |
-| Risk | Medium — identity bugs are costly; keep opt-in |
+| Risk | Medium — identity bugs are costly; grandfather existing globals |
 | Size | Medium (encoding + construct/package wiring + docs) |
 | Release impact | `minor` |
 
-Good follow-on after current docs/Methods work; not blocked by Methods split.
+Product shape and PR split: [`build-and-package-identity.md`](build-and-package-identity.md).

--- a/design/process/agent-workflow-journey.md
+++ b/design/process/agent-workflow-journey.md
@@ -336,6 +336,7 @@ These are recommendations for the next project, not self-flagellation.
 | `create-pr` rejects missing `impact:` label | Version job runs before the matrix; label-at-open avoids a wasted CI cycle |
 | Local docs preview; scan screenshots only on request | UI CSS review stays in the browser; PNG-in-context is a token tax, not a default loop |
 | Propose commit message; wait for go-ahead before commit/push | Maintainer skims the diff and steers before history moves (`AGENTS.md` Commit messages) |
+| Delete GitHub's pre-filled squash `Co-authored-by` | Helpers do not write trailers; GitHub adds one when branch-commit email ≠ account identity |
 
 ---
 

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -75,6 +75,7 @@
 * xref:integration-tests.adoc[Integration tests]
 ** xref:integration/test-minimal-example.adoc[Minimal example]
 ** xref:integration/test-configure-conf.adoc[configure.conf]
+** xref:integration/test-toolchain-identity.adoc[Toolchain identity]
 ** xref:integration/test-scripts-scoping.adoc[Scripts scoping]
 ** xref:integration/test-storage-roots.adoc[Storage roots]
 ** xref:integration/test-list-builds.adoc[List builds]

--- a/docs/modules/ROOT/pages/cli/toolchains-and-features.adoc
+++ b/docs/modules/ROOT/pages/cli/toolchains-and-features.adoc
@@ -12,6 +12,7 @@ with a clear reason when an explicitly requested feature cannot be honoured.
 | Option | Effect
 
 | `--toolchains=LIST` | Select comma-separated registered names or fnmatch patterns such as `gcc*`
+| `--toolchain-identity=full\|major` | Encode `_build` and package tokens as `gcc153` (`full`) or `gcc15` (`major`). Selection aliases and `--list-toolchains` reported versions are unchanged. See xref:toolchains/overview.adoc#toolchain-identity[Build and package identity]
 | `--list-toolchains` | Report discovered PATH drivers and managed registrations, then exit
 | `--toolchain-archive=URL_OR_PATH` | Fetch/register a Clang or GCC archive (`tar`, zip, or `.deb`)
 | `--clang-root=PATH` | Register an existing prefix containing `bin/clang{plus}{plus}`

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -64,10 +64,30 @@ cuppa.run(
 ----
 
 Keys in `configure.conf` and in `default_options` use each flag's internal SCons destination name.
-Those names are mixed: some use underscores (`reports_link_style`), while others retain hyphens
+Those names are mixed: some use underscores (`reports_link_style`, `toolchain_identity`), while others retain hyphens
 (`show-test-output`). Capture unfamiliar keys with `--save-conf` rather than converting the CLI
 spelling mechanically. Command-line flags still override saved or coded defaults when passed
 explicitly.
+
+[#toolchain-identity]
+=== Toolchain identity (`toolchain_identity`)
+
+`--toolchain-identity=full|major` controls whether build directories and GitLab package stems
+include the compiler point release. The configuration key is `toolchain_identity`.
+
+Cuppa writes this key into `~/.cuppaconfig` on configure load:
+
+* If the global file is missing, it is created with `toolchain_identity=major`.
+* If the file exists but the key is absent, Cuppa writes `full` (grandfather existing machines).
+* `--clear-global-conf` deletes the file; the next load is treated as a new install (`major`).
+
+Project `configure.conf` and the command line override the global value. Do not use the project
+file as the grandfather mechanism. `--list-toolchains` still prints the real compiler version.
+
+This is not Boost `-patched` / `-clean` package flavour and not the SemVer of software Cuppa
+publishes. Coarsening means you treat 15.2 and 15.3 objects as interchangeable for that project.
+
+xref:toolchains/overview.adoc#toolchain-identity[Toolchains overview] has the layout examples.
 
 === HTML report source links without CI flags
 

--- a/docs/modules/ROOT/pages/dependencies/gitlab.adoc
+++ b/docs/modules/ROOT/pages/dependencies/gitlab.adoc
@@ -23,6 +23,9 @@ The `cuppa` launcher redacts env values whose names contain `TOKEN` in logged ou
 
 To **publish** a Cuppa-built library to the same registry, see
 xref:packages.adoc[Publishing packages].
+Archive stems include `toolchain.package_name()`, so `--toolchain-identity=major` looks for
+`gcc15_…` rather than `gcc153_…` unless you keep `full`. Consume-side dual lookup is a later
+slice; until then, publish and consume with the same identity.
 
 [#boost-package]
 == Boost package

--- a/docs/modules/ROOT/pages/integration-tests.adoc
+++ b/docs/modules/ROOT/pages/integration-tests.adoc
@@ -42,6 +42,7 @@ cuppa.run(default_variants=['dbg'])
 
 * xref:integration/test-minimal-example.adoc[`examples/minimal` build + test]
 * xref:integration/test-configure-conf.adoc[`configure.conf` save / show]
+* xref:integration/test-toolchain-identity.adoc[`--toolchain-identity` layout and global conf]
 * xref:integration/test-scripts-scoping.adoc[`--scripts=` scoping]
 * xref:integration/test-storage-roots.adoc[Storage root resolution]
 * xref:integration/test-list-builds.adoc[List and remove builds]

--- a/docs/modules/ROOT/pages/integration/test-toolchain-identity.adoc
+++ b/docs/modules/ROOT/pages/integration/test-toolchain-identity.adoc
@@ -1,0 +1,51 @@
+= `test_toolchain_identity` — layout tokens and global conf
+:description: Cuppa integration test documentation for toolchain identity
+
+== What is tested
+
+`--toolchain-identity=full` and `major` write different `_build` toolchain segments for the
+same compiler. A missing `~/.cuppaconfig` is created with `toolchain_identity=major`. An
+existing global file without the key is grandfathered to `full`. `--list-toolchains` JSON still
+includes a `major.minor` compiler version under `major` identity.
+
+Tests isolate `HOME` so they do not rewrite the developer's global configuration.
+
+== Generated files
+
+Copied from the dummy project, then:
+
+=== `sconstruct`
+
+[source,python]
+----
+import cuppa
+
+cuppa.run(default_variants=['dbg'])
+----
+
+=== `sconscript`
+
+[source,python]
+----
+Import('env')
+env.AppendUnique(CPPPATH=['#/include'])
+env.CompileStatic('src/hello.cpp')
+----
+
+== Commands
+
+[source,sh]
+----
+cuppa -D --offline --toolchains=gcc --dbg --toolchain-identity=full
+cuppa -D --offline --toolchains=gcc --dbg --toolchain-identity=major
+cuppa -D --offline --toolchains=gcc --list-toolchains --list-format=json --toolchain-identity=major
+----
+
+== Expectations
+
+The `major` layout token is the coarsened form of the `full` token (`gcc153` → `gcc15`).
+`--list-toolchains` JSON `versions[].version` still looks like `15.3`.
+
+'''
+
+Related test module: `tests/integration/test_toolchain_identity.py`.

--- a/docs/modules/ROOT/pages/packages.adoc
+++ b/docs/modules/ROOT/pages/packages.adoc
@@ -13,7 +13,11 @@ You can publish to a GitLab generic package registry (`env.PublishPackage` +
 == Publishing (GitLab generic)
 
 From a sconscript, `env.PublishPackage(...)` with a `GitlabPackagePublisher` builds a toolchain-scoped tarball
-and writes a ``.packaged`` stamp beside it in ``final/``. When staged headers and libs are not newer than the
+and writes a ``.packaged`` stamp beside it in ``final/``. The toolchain token in the archive stem is
+`toolchain.package_name()`, which follows `--toolchain-identity=` (see
+xref:toolchains/overview.adoc#toolchain-identity[Build and package identity]). Switching identity
+does not rename archives already in a registry; republish or wait for consume-side lookup in a
+later Cuppa release. When staged headers and libs are not newer than the
 existing archive, cuppa skips recreating the tarball — so a follow-up ``cuppa --rel --publish-package`` can
 upload without re-tarring multi-gigabyte trees.
 Add `--publish-package` to upload it to the GitLab generic registry.

--- a/docs/modules/ROOT/pages/toolchains.adoc
+++ b/docs/modules/ROOT/pages/toolchains.adoc
@@ -44,6 +44,10 @@ If you omit `--toolchains`, cuppa uses the platform default toolchain.
 
 Prefer a family alias (`gcc`, `clang`, `vc`) for everyday builds; pin versioned aliases in CI for reproducibility.
 
+Layout and package stems use `toolchain.name()` / `package_name()`, which follow
+`--toolchain-identity=` (`full` keeps `gcc153`; `major` uses `gcc15`). Selection aliases are
+unchanged. See xref:toolchains/overview.adoc#toolchain-identity[Build and package identity].
+
 When debugging detection, use `--verbosity=debug` and `--dump`.
 
 [#list-toolchains]

--- a/docs/modules/ROOT/pages/toolchains/clang.adoc
+++ b/docs/modules/ROOT/pages/toolchains/clang.adoc
@@ -210,7 +210,7 @@ adds more when using `libc{plus}{plus}`. Verbose listing shows them as normal `-
 * On **Linux**, the default is `libstdc{plus}{plus}` so Boost b2 and the rest of the stack see an explicit `-stdlib=` when needed
 * On other platforms the default may be unset (system default)
 * When `libc{plus}{plus}` is selected on Linux, see the library table above for the extra `DYNAMICLIBS`
-* **Build identity:** `toolchain.name()` (and therefore `_build/.../<toolchain>/...`) includes a non-default stdlib tag, for example `clang21-libc{plus}{plus}`. The Linux default (`libstdc{plus}{plus}`) keeps the plain name (`clang21`). `package_name()` matches `name()`. Compile commands still use `toolchain.binary()` / `CXX` (`clang{plus}{plus}…`), not the tagged folder name.
+* **Build identity:** `toolchain.name()` (and therefore `_build/.../<toolchain>/...`) includes a non-default stdlib tag, for example `clang21-libc{plus}{plus}`. The Linux default (`libstdc{plus}{plus}`) keeps the plain name. `--toolchain-identity=major` also drops the Clang point-release digit (`clang211` → `clang21`) before applying that tag. `package_name()` matches `name()`. Compile commands still use `toolchain.binary()` / `CXX` (`clang{plus}{plus}…`), not the tagged folder name.
 * `--toolchains=clang` / versioned aliases remain the registry keys used on the CLI; they do not embed the stdlib tag
 
 == Modules (opt-in)

--- a/docs/modules/ROOT/pages/toolchains/gcc.adoc
+++ b/docs/modules/ROOT/pages/toolchains/gcc.adoc
@@ -22,6 +22,10 @@ cuppa -D --dbg --toolchains=gcc
 cuppa -D --dbg --toolchains=gcc15
 ----
 
+`--toolchains=` selects the compiler. `_build` folders and package stems use
+`toolchain.name()`, which follows `--toolchain-identity=` (`gcc153` vs `gcc15` for a 15.3
+driver). See xref:toolchains/overview.adoc#toolchain-identity[Build and package identity].
+
 For selection, listing, and archive workflows shared with Clang, see
 xref:toolchains.adoc[Toolchains]. Inspect the live default invocation strings with
 `--list-toolchains --list-format=verbose`.

--- a/docs/modules/ROOT/pages/toolchains/msvc.adoc
+++ b/docs/modules/ROOT/pages/toolchains/msvc.adoc
@@ -39,6 +39,8 @@ from the SCons MSVC **toolset** id:
 
 The alias drops the dot so CLI names stay short and match the familiar `v145`-style label
 (same digit style as `gcc15` / `clang21`).
+`--toolchain-identity=major` keys `_build` / package stems as `vc14` (toolset major only;
+experimental toolsets keep the `e` suffix). `full` keeps `vc145`.
 Capability floors use this toolset `(major, minor)` -- not compiler marketing strings such
 as `14.29` / `19.51`.
 

--- a/docs/modules/ROOT/pages/toolchains/overview.adoc
+++ b/docs/modules/ROOT/pages/toolchains/overview.adoc
@@ -38,6 +38,29 @@ Each selected toolchain combines with the requested variants (`--dbg`, `--rel`, 
 produce separate build environments and artefact paths. Toolchain family pages document the
 warning, optimisation, standard-library, runtime, and module flags applied to those variants.
 
+[#toolchain-identity]
+== Build and package identity
+
+`--toolchains=` *selects* a compiler. `toolchain.name()` / `package_name()` *key* `_build`
+directories and GitLab package stems. Those keys historically include the compiler's reported
+point release (`gcc153` for GCC 15.3). `--toolchain-identity=major` drops that point digit
+(`gcc15`, `clang21`, `vc14`) so 15.2 and 15.3 machines can share trees and archives. Stdlib tags
+such as `-libc{plus}{plus}` remain. Registered archive names (`gcc17_gcc_snapshot_…`) already use
+the major line plus a qualifier and are not rewritten.
+
+`full` keeps the point-release token. `--list-toolchains` and describe output still show the
+compiler version that was found.
+
+New installs (no `~/.cuppaconfig`) persist `toolchain_identity=major` in that file. An existing
+global file without the key is grandfathered to `full`. Pin a project with
+`--toolchain-identity=` or `cuppa.run(default_options={'toolchain_identity': 'major'})`.
+Coarsening asserts that those point releases are interchangeable for *your* binaries; it is not
+Boost patched/clean identity or product SemVer. Cuppa 2.0 may make `major` the silent built-in
+default; 1.x does not change existing global files that already store `full`.
+
+See xref:configuration.adoc#toolchain-identity[Configuration] and
+xref:cli/toolchains-and-features.adoc[Toolchains and features].
+
 == Language levels and features
 
 Cuppa chooses the newest supported {cpp} dialect it knows for GCC and Clang; MSVC defaults to

--- a/tests/integration/test_toolchain_identity.py
+++ b/tests/integration/test_toolchain_identity.py
@@ -1,0 +1,138 @@
+import json
+import re
+import shutil
+
+import pytest
+
+from tests.helpers.cuppa_runner import assert_success, find_under_build, run_cuppa
+from tests.helpers.project import copy_dummy_project, write_sconstruct, write_sconscript
+
+
+pytestmark = pytest.mark.integration
+
+_VERSION_RE = re.compile( r'^\d+\.\d+' )
+
+
+def _identity_env( home ):
+    return {
+        'HOME': str( home ),
+        'USERPROFILE': str( home ),
+        'CUPPA_TEST_IDENTITY_MIGRATE': '1',
+    }
+
+
+def _write_build_scripts( project ):
+    write_sconstruct( project )
+    write_sconscript(
+        project,
+        "Import('env')\n"
+        "env.AppendUnique(CPPPATH=['#/include'])\n"
+        "env.CompileStatic('src/hello.cpp')\n",
+    )
+
+
+def _layout_toolchain_tokens( project ):
+    tokens = set()
+    build_root = project / '_build'
+    for path in find_under_build( project, 'working' ):
+        if not path.is_dir() or path.name != 'working':
+            continue
+        try:
+            parts = path.relative_to( build_root ).parts
+        except ValueError:
+            continue
+        if len( parts ) >= 5 and parts[-1] == 'working':
+            tokens.add( parts[-5] )
+    return tokens
+
+
+def _coarsened_token( token ):
+    if '-' in token:
+        base, tag = token.split( '-', 1 )
+        return '{}-{}'.format( _coarsened_base( base ), tag )
+    return _coarsened_base( token )
+
+
+def _coarsened_base( base ):
+    match = re.match( r'^(gcc|clang|vc)(\d+)$', base )
+    if not match:
+        return base
+    family, digits = match.group( 1 ), match.group( 2 )
+    if family == 'vc':
+        if len( digits ) >= 3:
+            return family + digits[:2]
+        return base
+    if len( digits ) >= 3:
+        return family + digits[:-1]
+    return base
+
+
+def test_toolchain_identity_full_and_major_layout( tmp_path ):
+    project = copy_dummy_project( tmp_path / 'project' )
+    home = tmp_path / 'home'
+    home.mkdir()
+    _write_build_scripts( project )
+    env = _identity_env( home )
+
+    full = run_cuppa( project, '--dbg', '--toolchain-identity=full', extra_env=env )
+    assert_success( full )
+    full_tokens = _layout_toolchain_tokens( project )
+    assert full_tokens
+
+    shutil.rmtree( project / '_build', ignore_errors=True )
+
+    major = run_cuppa( project, '--dbg', '--toolchain-identity=major', extra_env=env )
+    assert_success( major )
+    major_tokens = _layout_toolchain_tokens( project )
+    assert major_tokens
+    assert major_tokens == { _coarsened_token( token ) for token in full_tokens }
+
+
+def test_missing_global_conf_persists_major( tmp_path ):
+    project = copy_dummy_project( tmp_path / 'project' )
+    home = tmp_path / 'home'
+    home.mkdir()
+    _write_build_scripts( project )
+    result = run_cuppa( project, '--dbg', extra_env=_identity_env( home ) )
+    assert_success( result )
+    conf = home / '.cuppaconfig'
+    assert conf.exists()
+    assert 'toolchain_identity = major' in conf.read_text( encoding='utf-8' )
+
+
+def test_existing_global_conf_grandfathers_full( tmp_path ):
+    project = copy_dummy_project( tmp_path / 'project' )
+    home = tmp_path / 'home'
+    home.mkdir()
+    ( home / '.cuppaconfig' ).write_text( 'offline = True\n', encoding='utf-8' )
+    _write_build_scripts( project )
+    result = run_cuppa( project, '--dbg', extra_env=_identity_env( home ) )
+    assert_success( result )
+    text = ( home / '.cuppaconfig' ).read_text( encoding='utf-8' )
+    assert 'toolchain_identity = full' in text
+    assert 'offline = True' in text
+
+
+def test_list_toolchains_keeps_reported_version_under_major( tmp_path ):
+    project = copy_dummy_project( tmp_path / 'project' )
+    home = tmp_path / 'home'
+    home.mkdir()
+    write_sconstruct( project )
+    write_sconscript( project, "Import('env')\n" )
+    result = run_cuppa(
+        project,
+        '--list-toolchains',
+        '--list-format=json',
+        '--toolchain-identity=major',
+        extra_env=_identity_env( home ),
+    )
+    assert_success( result )
+    start = result.stdout.find( '{' )
+    assert start >= 0
+    payload = json.loads( result.stdout[start:] )
+    versions = []
+    for section in payload.get( 'sections' ) or []:
+        for family in section.get( 'families' ) or []:
+            for version in family.get( 'versions' ) or []:
+                versions.append( str( version.get( 'version' ) or '' ) )
+    assert any( _VERSION_RE.match( item ) for item in versions ), versions

--- a/tests/unit/test_configure.py
+++ b/tests/unit/test_configure.py
@@ -38,7 +38,26 @@ def test_load_settings_from_file_skips_blank_and_comments(tmp_path):
     assert settings["projects"] == "foo"
 
 
-def test_load_conf_project_overrides_global(tmp_path):
+def test_load_migrates_missing_global_file_to_major( tmp_path, monkeypatch ):
+    monkeypatch.setenv( 'CUPPA_TEST_IDENTITY_MIGRATE', '1' )
+    conf, env = _configure( tmp_path )
+    conf.load()
+    global_conf = tmp_path / '.cuppaconfig'
+    assert global_conf.exists()
+    assert 'toolchain_identity = major' in global_conf.read_text( encoding='utf-8' )
+    assert env['default_options']['toolchain_identity'] == 'major'
+
+
+def test_load_grandfathers_existing_global_without_key( tmp_path, monkeypatch ):
+    monkeypatch.setenv( 'CUPPA_TEST_IDENTITY_MIGRATE', '1' )
+    ( tmp_path / '.cuppaconfig' ).write_text( 'dbg = True\n', encoding='utf-8' )
+    conf, env = _configure( tmp_path )
+    conf.load()
+    text = ( tmp_path / '.cuppaconfig' ).read_text( encoding='utf-8' )
+    assert 'toolchain_identity = full' in text
+    assert env['default_options']['dbg'] is True
+    assert env['default_options']['toolchain_identity'] == 'full'
+
     global_conf = tmp_path / ".cuppaconfig"
     project_conf = tmp_path / "configure.conf"
     global_conf.write_text("dbg = True\ntoolchains = ['gcc']\n", encoding="utf-8")

--- a/tests/unit/test_toolchain_identity_policy.py
+++ b/tests/unit/test_toolchain_identity_policy.py
@@ -1,0 +1,114 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+import pytest
+
+from cuppa.toolchains import identity
+from cuppa.toolchains.clang import Clang
+from cuppa.toolchains.cl import Cl, MsvcToolsetVersion
+from cuppa.toolchains.gcc import Gcc
+
+
+pytestmark = pytest.mark.unit
+
+
+def _gcc( major=15, minor=3, encoded=None ):
+    toolchain = Gcc.__new__( Gcc )
+    name = encoded or 'gcc{}{}'.format( major, minor )
+    toolchain._name = name
+    toolchain._reported_version = {
+        'name': name,
+        'major': major,
+        'minor': minor,
+    }
+    return toolchain
+
+
+def _clang( major=21, minor=1, stdlib=None, encoded=None ):
+    toolchain = Clang.__new__( Clang )
+    name = encoded or 'clang{}{}'.format( major, minor )
+    toolchain._name = name
+    toolchain._stdlib = stdlib
+    toolchain._reported_version = {
+        'name': name,
+        'major': major,
+        'minor': minor,
+    }
+    return toolchain
+
+
+def test_gnu_full_and_major_tokens():
+    assert identity.gnu_layout_name( 'gcc', 15, 3, 'full' ) == 'gcc153'
+    assert identity.gnu_layout_name( 'gcc', 15, 3, 'major' ) == 'gcc15'
+    assert identity.gnu_layout_name( 'clang', 21, 1, 'major', tag='libc++' ) == 'clang21-libc++'
+    assert identity.gnu_layout_name( 'clang', 21, 1, 'full', tag='libc++' ) == 'clang211-libc++'
+
+
+def test_gnu_keeps_registered_archive_qualifiers():
+    encoded = 'gcc17_gcc_snapshot_abc'
+    assert identity.gnu_layout_name(
+        'gcc', 17, 1, 'major', encoded_name=encoded,
+    ) == encoded
+    assert identity.gnu_layout_name(
+        'clang', 24, 0, 'full', encoded_name='clang24_profiles_xyz', tag='libc++',
+    ) == 'clang24_profiles_xyz-libc++'
+
+
+def test_msvc_major_drops_toolset_minor():
+    toolset = MsvcToolsetVersion( '14.5', 14, 5, False, 'vc145' )
+    assert identity.msvc_layout_name( toolset, 'full' ) == 'vc145'
+    assert identity.msvc_layout_name( toolset, 'major' ) == 'vc14'
+    experimental = MsvcToolsetVersion( '14.2Exp', 14, 2, True, 'vc142e' )
+    assert identity.msvc_layout_name( experimental, 'major' ) == 'vc14e'
+
+
+def test_gcc_name_honours_policy( monkeypatch ):
+    monkeypatch.setattr( 'cuppa.toolchains.identity.current_identity', lambda: 'full' )
+    assert _gcc().name() == 'gcc153'
+    monkeypatch.setattr( 'cuppa.toolchains.identity.current_identity', lambda: 'major' )
+    assert _gcc().name() == 'gcc15'
+    assert _gcc().package_name() == 'gcc15'
+
+
+def test_clang_name_tags_non_default_stdlib( monkeypatch ):
+    monkeypatch.setattr( 'cuppa.build_platform.name', lambda: 'Linux' )
+    monkeypatch.setattr( 'cuppa.toolchains.identity.current_identity', lambda: 'major' )
+    plain = _clang( stdlib='libstdc++' )
+    tagged = _clang( stdlib='libc++' )
+    assert plain.name() == 'clang21'
+    assert tagged.name() == 'clang21-libc++'
+
+
+def test_cl_name_honours_policy( monkeypatch ):
+    toolchain = Cl.__new__( Cl )
+    toolchain._toolset = MsvcToolsetVersion( '14.5', 14, 5, False, 'vc145' )
+    toolchain._name = 'vc145'
+    monkeypatch.setattr( 'cuppa.toolchains.identity.current_identity', lambda: 'full' )
+    assert toolchain.name() == 'vc145'
+    monkeypatch.setattr( 'cuppa.toolchains.identity.current_identity', lambda: 'major' )
+    assert toolchain.name() == 'vc14'
+
+
+def test_migrate_creates_major_when_file_missing( tmp_path ):
+    path = str( tmp_path / '.cuppaconfig' )
+    assert identity.migrate_global_toolchain_identity( path ) == 'major'
+    text = ( tmp_path / '.cuppaconfig' ).read_text( encoding='utf-8' )
+    assert 'toolchain_identity = major' in text
+
+
+def test_migrate_grandfathers_full_when_key_missing( tmp_path ):
+    conf = tmp_path / '.cuppaconfig'
+    conf.write_text( 'offline = True\n', encoding='utf-8' )
+    assert identity.migrate_global_toolchain_identity( str( conf ) ) == 'full'
+    text = conf.read_text( encoding='utf-8' )
+    assert 'toolchain_identity = full' in text
+    assert 'offline = True' in text
+
+
+def test_migrate_leaves_existing_key( tmp_path ):
+    conf = tmp_path / '.cuppaconfig'
+    conf.write_text( 'toolchain_identity = major\n', encoding='utf-8' )
+    assert identity.migrate_global_toolchain_identity( str( conf ) ) == 'major'
+    assert conf.read_text( encoding='utf-8' ).count( 'toolchain_identity' ) == 1


### PR DESCRIPTION
## Summary

- Add `--toolchain-identity=full|major` (`toolchain_identity` in `cuppa.run` / configure files) so `_build` paths and GitLab package stems can drop compiler point-release digits (`gcc153` → `gcc15`), including Clang stdlib tags and MSVC `vc145` → `vc14`.
- Missing `~/.cuppaconfig` is created with `major`; an existing global file without the key is grandfathered to `full`. `--list-toolchains` still reports the real compiler version.
- Docs, CHANGELOG, design plan PR A snapshot; `AGENTS.md` notes GitHub's squash `Co-authored-by` pre-fill.

## Test plan

- [x] Local `flake8` / `pylint -E` / `pytest -m unit` / `pytest -m integration`
- [x] Focused: `tests/unit/test_toolchain_identity_policy.py`, `tests/unit/test_configure.py`, `tests/integration/test_toolchain_identity.py`
- [x] CI green on the matrix
