### PR TITLE
Add GitLab package lookup overrides and dual-stem 404 fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -714,6 +714,7 @@ cuppa -D --dbg --cxx-profiles --cxx-profiles-enforce=std::init \
 
 Package registry dependencies need matching toolchain archives in the registry (or cache); `--develop` does not invent them.
 GitLab auth: `GITLAB_REGISTRY_TOKEN` or `CI_JOB_TOKEN`.
+To fetch an archive published under another OS or identity: `--package-gitlab-os-override[-<name>]=`, `--package-gitlab-toolchain-override-<name>=`. Dual-stem `404` retry is on unless `--package-gitlab-identity-fallback=off`.
 
 ---
 description: Documentation style guide for Cuppa docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   file without the key is grandfathered to ``full``. ``--list-toolchains`` still
   reports the real compiler version. Cuppa 2.0 may make ``major`` the silent
   built-in default; 1.x does not flip existing globals.
+- GitLab package **lookup** can force the OS segment
+  (``--package-gitlab-os-override[-<name>]=``) and the toolchain token
+  (``--package-gitlab-toolchain-override-<name>=``). If the preferred archive is missing
+  (``404``), Cuppa tries the other toolchain identity (full vs major) with the
+  same OS unless ``--package-gitlab-identity-fallback=off``. Dual-try is consume-only;
+  publish still emits one stem. A successful fallback is an ABI bet the project
+  owns ([#243](https://github.com/ja11sop/cuppa/issues/243)).
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -424,7 +424,7 @@ C++ Profiles are a separate roadmap section — see [C++ Profiles](#c-profiles).
 | `tc-dep-url-sugar` | Optional URL token in `--toolchains=` | Low | Keep `--toolchain-archive=` as explicit supply |
 | `tc-dep-actions` | Authenticated Actions artifact URLs | Low | After public HTTPS / file path is solid |
 | `tc-dep-msvc` | MSVC archive / layout as toolchain dep | Low | Separate driver; not gcc-snapshot |
-| `tc-identity-coarsen` | Major toolchain identity for `_build` / package stems (`gcc153`→`gcc15`); optional OS omit and consume overrides | High | New-install `major` via absent `~/.cuppaconfig`; grandfather `full` — [`build-and-package-identity.md`](design/plans/build-and-package-identity.md), encoding [`ignore-toolchain-point-release.md`](design/plans/ignore-toolchain-point-release.md) |
+| `tc-identity-coarsen` | Major toolchain identity for `_build` / package stems (`gcc153`→`gcc15`); optional OS omit and consume overrides | High | Identity shipped; consume overrides this slice — [`build-and-package-identity.md`](design/plans/build-and-package-identity.md), encoding [`ignore-toolchain-point-release.md`](design/plans/ignore-toolchain-point-release.md) |
 
 ### Out of scope (toolchains-as-deps)
 

--- a/cuppa/package_managers/gitlab.py
+++ b/cuppa/package_managers/gitlab.py
@@ -35,9 +35,12 @@ def remove_suffix( text, suffix ):
     return text
 
 
-def tool_variant( env, variant=None ):
+def tool_variant( env, variant=None, toolchain_token=None ):
+    token = toolchain_token
+    if token is None:
+        token = env['toolchain'].package_name()
     return "{toolchain}_{variant}_{arch}_{abi}".format(
-            toolchain = env['toolchain'].package_name(),
+            toolchain = token,
             variant = variant and variant or env['variant'].name(),
             arch = env['target_arch'],
             abi = env['abi']
@@ -75,17 +78,32 @@ def package_archive_extensions():
     return preferred, alternate
 
 
-def package_file_stem( env, package=None, variant=None ):
+def package_file_stem( env, package=None, variant=None, system=None, toolchain_token=None ):
     """Basename without archive extension: ``{package}_{os}_{tool_variant}``."""
+    if system is None:
+        system = os_release_id()
     return "{package}_{system}_{build_name}".format(
             package    = str(package),
-            system     = os_release_id(),
-            build_name = tool_variant( env, variant )
+            system     = system,
+            build_name = tool_variant( env, variant, toolchain_token=toolchain_token )
     )
 
 
-def package_file_name( env, package=None, variant=None, target_dir=None ):
-    name = package_file_stem( env, package=package, variant=variant ) + package_archive_extension()
+def package_file_name(
+        env,
+        package=None,
+        variant=None,
+        target_dir=None,
+        system=None,
+        toolchain_token=None
+):
+    name = package_file_stem(
+            env,
+            package=package,
+            variant=variant,
+            system=system,
+            toolchain_token=toolchain_token,
+    ) + package_archive_extension()
     if target_dir:
         return os.path.join( target_dir, name )
     return name
@@ -193,12 +211,182 @@ def extract_package_archive( archive_path, extraction_dir ):
         return 1
 
 
-def package_url( env, registry=None, package=None, version=None, variant=None ):
+def package_url(
+        env,
+        registry=None,
+        package=None,
+        version=None,
+        variant=None,
+        system=None,
+        toolchain_token=None
+):
     return "{registry}/packages/generic/{package}/{version}/{package_file}".format(
             registry = str(registry),
             package = str(package),
             version = str(version),
-            package_file = package_file_name( env, package=package, variant=variant )
+            package_file = package_file_name(
+                    env,
+                    package=package,
+                    variant=variant,
+                    system=system,
+                    toolchain_token=toolchain_token,
+            )
+    )
+
+
+def consume_os_id( env, package_os=None ):
+    """OS segment: per-dep, then ``--package-gitlab-os-override``, then host."""
+    from cuppa.toolchains.identity import option_text, package_os_override
+    explicit = option_text( package_os )
+    if explicit:
+        return explicit
+    project = package_os_override( env )
+    if project:
+        return project
+    return os_release_id()
+
+
+def consume_toolchain_tokens( env, package_toolchain=None, fallback=None ):
+    """Ordered toolchain tokens for GitLab lookup (preferred, then full↔major)."""
+    from cuppa.toolchains.identity import (
+        option_text,
+        package_identity_fallback_enabled,
+        paired_package_tokens,
+    )
+    if fallback is None:
+        fallback = package_identity_fallback_enabled( env )
+    explicit = option_text( package_toolchain )
+    preferred = explicit or env['toolchain'].package_name()
+    if not fallback:
+        return [ preferred ]
+    return paired_package_tokens( preferred, env.get( 'toolchain' ) )
+
+
+def consume_package_file_stems(
+        env,
+        package=None,
+        variant=None,
+        package_os=None,
+        package_toolchain=None,
+        fallback=None
+):
+    """Lookup stems in resolution order (OS override applied; dual identity when enabled)."""
+    system = consume_os_id( env, package_os )
+    tokens = consume_toolchain_tokens(
+            env,
+            package_toolchain=package_toolchain,
+            fallback=fallback,
+    )
+    return [
+        package_file_stem(
+                env,
+                package=package,
+                variant=variant,
+                system=system,
+                toolchain_token=token,
+        )
+        for token in tokens
+    ]
+
+
+def consume_archive_candidates(
+        env,
+        registry=None,
+        package=None,
+        version=None,
+        variant=None,
+        package_os=None,
+        package_toolchain=None,
+        fallback=None
+):
+    """``(stem, filename, url, toolchain_token)`` tuples for consume lookup."""
+    system = consume_os_id( env, package_os )
+    tokens = consume_toolchain_tokens(
+            env,
+            package_toolchain=package_toolchain,
+            fallback=fallback,
+    )
+    candidates = []
+    for token in tokens:
+        stem = package_file_stem(
+                env,
+                package=package,
+                variant=variant,
+                system=system,
+                toolchain_token=token,
+        )
+        filename = stem + package_archive_extension()
+        url = package_url(
+                env,
+                registry=registry,
+                package=package,
+                version=version,
+                variant=variant,
+                system=system,
+                toolchain_token=token,
+        )
+        candidates.append( ( stem, filename, url, token ) )
+    return candidates
+
+
+def resolve_cached_consume_archive( directory, stems ):
+    """First existing archive among consume stems, preferring each stem's platform extension."""
+    for stem in stems:
+        existing = resolve_existing_package_archive( directory, stem )
+        if existing:
+            return existing, stem
+    return None, None
+
+
+def download_first_available_package(
+        candidates,
+        dest_dir,
+        custom_token=None,
+        download=None,
+        log_id=None,
+):
+    """Download the first candidate that exists; skip 404s until the list is exhausted.
+
+    ``candidates`` is a sequence of ``(stem, filename, url, token)``.
+    Returns ``(dest_path, filename, stem)``. Raises ``DownloadError`` when none succeed.
+    """
+    from cuppa.utility.download import DownloadError, is_http_not_found
+    if download is None:
+        download = download_registry_package
+    tried = []
+    last_error = None
+    last_index = len( candidates ) - 1
+    for index, item in enumerate( candidates ):
+        stem, filename, url, _token = item
+        dest_path = os.path.join( dest_dir, filename )
+        tried.append( filename )
+        logger.info( "Downloading package archive [{}]{}...".format(
+                as_info( filename ),
+                " for [{}]".format( as_info( log_id ) ) if log_id else "",
+        ) )
+        try:
+            download(
+                    url,
+                    dest_path,
+                    custom_token=custom_token,
+                    label=filename,
+            )
+            return dest_path, filename, stem
+        except DownloadError as error:
+            last_error = error
+            if is_http_not_found( error ) and index < last_index:
+                logger.info(
+                    "Archive [{}] was not in the registry (404); trying the next identity stem.".format(
+                            as_info( filename )
+                    )
+                )
+                continue
+            break
+    names = ", ".join( tried )
+    detail = last_error.parameter if last_error is not None else "no candidates"
+    raise DownloadError(
+        "Failed to download any of [{}]: {}".format( names, detail ),
+        http_status=getattr( last_error, 'http_status', None ),
     )
 
 
@@ -429,11 +617,19 @@ class GitlabPackageInstaller:
         else:
             self._target_dir = str(target_dir)
 
-        package_file = package_file_name( env, package=package, variant=variant )
-        stem = package_file_stem( env, package=package, variant=variant )
-        # package_variant_dir = remove_prefix( package_file, package + "_" ).split(".")[0]
-        preferred_target = os.path.join( self._target_dir, package_file )
-        existing = resolve_existing_package_archive( self._target_dir, stem )
+        self._candidates = consume_archive_candidates(
+                env,
+                registry=registry,
+                package=package,
+                version=version,
+                variant=variant,
+        )
+        stems = [ item[0] for item in self._candidates ]
+        preferred_file = self._candidates[0][1] if self._candidates else package_file_name(
+                env, package=package, variant=variant
+        )
+        preferred_target = os.path.join( self._target_dir, preferred_file )
+        existing, _stem = resolve_cached_consume_archive( self._target_dir, stems )
         self._download_target = existing or preferred_target
         download_dir = os.path.split( self._download_target )[0]
         self._extraction_dir = os.path.join( download_dir, tool_variant( env, variant=variant ) )
@@ -453,27 +649,22 @@ class GitlabPackageInstaller:
         if not os.path.exists( self._extraction_dir ):
             os.makedirs( self._extraction_dir )
 
-        self._package_url = package_url(
-                env, registry=registry, package=package, version=version, variant=variant
-        )
         self._custom_token = custom_token
-        self._package_file = package_file
+        self._package_file = os.path.basename( self._download_target )
 
 
     def __call__( self, target, source, env ):
 
         if not os.path.exists( self._download_target ):
             from cuppa.utility.download import DownloadError
-            logger.info( "Downloading package archive [{}] from registry...".format(
-                    as_info( self._package_file )
-            ) )
             try:
-                download_registry_package(
-                        self._package_url,
-                        self._download_target,
+                dest, filename, _stem = download_first_available_package(
+                        self._candidates,
+                        self._target_dir,
                         custom_token=self._custom_token,
-                        label=self._package_file,
                 )
+                self._download_target = dest
+                self._package_file = filename
             except DownloadError as error:
                 logger.error( "Failed to download [{}]: {}".format(
                         as_error( self._package_file ),
@@ -578,27 +769,51 @@ class GitlabPackageDependency:
         "library-prefix" : { "help": "package library prefix that can be used (or omitted) when referencing libs from the package", },
         "pkg-config-dir" : { "help": "package pkg-config folder to use to find pc files", },
         "develop"        : { "help": "local package to build against when in develop mode", },
-        "custom-token"   : { "help": "custom token that should be used to authenticate with the registry", }
+        "custom-token"   : { "help": "custom token that should be used to authenticate with the registry", },
+        "os-override"    : {
+            "help": "OS segment override for registry lookup (does not change published stems)",
+            "scope": "package-manager-override",
+        },
+        "toolchain-override": {
+            "help": "toolchain token override for registry lookup (for example gcc152 or gcc15)",
+            "scope": "package-manager-override",
+        },
     }
+
+    @classmethod
+    def option_id( cls, manager, name, option, attributes=None ):
+        """Return the registered option id.
+
+        Existing package settings retain ``<name>-<manager>-<setting>``. Loud
+        consume overrides reserve ``package-<manager>-<override>-<name>`` so a
+        project-supplied dependency name cannot occupy the leading namespace.
+        """
+        attributes = attributes or {}
+        if attributes.get( 'scope' ) == 'package-manager-override':
+            return "-".join( [ "package", manager, option, name ] )
+        return "-".join( [ name, manager, option ] )
 
 
     class add_option_factory:
 
         def __init__( self, manager, name, add_option ):
-            self._id = "-".join( [ name, manager ] )
+            self._manager = manager
+            self._name = name
             self._add_option = add_option
 
-        def option_id( self, option ):
-            return "-".join( [ self._id, option ] )
-
-        def __call__( self, option, help_string ):
+        def __call__( self, option, attributes ):
+            option_id = GitlabPackageDependency.option_id(
+                    self._manager, self._name, option, attributes
+            )
             self._add_option(
-                    '--' + self.option_id( option ),
-                    dest   = self.option_id( option ),
+                    '--' + option_id,
+                    dest   = option_id,
                     type   = 'string',
                     nargs  = 1,
                     action = 'store',
-                    help   = " ".join( [ self._id, help_string ] )
+                    help   = " ".join( [
+                        "package", self._manager, self._name, attributes['help']
+                    ] )
             )
 
 
@@ -606,8 +821,7 @@ class GitlabPackageDependency:
     def add_options( cls, manager, name, add_option ):
         AddOption = cls.add_option_factory( manager, name, add_option )
         for option, attributes in cls._options.items():
-            AddOption( option, attributes['help'] )
-            attributes['id'] = AddOption.option_id( option )
+            AddOption( option, attributes )
 
 
     @classmethod
@@ -628,16 +842,18 @@ class GitlabPackageDependency:
     @classmethod
     def package_id( cls, package, env ):
 
+        manager = getattr( package, '_package_manager', 'gitlab' )
+        name = getattr( package, '_name', None ) or getattr( package, '_package', None )
         for option, attributes in cls._options.items():
-            if 'id' in attributes:
-                logger.trace( "Getting option for [{}]".format( as_notice(attributes['id']) ) )
-                env_option = env.get_option( attributes['id'] )
-                if env_option:
-                    logger.trace( "Setting option for [{}] to [{}]".format(
-                            as_notice(attributes['id']),
-                            as_info(str(env_option))
-                    ) )
-                    setattr( package, cls._member(option), env_option )
+            option_id = cls.option_id( manager, name, option, attributes )
+            logger.trace( "Getting option for [{}]".format( as_notice(option_id) ) )
+            env_option = env.get_option( option_id )
+            if env_option:
+                logger.trace( "Setting option for [{}] to [{}]".format(
+                        as_notice(option_id),
+                        as_info(str(env_option))
+                ) )
+                setattr( package, cls._member(option), env_option )
 
         if not package._variant:
             package._variant = "rel"
@@ -653,6 +869,12 @@ class GitlabPackageDependency:
         except ( KeyError, AttributeError, TypeError ):
             build_id = None
 
+        from cuppa.toolchains.identity import (
+            option_text,
+            package_identity_fallback_enabled,
+            package_os_override,
+        )
+
         identity = (
             package._registry,
             package._package,
@@ -660,6 +882,10 @@ class GitlabPackageDependency:
             package._variant,
             use_develop,
             build_id,
+            option_text( getattr( package, '_os_override', None ) ),
+            option_text( getattr( package, '_toolchain_override', None ) ),
+            package_os_override( env ),
+            package_identity_fallback_enabled( env ),
         )
 
         short_id = cls._id( package._package, package._version, package._variant )
@@ -688,8 +914,14 @@ class GitlabPackageDependency:
             library_prefix=None,
             pkg_config_dir=None,
             custom_token=None,
-            develop=None
+            develop=None,
+            os_override=None,
+            toolchain_override=None
         ):
+
+        from cuppa.toolchains.identity import option_text
+        self._os_override = option_text( os_override )
+        self._toolchain_override = option_text( toolchain_override )
 
         self._cuppa_env = cuppa_env
         self._env = None
@@ -719,11 +951,23 @@ class GitlabPackageDependency:
         cuppa.core.storage_options.report_roots( cuppa_env )
 
         cache_dir = os.path.join( cuppa_env['downloads_root'], 'packages', package, version )
-        package_file = package_file_name( cuppa_env, package=package, variant=variant )
-        stem = package_file_stem( cuppa_env, package=package, variant=variant )
-        preferred_target = os.path.join( cache_dir, package_file )
-        existing = resolve_existing_package_archive( cache_dir, stem )
+        candidates = consume_archive_candidates(
+                cuppa_env,
+                registry=registry,
+                package=package,
+                version=self.version(),
+                variant=self._variant,
+                package_os=self._os_override,
+                package_toolchain=self._toolchain_override,
+        )
+        stems = [ item[0] for item in candidates ]
+        preferred_file = candidates[0][1] if candidates else package_file_name(
+                cuppa_env, package=package, variant=self._variant
+        )
+        preferred_target = os.path.join( cache_dir, preferred_file )
+        existing, _existing_stem = resolve_cached_consume_archive( cache_dir, stems )
         self._download_target = existing or preferred_target
+        package_file = os.path.basename( self._download_target )
 
         extraction_root = cuppa_env['dependencies_root']
         if not os.path.isabs( extraction_root ):
@@ -765,48 +1009,41 @@ class GitlabPackageDependency:
         if not os.path.exists( self._extraction_dir ):
             os.makedirs( self._extraction_dir )
 
-        # Prefer an already-cached alternate extension (e.g. legacy Windows .tar.gz).
-        existing = resolve_existing_package_archive( cache_dir, stem )
+        # Prefer an already-cached alternate extension or identity stem.
+        existing, _existing_stem = resolve_cached_consume_archive( cache_dir, stems )
         if existing:
             self._download_target = existing
             package_file = os.path.basename( existing )
 
-        package_location = package_url(
-                cuppa_env,
-                registry=registry,
-                package=package,
-                version=self.version(),
-                variant=variant,
-        )
-
         # The package file doesn't exist so lets attempt to download it
         if not self._offline:
             if not os.path.exists( self._download_target ):
-                # Download the preferred platform name into cache_dir.
-                self._download_target = preferred_target
-                package_file = os.path.basename( preferred_target )
                 if not os.path.isdir( cache_dir ):
                     os.makedirs( cache_dir )
                 from cuppa.utility.download import DownloadError
-                logger.info( "Downloading package [{}] from [{}] as archive [{}]...".format(
+                logger.info( "Downloading package [{}] from [{}] (stems [{}])...".format(
                         as_info( self._package_id ),
                         as_notice( registry ),
-                        as_info( package_file )
+                        as_info( ", ".join( stems ) )
                 ) )
                 try:
-                    download_registry_package(
-                            package_location,
-                            self._download_target,
+                    dest, package_file, _stem = download_first_available_package(
+                            candidates,
+                            cache_dir,
                             custom_token=custom_token,
-                            label=package_file,
+                            log_id=self._package_id,
                     )
+                    self._download_target = dest
                 except DownloadError as error:
-                    logger.error( "Downloading package archive [{}] failed: {}".format(
-                            as_error( package_file ),
+                    logger.error( "Downloading package archives [{}] failed: {}".format(
+                            as_error( ", ".join( stems ) ),
                             as_error( str( error.parameter ) ),
                     ) )
                     raise GitlabPackageDependencyException(
-                        "Failed to download [{}]: {}".format( package_file, error.parameter )
+                        "Failed to download [{}]: {}".format(
+                                ", ".join( stems ),
+                                error.parameter,
+                        )
                     )
                 logger.info( "Package archive [{}] downloaded successfully for package [{}] from [{}]".format(
                         as_info( package_file ),

--- a/cuppa/toolchains/identity.py
+++ b/cuppa/toolchains/identity.py
@@ -7,17 +7,19 @@
 #   Toolchain identity — full vs major layout / package tokens
 #-------------------------------------------------------------------------------
 
-"""Policy for ``toolchain.name()`` / ``package_name()``.
+"""Policy for ``toolchain.name()`` / ``package_name()`` and consume-side pairing.
 
 ``full`` keeps today's encoded major.minor token (``gcc153``, ``clang211``, ``vc145``).
 ``major`` drops the point-release digits (``gcc15``, ``clang21``, ``vc14``) while leaving
 stdlib tags and registered archive qualifiers (``gcc17_gcc_snapshot_…``) intact.
 
 Selection aliases (``--toolchains=gcc153``) and ``--list-toolchains`` version fields are
-unchanged. This module only names *layout and package* identity.
+unchanged. Layout identity lives here; GitLab lookup overrides live on
+``PackageConsumeIdentity`` and in ``cuppa.package_managers.gitlab``.
 """
 
 import os
+import re
 
 from cuppa.log import logger
 from cuppa.colourise import as_info, as_notice
@@ -28,6 +30,12 @@ IDENTITY_MAJOR = 'major'
 IDENTITY_CHOICES = ( IDENTITY_FULL, IDENTITY_MAJOR )
 
 TOOLCHAIN_IDENTITY_KEY = 'toolchain_identity'
+PACKAGE_OS_OVERRIDE_KEY = 'package_gitlab_os_override'
+PACKAGE_IDENTITY_FALLBACK_KEY = 'package_gitlab_identity_fallback'
+PACKAGE_IDENTITY_FALLBACK_CHOICES = ( 'on', 'off' )
+
+_GNU_PACKAGE_TOKEN = re.compile( r'^(gcc|clang)(\d+)(?:-(.+))?$' )
+_MSVC_PACKAGE_TOKEN = re.compile( r'^vc(\d+)(e)?$', re.I )
 
 
 class ToolchainIdentity( object ):
@@ -50,6 +58,38 @@ class ToolchainIdentity( object ):
     @classmethod
     def add_to_env( cls, env, add_toolchain, add_to_supported ):
         # Option-only helper; do not register a compiler.
+        pass
+
+
+class PackageConsumeIdentity( object ):
+    """Registers consume-side GitLab lookup overrides; not a compiler toolchain."""
+
+    @classmethod
+    def add_options( cls, add_option ):
+        add_option(
+            '--package-gitlab-os-override',
+            dest=PACKAGE_OS_OVERRIDE_KEY,
+            type='string',
+            nargs=1,
+            action='store',
+            help="Force the OS segment used when looking up GitLab package archives "
+                 "(for example debian while the host is ubuntu). Does not change "
+                 "published stems. Per-dependency "
+                 "--package-gitlab-os-override-<name>= takes precedence.",
+        )
+        add_option(
+            '--package-gitlab-identity-fallback',
+            dest=PACKAGE_IDENTITY_FALLBACK_KEY,
+            choices=list( PACKAGE_IDENTITY_FALLBACK_CHOICES ),
+            nargs=1,
+            action='store',
+            help="When a GitLab archive 404s, try the other toolchain identity "
+                 "(full vs major) with the same OS. Default on. Dual-try is consume-only; "
+                 "a successful fallback is an ABI bet the project owns.",
+        )
+
+    @classmethod
+    def add_to_env( cls, env, add_toolchain, add_to_supported ):
         pass
 
 
@@ -164,3 +204,164 @@ def migrate_global_toolchain_identity( conf_path ):
             as_notice( conf_path ),
     ) )
     return value
+
+
+def option_text( value ):
+    """Flatten SCons ``nargs=1`` lists to a stripped string, or ``None``."""
+    if value is None or value == '':
+        return None
+    if isinstance( value, ( list, tuple ) ):
+        if not value:
+            return None
+        return option_text( value[0] )
+    text = str( value ).strip()
+    return text or None
+
+
+def _option_from_env( env, key ):
+    if env is not None:
+        getter = getattr( env, 'get_option', None )
+        if callable( getter ):
+            try:
+                return option_text( getter( key ) )
+            except Exception:
+                pass
+        if isinstance( env, dict ) and key in env:
+            return option_text( env.get( key ) )
+    try:
+        from cuppa.core.environment import CuppaEnvironment
+        return option_text( CuppaEnvironment.get_option( key ) )
+    except Exception:
+        return None
+
+
+def package_os_override( env=None ):
+    """Project-level OS segment for GitLab lookup, or ``None``."""
+    return _option_from_env( env, PACKAGE_OS_OVERRIDE_KEY )
+
+
+def package_identity_fallback_enabled( env=None ):
+    """True unless ``--package-gitlab-identity-fallback=off`` (default on)."""
+    raw = _option_from_env( env, PACKAGE_IDENTITY_FALLBACK_KEY )
+    if raw is None:
+        return True
+    text = raw.lower()
+    if text in ( 'off', 'false', '0', 'no' ):
+        return False
+    if text in ( 'on', 'true', '1', 'yes' ):
+        return True
+    return True
+
+
+def host_package_identity_tokens( toolchain ):
+    """``(full, major)`` layout tokens for ``toolchain``, or ``(name, None)``."""
+    if toolchain is None:
+        return None, None
+    family = None
+    try:
+        family = toolchain.family()
+    except Exception:
+        family = None
+    reported = getattr( toolchain, '_reported_version', None )
+    if family in ( 'gcc', 'clang' ) and reported:
+        tag = None
+        if family == 'clang':
+            stdlib = getattr( toolchain, '_stdlib', None )
+            default = None
+            default_fn = getattr( toolchain, 'default_stdlib', None )
+            if callable( default_fn ):
+                try:
+                    default = default_fn()
+                except Exception:
+                    default = None
+            if stdlib and stdlib != default:
+                tag = stdlib
+        encoded = getattr( toolchain, '_name', None )
+        full = gnu_layout_name(
+                family,
+                reported['major'],
+                reported['minor'],
+                policy=IDENTITY_FULL,
+                encoded_name=encoded,
+                tag=tag,
+        )
+        major = gnu_layout_name(
+                family,
+                reported['major'],
+                reported['minor'],
+                policy=IDENTITY_MAJOR,
+                encoded_name=encoded,
+                tag=tag,
+        )
+        return full, major
+    if family == 'cl':
+        toolset = getattr( toolchain, '_toolset', None )
+        if toolset is not None:
+            return (
+                msvc_layout_name( toolset, policy=IDENTITY_FULL ),
+                msvc_layout_name( toolset, policy=IDENTITY_MAJOR ),
+            )
+    try:
+        name = toolchain.package_name()
+    except Exception:
+        name = None
+    return name, None
+
+
+def coarsen_package_token( token ):
+    """Syntactic full → major for plain gcc/clang/vc tokens; else ``None``.
+
+    Three-or-more GNU version digits drop the last (``gcc153`` → ``gcc15``).
+    Two-digit GNU tokens are left alone so ``gcc15`` is not treated as ``gcc1``.
+    MSVC ``vc145`` → ``vc14``. Archive qualifiers are not rewritten.
+    """
+    text = option_text( token )
+    if not text:
+        return None
+    match = _GNU_PACKAGE_TOKEN.match( text )
+    if match:
+        prefix, digits, tag = match.group( 1 ), match.group( 2 ), match.group( 3 )
+        if len( digits ) < 3:
+            return None
+        out = '{}{}'.format( prefix, digits[:-1] )
+        if tag:
+            out = '{}-{}'.format( out, tag )
+        return out if out != text else None
+    match = _MSVC_PACKAGE_TOKEN.match( text )
+    if match:
+        digits = match.group( 1 )
+        experimental = match.group( 2 ) or ''
+        if len( digits ) < 3:
+            return None
+        out = 'vc{}{}'.format( digits[:2], experimental )
+        return out if out != text else None
+    return None
+
+
+def alternate_package_token( token, toolchain=None ):
+    """The other of full ↔ major for ``token``, or ``None``."""
+    text = option_text( token )
+    if not text:
+        return None
+    full, major = host_package_identity_tokens( toolchain )
+    if full and major and full != major:
+        if text == full:
+            return major
+        if text == major:
+            return full
+    coarsened = coarsen_package_token( text )
+    if coarsened and coarsened != text:
+        return coarsened
+    return None
+
+
+def paired_package_tokens( token, toolchain=None ):
+    """Preferred token then the full↔major alternate when one exists."""
+    preferred = option_text( token )
+    if not preferred:
+        return []
+    tokens = [ preferred ]
+    alternate = alternate_package_token( preferred, toolchain )
+    if alternate and alternate not in tokens:
+        tokens.append( alternate )
+    return tokens

--- a/cuppa/utility/download.py
+++ b/cuppa/utility/download.py
@@ -26,8 +26,9 @@ import zipfile
 
 try:
     from urllib.request import urlopen, Request
+    from urllib.error import HTTPError
 except ImportError:
-    from urllib2 import urlopen, Request
+    from urllib2 import urlopen, Request, HTTPError
 
 from cuppa.colourise import as_emphasised, as_info, as_subdued
 from cuppa.log import logger
@@ -36,11 +37,25 @@ from cuppa.utility.storage import human_size, pad_visible, visible_len
 
 
 class DownloadError( CuppaException ):
-    def __init__( self, value ):
+    def __init__( self, value, http_status=None ):
         self.parameter = value
+        self.http_status = http_status
 
     def __str__( self ):
         return repr( self.parameter )
+
+
+def is_http_not_found( error ):
+    """True when ``error`` is a missing HTTP resource (404)."""
+    status = getattr( error, 'http_status', None )
+    if status == 404:
+        return True
+    cause = getattr( error, '__cause__', None )
+    if getattr( cause, 'code', None ) == 404:
+        return True
+    if isinstance( error, HTTPError ) and getattr( error, 'code', None ) == 404:
+        return True
+    return False
 
 
 _CHUNK_SIZE = 256 * 1024
@@ -587,6 +602,10 @@ def download_file(
                 pass
         if isinstance( error, DownloadError ):
             raise
-        raise DownloadError(
-            "failed to download [{}]: {}".format( url, error )
+        status = getattr( error, 'code', None )
+        wrapped = DownloadError(
+            "failed to download [{}]: {}".format( url, error ),
+            http_status=status,
         )
+        wrapped.__cause__ = error
+        raise wrapped

--- a/design/plans/build-and-package-identity.md
+++ b/design/plans/build-and-package-identity.md
@@ -9,7 +9,7 @@ This document is the **settled product shape** for 1.9. Point-release encoding, 
 
 **Priority:** toolchain **major** identity is the key win (layout churn + package fleets). OS omit and consume overrides are secondary slices.
 
-**Sequencing:** toolchain identity + global-config migration → consume overrides / dual lookup → OS omit at publish + OS consume override.
+**Sequencing:** toolchain identity + global-config migration → consume overrides / dual lookup → OS omit at publish.
 
 ## Two concerns (keep distinct)
 
@@ -75,7 +75,7 @@ Notes:
 |----------|--------|
 | Values | `include` (default) \| `omit` |
 | When chosen | **At package build/publish time** when the builder is confident the artefact is not OS-scoped (or consumers will override OS on lookup) |
-| CLI / config | `--package-os-identity=` / `package_os_identity=` (and/or `PublishPackage` argument — settle in PR C) |
+| CLI / config | `--package-gitlab-os-identity=` / `package_gitlab_os_identity=` (and/or `PublishPackage` argument — settle in PR C) |
 | Omit stem | `{package}_{tool_variant}` (no empty OS segment) |
 
 **Often workable:** ABI-stable static lib / headers; controlled fleets; ubuntu↔debian via **explicit** consume override; Windows/macOS already coarse.
@@ -84,18 +84,23 @@ Notes:
 
 ### Consume overrides and “try similar”
 
-Per-dependency GitLab options (same style as `--<name>-gitlab-variant`):
+Lookup overrides use a reserved package/backend namespace. The semantic prefix is fixed and the
+dependency name is an opaque suffix, avoiding collisions between project-selected dependency
+names and future top-level option families:
 
-| Option (sketch) | Role |
+| Option | Role |
 |-----------------|------|
-| `--<name>-gitlab-os=<id>` | Force OS segment for **lookup** (e.g. `debian` while host is `ubuntu`) |
-| `--<name>-gitlab-toolchain=<token>` | Force toolchain token for **lookup** (e.g. `gcc152` or `gcc15`) |
+| `--package-gitlab-os-override=<id>` | Project-wide OS segment for **lookup** |
+| `--package-gitlab-os-override-<name>=<id>` | Force OS segment for one dependency (e.g. `debian` while host is `ubuntu`) |
+| `--package-gitlab-toolchain-override-<name>=<token>` | Force toolchain token for one dependency (e.g. `gcc152` or `gcc15`) |
 
-Optional project-level `--package-os-override=<id>`. Dual-lookup during toolchain transition: if preferred stem 404s, try the other toolchain identity (full ↔ major) before failing — on by default during transition, with a switch to disable.
+Dual-lookup during toolchain transition: if the preferred stem 404s, try the other toolchain
+identity (full vs major) before failing — on by default
+(`--package-gitlab-identity-fallback=on|off`, default `on`).
 
 **Resolution order:**
 
-1. Explicit `--<name>-gitlab-toolchain=` / `--<name>-gitlab-os=` (and project OS override if set)
+1. Explicit per-dependency toolchain / OS override (then project-wide OS override if set)
 2. Stem from current effective toolchain identity + host OS (or omitted OS if that is the published shape)
 3. Fallback: alternate toolchain token (full ↔ major) with same OS choice
 4. Fail listing stems tried
@@ -112,15 +117,15 @@ Publish emits **one** stem. Dual-try is **consume-only**. Success is an ABI bet 
 | `tc-id-config-migrate` | Absent `~/.cuppaconfig` → create `major`; existing missing key → backfill `full` | Shipped in PR A |
 | `tc-id-tests` | Unit + integration: full vs major; conf cases | Shipped in PR A |
 | `tc-id-docs` | Toolchains + Packages; CHANGELOG; 2.0 outlook one sentence | Shipped in PR A |
-| `pkg-consume-override` | Per-dep OS/toolchain lookup; dual-stem 404 fallback | Next (PR B) |
+| `pkg-consume-override` | Per-dep OS/toolchain lookup; dual-stem 404 fallback | This PR (PR B) |
 | `pkg-os-apply` | Publish-time include \| omit; parsers accept both shapes | After consume overrides |
 | `pkg-os-docs` | Builder confidence; when omit/cross-OS is sane | Antora |
 
 ## Implementation PRs
 
-**PR A** (`minor`) — toolchain identity + global config migration (primary win). **This PR.**
+**PR A** (`minor`) — toolchain identity + global config migration (primary win). **Shipped.**
 
-**PR B** (`minor`) — consume overrides + dual-stem lookup.
+**PR B** (`minor`) — consume overrides + dual-stem lookup. **This PR.**
 
 **PR C** (`minor`) — package OS omit at publish; align with OS override from B.
 
@@ -146,3 +151,12 @@ Publish emits **one** stem. Dual-try is **consume-only**. Success is an ABI bet 
 2. Existing global file without the key → `full` and the key is written.
 3. `--list-toolchains` / describe still expose the real compiler version.
 4. Docs: new-install major, grandfather full, not Boost patched/clean or product SemVer.
+
+## Acceptance (PR B)
+
+1. `--package-gitlab-os-override[-<name>]=` changes the OS segment used for lookup only.
+2. `--package-gitlab-toolchain-override-<name>=` selects the preferred toolchain token; dual-try coarsens or pairs full vs major.
+3. Preferred stem `404` retries the alternate token; other HTTP errors do not.
+4. Failure messages list every stem attempted.
+5. `--package-gitlab-identity-fallback=off` disables dual-try.
+6. Publish still emits a single stem.

--- a/docs/modules/ROOT/pages/cli/dependencies-and-develop.adoc
+++ b/docs/modules/ROOT/pages/cli/dependencies-and-develop.adoc
@@ -112,6 +112,22 @@ also registers this family:
 | `--<name>-gitlab-custom-token=TOKEN` | Package-specific registry credential
 |===
 
+== Package lookup (all GitLab packages)
+
+These flags apply to consume, not publish. A `404` on the preferred stem retries the other
+toolchain identity (full vs major) unless fallback is off. See
+xref:dependencies/gitlab.adoc#consume-overrides[GitLab lookup overrides].
+
+[cols="3,4"]
+|===
+| Option | Meaning
+
+| `--package-gitlab-os-override=ID` | OS segment for every GitLab package
+| `--package-gitlab-os-override-<name>=ID` | OS segment for one named dependency; takes precedence over the project-wide override
+| `--package-gitlab-toolchain-override-<name>=TOKEN` | Toolchain token for one named dependency (`gcc152` or `gcc15`)
+| `--package-gitlab-identity-fallback=on\|off` | Dual-stem `404` retry (default `on`)
+|===
+
 Prefer `GITLAB_REGISTRY_TOKEN` or `CI_JOB_TOKEN` when one credential serves the registry. The
 wrapper masks environment values whose names contain `TOKEN`, but credentials should never be
 written to tracked configuration.

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -89,6 +89,19 @@ publishes. Coarsening means you treat 15.2 and 15.3 objects as interchangeable f
 
 xref:toolchains/overview.adoc#toolchain-identity[Toolchains overview] has the layout examples.
 
+[#package-consume-identity]
+=== GitLab package lookup (`package_gitlab_os_override`, `package_gitlab_identity_fallback`)
+
+`--package-gitlab-os-override=` forces the OS segment used when **fetching** GitLab generic
+archives. `--package-gitlab-identity-fallback=on|off` controls whether a missing preferred stem
+(`404`) retries the other toolchain identity (full vs major). Default is `on`. Neither flag
+changes published stems. Per-package `--package-gitlab-os-override-<name>=` and
+`--package-gitlab-toolchain-override-<name>=` win over the project OS override. Keys in
+`configure.conf` / `cuppa.run` `default_options` are `package_gitlab_os_override` and
+`package_gitlab_identity_fallback`.
+
+See xref:dependencies/gitlab.adoc#consume-overrides[GitLab lookup overrides].
+
 === HTML report source links without CI flags
 
 Projects that publish Profiles or test HTML from CI often need ``remote`` link resolution and

--- a/docs/modules/ROOT/pages/dependencies/gitlab.adoc
+++ b/docs/modules/ROOT/pages/dependencies/gitlab.adoc
@@ -24,8 +24,35 @@ The `cuppa` launcher redacts env values whose names contain `TOKEN` in logged ou
 To **publish** a Cuppa-built library to the same registry, see
 xref:packages.adoc[Publishing packages].
 Archive stems include `toolchain.package_name()`, so `--toolchain-identity=major` looks for
-`gcc15_…` rather than `gcc153_…` unless you keep `full`. Consume-side dual lookup is a later
-slice; until then, publish and consume with the same identity.
+`gcc15_…` rather than `gcc153_…` unless you keep `full`. If the preferred stem is missing
+(`404`), Cuppa tries the other identity (full vs major) with the same OS before failing, and
+logs every stem it attempted. Disable that with
+`--package-gitlab-identity-fallback=off`. Publish still emits one stem.
+
+[#consume-overrides]
+== Lookup overrides
+
+Host identity does not have to match the archive you fetch. These options change **lookup** only;
+they do not rename what `env.PublishPackage` writes.
+
+[cols="3,7"]
+|===
+| Option | Role
+
+| `--package-gitlab-os-override=<id>` | Force the OS segment for every GitLab package
+| `--package-gitlab-os-override-<name>=<id>` | Force the OS segment for one named dependency (`debian` while the host is `ubuntu`)
+| `--package-gitlab-toolchain-override-<name>=<token>` | Force the toolchain token for one named dependency (`gcc152` or `gcc15`)
+| `--package-gitlab-identity-fallback=on\|off` | Try the other toolchain identity after a `404` (default `on`)
+|===
+
+Resolution order is: explicit per-package OS and toolchain overrides (then the project-wide OS
+override), then the current toolchain identity plus host OS, then the alternate full vs major
+token. Success is an ABI bet the project owns — Cuppa does not treat Debian archives as
+equivalent to Ubuntu ones unless you ask for that stem.
+
+xref:cli/dependencies-and-develop.adoc[Dependencies and develop] lists the flags.
+xref:toolchains/overview.adoc#toolchain-identity[Build and package identity] covers layout
+identity. OS omit at **publish** time is a later slice.
 
 [#boost-package]
 == Boost package

--- a/docs/modules/ROOT/pages/packages.adoc
+++ b/docs/modules/ROOT/pages/packages.adoc
@@ -16,8 +16,10 @@ From a sconscript, `env.PublishPackage(...)` with a `GitlabPackagePublisher` bui
 and writes a ``.packaged`` stamp beside it in ``final/``. The toolchain token in the archive stem is
 `toolchain.package_name()`, which follows `--toolchain-identity=` (see
 xref:toolchains/overview.adoc#toolchain-identity[Build and package identity]). Switching identity
-does not rename archives already in a registry; republish or wait for consume-side lookup in a
-later Cuppa release. When staged headers and libs are not newer than the
+does not rename archives already in a registry; republish or use consume-side lookup
+(`--package-gitlab-toolchain-override-<name>=`,
+`--package-gitlab-identity-fallback`) described in
+xref:dependencies/gitlab.adoc#consume-overrides[GitLab lookup overrides]. When staged headers and libs are not newer than the
 existing archive, cuppa skips recreating the tarball — so a follow-up ``cuppa --rel --publish-package`` can
 upload without re-tarring multi-gigabyte trees.
 Add `--publish-package` to upload it to the GitLab generic registry.

--- a/docs/modules/ROOT/pages/toolchains/overview.adoc
+++ b/docs/modules/ROOT/pages/toolchains/overview.adoc
@@ -58,6 +58,13 @@ Coarsening asserts that those point releases are interchangeable for *your* bina
 Boost patched/clean identity or product SemVer. Cuppa 2.0 may make `major` the silent built-in
 default; 1.x does not change existing global files that already store `full`.
 
+If a published archive uses a different OS or identity than this machine, consume overrides
+select the stem to download (`--package-gitlab-os-override[-<name>]=`,
+`--package-gitlab-toolchain-override-<name>=`) and, on `404`, the other full vs major token
+(`--package-gitlab-identity-fallback`, default on). That is lookup, not a claim that two
+distros are the same ABI. See
+xref:dependencies/gitlab.adoc#consume-overrides[GitLab lookup overrides].
+
 See xref:configuration.adoc#toolchain-identity[Configuration] and
 xref:cli/toolchains-and-features.adoc[Toolchains and features].
 

--- a/tests/integration/methods/test_compile_object_paths.py
+++ b/tests/integration/methods/test_compile_object_paths.py
@@ -103,12 +103,14 @@ def test_compile_object_paths_stable_from_nested_launch(tmp_path):
     import shutil
     shutil.rmtree(project / "_build")
 
+    # Nested -D + two MSVC variants can exceed the default 180s on Windows CI.
     nested_result = run_cuppa(
         nested,
         "--dbg",
         "--rel",
         "--offline",
         "--scripts=../../sconscript",
+        timeout=360,
     )
     assert_success(nested_result)
     nested_layout = _objects_under_working(project)

--- a/tests/unit/test_build_with_package.py
+++ b/tests/unit/test_build_with_package.py
@@ -95,3 +95,55 @@ def test_package_id_includes_tool_variant_per_toolchain():
     assert gcc_id[5] == "gcc153_rel_x86_64_cxx2c"
     assert clang_id[5] == "clang211_rel_x86_64_cxx2c"
     assert gcc_id != clang_id
+
+
+def test_gitlab_override_options_use_reserved_package_namespace():
+    registered = []
+
+    def add_option(flag, **attributes):
+        registered.append((flag, attributes["dest"]))
+
+    GitlabPackageDependency.add_options("gitlab", "widget", add_option)
+
+    assert ("--widget-gitlab-version", "widget-gitlab-version") in registered
+    assert (
+        "--package-gitlab-os-override-widget",
+        "package-gitlab-os-override-widget",
+    ) in registered
+    assert (
+        "--package-gitlab-toolchain-override-widget",
+        "package-gitlab-toolchain-override-widget",
+    ) in registered
+    assert not any(flag == "--widget-gitlab-os" for flag, _dest in registered)
+
+
+def test_gitlab_override_option_ids_stay_scoped_to_each_dependency():
+    Widget = package_dependency(
+        "widget",
+        package_manager="gitlab",
+        registry="https://gitlab.example/api/v4",
+        package="widget",
+        version="1.2.3",
+    )
+    Gadget = package_dependency(
+        "gadget",
+        package_manager="gitlab",
+        registry="https://gitlab.example/api/v4",
+        package="gadget",
+        version="2.0.0",
+    )
+    env = FakeEnv(
+        develop=False,
+        **{
+            "package-gitlab-os-override-widget": "debian",
+            "package-gitlab-os-override-gadget": "ubuntu",
+        }
+    )
+
+    widget = Widget.package_info(env)["package"]
+    gadget = Gadget.package_info(env)["package"]
+
+    assert widget["args"]["os_override"] == "debian"
+    assert gadget["args"]["os_override"] == "ubuntu"
+    assert widget["id"][6] == "debian"
+    assert gadget["id"][6] == "ubuntu"

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -331,3 +331,9 @@ def test_extract_zip_archive_with_progress( tmp_path ):
     assert ( target / 'dir' / 'a.txt' ).read_text( encoding='utf-8' ) == 'aaa' * 1000
     assert ( target / 'dir' / 'b.txt' ).read_text( encoding='utf-8' ) == 'bbb' * 1000
     assert 'Extracting pkg.zip' in stream.getvalue()
+
+
+def test_is_http_not_found():
+    assert dl.is_http_not_found( dl.DownloadError( 'missing', http_status=404 ) )
+    assert not dl.is_http_not_found( dl.DownloadError( 'denied', http_status=403 ) )
+    assert not dl.is_http_not_found( dl.DownloadError( 'no status' ) )

--- a/tests/unit/test_gitlab_naming.py
+++ b/tests/unit/test_gitlab_naming.py
@@ -1,9 +1,12 @@
+import os
 from types import SimpleNamespace
 
 import pytest
 
 from cuppa.package_managers.gitlab import (
     GitlabPackageDependency,
+    consume_package_file_stems,
+    download_first_available_package,
     os_release_id,
     package_archive_extension,
     package_archive_extensions,
@@ -144,3 +147,146 @@ def test_parse_pkg_config_runs_when_not_cleaning(tmp_path):
     dependency.parse_pkg_config(["widget_kms"])
     assert len(dependency._env.parsed) == 1
     assert "widget_kms" in dependency._env.parsed[0]
+
+
+def _lookup_env( package_name="gcc153", os_override=None, fallback=None ):
+    class Env( dict ):
+        def get_option( self, key, default=None ):
+            return self.get( key, default )
+
+    toolchain = SimpleNamespace(
+        package_name=lambda: package_name,
+        family=lambda: "gcc",
+        _reported_version={ "major": 15, "minor": 3 },
+        _name=package_name,
+    )
+    env = Env(
+        toolchain=toolchain,
+        variant=SimpleNamespace( name=lambda: "rel" ),
+        target_arch="x86_64",
+        abi="cxx2c",
+    )
+    if os_override is not None:
+        env["package_gitlab_os_override"] = os_override
+    if fallback is not None:
+        env["package_gitlab_identity_fallback"] = fallback
+    return env
+
+
+def test_consume_stems_host_os_and_identity_pair( monkeypatch ):
+    monkeypatch.setattr(
+        "cuppa.package_managers.gitlab.platform.freedesktop_os_release",
+        lambda: { "ID": "ubuntu" },
+    )
+    monkeypatch.setattr(
+        "cuppa.package_managers.gitlab.platform.system",
+        lambda: "Linux",
+    )
+    env = _lookup_env()
+    stems = consume_package_file_stems( env, package="widget", variant="rel" )
+    assert stems == [
+        "widget_ubuntu_gcc153_rel_x86_64_cxx2c",
+        "widget_ubuntu_gcc15_rel_x86_64_cxx2c",
+    ]
+
+
+def test_consume_stems_os_override_and_explicit_toolchain( monkeypatch ):
+    monkeypatch.setattr(
+        "cuppa.package_managers.gitlab.platform.freedesktop_os_release",
+        lambda: { "ID": "ubuntu" },
+    )
+    monkeypatch.setattr(
+        "cuppa.package_managers.gitlab.platform.system",
+        lambda: "Linux",
+    )
+    env = _lookup_env( os_override="debian" )
+    stems = consume_package_file_stems( env, package="widget", variant="rel" )
+    assert stems[0].startswith( "widget_debian_" )
+    stems = consume_package_file_stems(
+            env, package="widget", variant="rel", package_os="fedora"
+    )
+    assert stems[0] == "widget_fedora_gcc153_rel_x86_64_cxx2c"
+    stems = consume_package_file_stems(
+            env, package="widget", variant="rel", package_toolchain="gcc152"
+    )
+    assert stems == [
+        "widget_debian_gcc152_rel_x86_64_cxx2c",
+        "widget_debian_gcc15_rel_x86_64_cxx2c",
+    ]
+
+
+def test_consume_stems_fallback_off( monkeypatch ):
+    monkeypatch.setattr(
+        "cuppa.package_managers.gitlab.platform.freedesktop_os_release",
+        lambda: { "ID": "debian" },
+    )
+    env = _lookup_env( fallback="off" )
+    stems = consume_package_file_stems( env, package="widget", variant="rel" )
+    assert stems == [ "widget_debian_gcc153_rel_x86_64_cxx2c" ]
+
+
+def test_download_first_skips_404_then_succeeds( tmp_path ):
+    from cuppa.utility.download import DownloadError
+
+    calls = []
+
+    def fake_download( url, dest, custom_token=None, label=None ):
+        calls.append( url )
+        if "gcc153" in url:
+            raise DownloadError( "missing", http_status=404 )
+        with open( dest, "wb" ) as handle:
+            handle.write( b"ok" )
+        return dest
+
+    candidates = [
+        ( "s153", "widget_gcc153.tar.gz", "https://example/widget_gcc153.tar.gz", "gcc153" ),
+        ( "s15", "widget_gcc15.tar.gz", "https://example/widget_gcc15.tar.gz", "gcc15" ),
+    ]
+    dest, filename, stem = download_first_available_package(
+            candidates, str( tmp_path ), download=fake_download
+    )
+    assert filename == "widget_gcc15.tar.gz"
+    assert stem == "s15"
+    assert os.path.isfile( dest )
+    assert len( calls ) == 2
+
+
+def test_download_first_does_not_fallback_on_forbidden( tmp_path ):
+    from cuppa.utility.download import DownloadError
+
+    calls = []
+
+    def fake_download( url, dest, custom_token=None, label=None ):
+        calls.append( url )
+        raise DownloadError( "denied", http_status=403 )
+
+    candidates = [
+        ( "s153", "widget_gcc153.tar.gz", "https://example/widget_gcc153.tar.gz", "gcc153" ),
+        ( "s15", "widget_gcc15.tar.gz", "https://example/widget_gcc15.tar.gz", "gcc15" ),
+    ]
+    with pytest.raises( DownloadError ) as caught:
+        download_first_available_package(
+                candidates, str( tmp_path ), download=fake_download
+        )
+    assert "widget_gcc153.tar.gz" in str( caught.value.parameter )
+    assert "widget_gcc15.tar.gz" not in str( caught.value.parameter )
+    assert calls == [ "https://example/widget_gcc153.tar.gz" ]
+
+
+def test_download_first_lists_stems_when_all_404( tmp_path ):
+    from cuppa.utility.download import DownloadError
+
+    def fake_download( url, dest, custom_token=None, label=None ):
+        raise DownloadError( "missing", http_status=404 )
+
+    candidates = [
+        ( "s153", "widget_gcc153.tar.gz", "https://example/widget_gcc153.tar.gz", "gcc153" ),
+        ( "s15", "widget_gcc15.tar.gz", "https://example/widget_gcc15.tar.gz", "gcc15" ),
+    ]
+    with pytest.raises( DownloadError ) as caught:
+        download_first_available_package(
+                candidates, str( tmp_path ), download=fake_download
+        )
+    message = str( caught.value.parameter )
+    assert "widget_gcc153.tar.gz" in message
+    assert "widget_gcc15.tar.gz" in message

--- a/tests/unit/test_toolchain_identity_policy.py
+++ b/tests/unit/test_toolchain_identity_policy.py
@@ -3,6 +3,8 @@
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)
 
+from types import SimpleNamespace
+
 import pytest
 
 from cuppa.toolchains import identity
@@ -105,6 +107,68 @@ def test_migrate_grandfathers_full_when_key_missing( tmp_path ):
     text = conf.read_text( encoding='utf-8' )
     assert 'toolchain_identity = full' in text
     assert 'offline = True' in text
+
+
+def test_paired_package_tokens_full_and_major( monkeypatch ):
+    monkeypatch.setattr( identity, 'current_identity', lambda: 'full' )
+    gcc = _gcc( 15, 3 )
+    assert identity.paired_package_tokens( gcc.package_name(), gcc ) == [ 'gcc153', 'gcc15' ]
+    monkeypatch.setattr( identity, 'current_identity', lambda: 'major' )
+    gcc_major = _gcc( 15, 3 )
+    assert identity.paired_package_tokens( gcc_major.package_name(), gcc_major ) == [
+        'gcc15', 'gcc153',
+    ]
+
+
+def test_paired_package_tokens_explicit_point_coarsens():
+    gcc = _gcc( 15, 3 )
+    assert identity.paired_package_tokens( 'gcc152', gcc ) == [ 'gcc152', 'gcc15' ]
+
+
+def test_paired_package_tokens_archive_qualifier_unchanged():
+    gcc = _gcc( 17, 0, encoded='gcc17_gcc_snapshot_abc' )
+    assert identity.paired_package_tokens( gcc.package_name(), gcc ) == [
+        'gcc17_gcc_snapshot_abc',
+    ]
+
+
+def test_paired_package_tokens_clang_tag( monkeypatch ):
+    monkeypatch.setattr( identity, 'current_identity', lambda: 'full' )
+    tagged = _clang( 21, 1, stdlib='libc++' )
+    tagged.default_stdlib = lambda: 'libstdc++'
+    tokens = identity.paired_package_tokens( tagged.package_name(), tagged )
+    assert tokens == [ 'clang211-libc++', 'clang21-libc++' ]
+
+
+def test_coarsen_msvc_token():
+    assert identity.coarsen_package_token( 'vc145' ) == 'vc14'
+    assert identity.coarsen_package_token( 'vc14' ) is None
+
+
+def test_package_identity_fallback_default_on():
+    assert identity.package_identity_fallback_enabled( {} ) is True
+    env = SimpleNamespace(
+        get_option=lambda key, default=None:
+            ['off'] if key == 'package_gitlab_identity_fallback' else None
+    )
+    assert identity.package_identity_fallback_enabled( env ) is False
+
+
+def test_package_consume_identity_registers_gitlab_namespace():
+    registered = []
+
+    def add_option(flag, **attributes):
+        registered.append((flag, attributes["dest"]))
+
+    identity.PackageConsumeIdentity.add_options(add_option)
+
+    assert registered == [
+        ("--package-gitlab-os-override", "package_gitlab_os_override"),
+        (
+            "--package-gitlab-identity-fallback",
+            "package_gitlab_identity_fallback",
+        ),
+    ]
 
 
 def test_migrate_leaves_existing_key( tmp_path ):


### PR DESCRIPTION
## Summary

Consume-side GitLab archive lookup can now target a published OS or toolchain token that differs from the host (`--package-gitlab-os-override[-<name>]=`, `--package-gitlab-toolchain-override-<name>=`). If the preferred stem is missing (`404`), Cuppa tries the other full vs major identity with the same OS unless `--package-gitlab-identity-fallback=off`. Publish still emits one stem. A successful fallback is an ABI bet the project owns.

Groundwork for [#243](https://github.com/ja11sop/cuppa/issues/243). Does not close that umbrella (OS omit at publish is PR C).

## Test plan

- [x] Local: `flake8 cuppa`, `pylint -E cuppa`, `pytest -m unit`, `pytest -m integration`
- [x] Unit coverage for stem lists, 404 vs non-404 retry, reserved option namespace
- [x] Local consume of a registry archive with OS/toolchain override (maintainer)
- [x] CI green on the matrix
