### PR TITLE
Add GitLab package OS identity include or omit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -714,7 +714,7 @@ cuppa -D --dbg --cxx-profiles --cxx-profiles-enforce=std::init \
 
 Package registry dependencies need matching toolchain archives in the registry (or cache); `--develop` does not invent them.
 GitLab auth: `GITLAB_REGISTRY_TOKEN` or `CI_JOB_TOKEN`.
-To fetch an archive published under another OS or identity: `--package-gitlab-os-override[-<name>]=`, `--package-gitlab-toolchain-override-<name>=`. Dual-stem `404` retry is on unless `--package-gitlab-identity-fallback=off`.
+To fetch an archive published under another OS or identity: `--package-gitlab-os-override[-<name>]=`, `--package-gitlab-toolchain-override-<name>=`. Dual-stem `404` retry is on unless `--package-gitlab-identity-fallback=off`. Publish without an OS segment: `--package-gitlab-os-identity=omit`.
 
 ---
 description: Documentation style guide for Cuppa docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ``GitlabPackagePublisher`` skips the package staging directory (and stamps /
+  archives) when copying ``source_lib_dir`` from ``abs_final_dir``, so staging
+  cannot nest into itself.
 - ``CollateTestReportIndex()`` creates the destination directory before writing
   ``test-report-index.json`` / ``.html`` at ``#SconstructEnd`` (and before
   ``Copy`` of per-test reports). A missing ``_artefacts/test`` (or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same OS unless ``--package-gitlab-identity-fallback=off``. Dual-try is consume-only;
   publish still emits one stem. A successful fallback is an ABI bet the project
   owns ([#243](https://github.com/ja11sop/cuppa/issues/243)).
+- ``--package-gitlab-os-identity=include|omit`` (default ``include``) selects
+  whether GitLab generic archive stems include the OS id. ``omit`` publishes
+  ``{package}_{tool_variant}``. Consume prefers that shape when the flag is set,
+  and with identity fallback also tries the other encoding after a ``404``.
+  Explicit OS overrides still look up the include shape. Omit is not the 1.x
+  product default ([#243](https://github.com/ja11sop/cuppa/issues/243)).
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -424,7 +424,7 @@ C++ Profiles are a separate roadmap section — see [C++ Profiles](#c-profiles).
 | `tc-dep-url-sugar` | Optional URL token in `--toolchains=` | Low | Keep `--toolchain-archive=` as explicit supply |
 | `tc-dep-actions` | Authenticated Actions artifact URLs | Low | After public HTTPS / file path is solid |
 | `tc-dep-msvc` | MSVC archive / layout as toolchain dep | Low | Separate driver; not gcc-snapshot |
-| `tc-identity-coarsen` | Major toolchain identity for `_build` / package stems (`gcc153`→`gcc15`); optional OS omit and consume overrides | High | Identity + consume shipped; OS omit this slice — [`build-and-package-identity.md`](design/plans/build-and-package-identity.md), encoding [`ignore-toolchain-point-release.md`](design/plans/ignore-toolchain-point-release.md) |
+| `tc-identity-coarsen` | Major toolchain identity for `_build` / package stems (`gcc153`→`gcc15`); optional OS omit and consume overrides | High | Identity [#242](https://github.com/ja11sop/cuppa/pull/242), consume [#244](https://github.com/ja11sop/cuppa/pull/244), OS omit [#245](https://github.com/ja11sop/cuppa/pull/245) — [`build-and-package-identity.md`](design/plans/build-and-package-identity.md), encoding [`ignore-toolchain-point-release.md`](design/plans/ignore-toolchain-point-release.md) |
 
 ### Out of scope (toolchains-as-deps)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -424,7 +424,7 @@ C++ Profiles are a separate roadmap section — see [C++ Profiles](#c-profiles).
 | `tc-dep-url-sugar` | Optional URL token in `--toolchains=` | Low | Keep `--toolchain-archive=` as explicit supply |
 | `tc-dep-actions` | Authenticated Actions artifact URLs | Low | After public HTTPS / file path is solid |
 | `tc-dep-msvc` | MSVC archive / layout as toolchain dep | Low | Separate driver; not gcc-snapshot |
-| `tc-identity-coarsen` | Major toolchain identity for `_build` / package stems (`gcc153`→`gcc15`); optional OS omit and consume overrides | High | Identity shipped; consume overrides this slice — [`build-and-package-identity.md`](design/plans/build-and-package-identity.md), encoding [`ignore-toolchain-point-release.md`](design/plans/ignore-toolchain-point-release.md) |
+| `tc-identity-coarsen` | Major toolchain identity for `_build` / package stems (`gcc153`→`gcc15`); optional OS omit and consume overrides | High | Identity + consume shipped; OS omit this slice — [`build-and-package-identity.md`](design/plans/build-and-package-identity.md), encoding [`ignore-toolchain-point-release.md`](design/plans/ignore-toolchain-point-release.md) |
 
 ### Out of scope (toolchains-as-deps)
 

--- a/cuppa/core/dependency_identity.py
+++ b/cuppa/core/dependency_identity.py
@@ -461,7 +461,7 @@ def gitlab_remote_for_package_version( registry_base, package, version ):
     )
 
 
-def gitlab_archive_name( package, tool_variant, system=None, extension=None ):
+def gitlab_archive_name( package, tool_variant, system=None, extension=None, omit_os=False ):
     """Archive basename as published/downloaded for a GitLab generic package."""
     if not package or not tool_variant or tool_variant in ( '-', '' ):
         return None
@@ -469,10 +469,16 @@ def gitlab_archive_name( package, tool_variant, system=None, extension=None ):
         os_release_id,
         package_archive_extension,
     )
-    if system is None:
-        system = os_release_id()
     if extension is None:
         extension = package_archive_extension()
+    if omit_os:
+        return '{package}_{build}{ext}'.format(
+                package=package,
+                build=tool_variant,
+                ext=extension,
+        )
+    if system is None:
+        system = os_release_id()
     return '{package}_{system}_{build}{ext}'.format(
             package=package,
             system=system,

--- a/cuppa/package_managers/gitlab.py
+++ b/cuppa/package_managers/gitlab.py
@@ -23,6 +23,30 @@ from cuppa.log import logger, register_secret
 from cuppa.colourise import as_error, as_info, as_notice, as_info_label
 
 
+def _resolve_node_path( node ):
+    path = str( node )
+    if hasattr( node, 'srcnode' ):
+        path = str( node.srcnode() )
+    return path
+
+
+def lib_copy_ignore_names( names, package_dir_name, package_file_name ):
+    """Names to skip when copying ``source_lib_dir`` (often ``abs_final_dir``).
+
+    Staging lives under ``final/<package>/<version>/``, so copying ``final/``
+    into that tree without this filter nests forever.
+    """
+    ignored = set()
+    for name in names:
+        if name in ( 'modules', package_dir_name ):
+            ignored.add( name )
+        elif name == package_file_name:
+            ignored.add( name )
+        elif name.endswith( ( '.packaged', '.published', '.tar.gz', '.zip' ) ):
+            ignored.add( name )
+    return ignored
+
+
 def remove_prefix( text, prefix ):
     if text.startswith( prefix ):
         return text[len(prefix):]
@@ -548,26 +572,32 @@ class GitlabPackagePublisher:
         from SCons.Script import Touch
 
         if not os.path.exists( str(self._target_include_dir) ):
+            source_include = _resolve_node_path( self._source_include_dir )
             logger.info( "For package [{}], include dir [{}] does not exist so copying include files from [{}]...".format(
                     as_info( self._package_file_name ),
                     as_info( str(self._target_include_dir) ),
-                    as_notice( str(self._source_include_dir) )
+                    as_notice( source_include )
             ) )
-            shutil.copytree( str( self._source_include_dir ), str(self._target_include_dir) )
+            shutil.copytree( source_include, str(self._target_include_dir) )
 
+        source_lib = _resolve_node_path( self._source_lib_dir )
         if not os.path.exists( str(self._target_lib_dir) ):
             logger.info( "For package [{}], lib dir [{}] does not exist so copying lib files from [{}]...".format(
                     as_info( self._package_file_name ),
                     as_info( str(self._target_lib_dir) ),
-                    as_notice( str(self._source_lib_dir) )
+                    as_notice( source_lib )
             ) )
+            package_dir_name = os.path.normpath( str( self._package_source_dir ) )
+            package_file_name = os.path.basename( str( self._package_file_name ) )
             shutil.copytree(
-                str( self._source_lib_dir ),
+                source_lib,
                 str( self._target_lib_dir ),
-                ignore=shutil.ignore_patterns( 'modules' ),
+                ignore=lambda _directory, names: lib_copy_ignore_names(
+                        names, package_dir_name, package_file_name
+                ),
             )
 
-        source_modules = os.path.join( str( self._source_lib_dir ), 'modules' )
+        source_modules = os.path.join( source_lib, 'modules' )
         target_modules = os.path.join( str( self._package_base_dir ), 'modules' )
         if os.path.isdir( source_modules ) and not os.path.exists( target_modules ):
             logger.info( "For package [{}], copying modules from [{}]...".format(

--- a/cuppa/package_managers/gitlab.py
+++ b/cuppa/package_managers/gitlab.py
@@ -78,14 +78,30 @@ def package_archive_extensions():
     return preferred, alternate
 
 
-def package_file_stem( env, package=None, variant=None, system=None, toolchain_token=None ):
-    """Basename without archive extension: ``{package}_{os}_{tool_variant}``."""
+def package_file_stem(
+        env,
+        package=None,
+        variant=None,
+        system=None,
+        toolchain_token=None,
+        omit_os=False
+):
+    """Basename without archive extension.
+
+    Default ``{package}_{os}_{tool_variant}``. With ``omit_os``, ``{package}_{tool_variant}``.
+    """
+    build_name = tool_variant( env, variant, toolchain_token=toolchain_token )
+    if omit_os:
+        return "{package}_{build_name}".format(
+                package    = str(package),
+                build_name = build_name,
+        )
     if system is None:
         system = os_release_id()
     return "{package}_{system}_{build_name}".format(
             package    = str(package),
             system     = system,
-            build_name = tool_variant( env, variant, toolchain_token=toolchain_token )
+            build_name = build_name,
     )
 
 
@@ -95,7 +111,8 @@ def package_file_name(
         variant=None,
         target_dir=None,
         system=None,
-        toolchain_token=None
+        toolchain_token=None,
+        omit_os=False
 ):
     name = package_file_stem(
             env,
@@ -103,6 +120,7 @@ def package_file_name(
             variant=variant,
             system=system,
             toolchain_token=toolchain_token,
+            omit_os=omit_os,
     ) + package_archive_extension()
     if target_dir:
         return os.path.join( target_dir, name )
@@ -218,7 +236,8 @@ def package_url(
         version=None,
         variant=None,
         system=None,
-        toolchain_token=None
+        toolchain_token=None,
+        omit_os=False
 ):
     return "{registry}/packages/generic/{package}/{version}/{package_file}".format(
             registry = str(registry),
@@ -230,6 +249,7 @@ def package_url(
                     variant=variant,
                     system=system,
                     toolchain_token=toolchain_token,
+                    omit_os=omit_os,
             )
     )
 
@@ -244,6 +264,38 @@ def consume_os_id( env, package_os=None ):
     if project:
         return project
     return os_release_id()
+
+
+def consume_os_shapes( env, package_os=None, fallback=None ):
+    """Ordered ``(omit_os, system)`` pairs for lookup.
+
+    An explicit OS override locks the include shape. Otherwise the preferred
+    shape follows ``--package-gitlab-os-identity`` (default include); fallback
+    also tries the other encoding.
+    """
+    from cuppa.toolchains.identity import (
+        OS_IDENTITY_OMIT,
+        option_text,
+        package_identity_fallback_enabled,
+        package_os_identity,
+        package_os_override,
+    )
+    if fallback is None:
+        fallback = package_identity_fallback_enabled( env )
+    explicit = option_text( package_os ) or package_os_override( env )
+    if explicit:
+        return [ ( False, explicit ) ]
+    omit_preferred = package_os_identity( env ) == OS_IDENTITY_OMIT
+    host = consume_os_id( env )
+    if omit_preferred:
+        shapes = [ ( True, None ) ]
+        if fallback:
+            shapes.append( ( False, host ) )
+        return shapes
+    shapes = [ ( False, host ) ]
+    if fallback:
+        shapes.append( ( True, None ) )
+    return shapes
 
 
 def consume_toolchain_tokens( env, package_toolchain=None, fallback=None ):
@@ -271,22 +323,23 @@ def consume_package_file_stems(
         fallback=None
 ):
     """Lookup stems in resolution order (OS override applied; dual identity when enabled)."""
-    system = consume_os_id( env, package_os )
     tokens = consume_toolchain_tokens(
             env,
             package_toolchain=package_toolchain,
             fallback=fallback,
     )
-    return [
-        package_file_stem(
-                env,
-                package=package,
-                variant=variant,
-                system=system,
-                toolchain_token=token,
-        )
-        for token in tokens
-    ]
+    stems = []
+    for omit_os, system in consume_os_shapes( env, package_os, fallback=fallback ):
+        for token in tokens:
+            stems.append( package_file_stem(
+                    env,
+                    package=package,
+                    variant=variant,
+                    system=system,
+                    toolchain_token=token,
+                    omit_os=omit_os,
+            ) )
+    return stems
 
 
 def consume_archive_candidates(
@@ -300,32 +353,34 @@ def consume_archive_candidates(
         fallback=None
 ):
     """``(stem, filename, url, toolchain_token)`` tuples for consume lookup."""
-    system = consume_os_id( env, package_os )
     tokens = consume_toolchain_tokens(
             env,
             package_toolchain=package_toolchain,
             fallback=fallback,
     )
     candidates = []
-    for token in tokens:
-        stem = package_file_stem(
-                env,
-                package=package,
-                variant=variant,
-                system=system,
-                toolchain_token=token,
-        )
-        filename = stem + package_archive_extension()
-        url = package_url(
-                env,
-                registry=registry,
-                package=package,
-                version=version,
-                variant=variant,
-                system=system,
-                toolchain_token=token,
-        )
-        candidates.append( ( stem, filename, url, token ) )
+    for omit_os, system in consume_os_shapes( env, package_os, fallback=fallback ):
+        for token in tokens:
+            stem = package_file_stem(
+                    env,
+                    package=package,
+                    variant=variant,
+                    system=system,
+                    toolchain_token=token,
+                    omit_os=omit_os,
+            )
+            filename = stem + package_archive_extension()
+            url = package_url(
+                    env,
+                    registry=registry,
+                    package=package,
+                    version=version,
+                    variant=variant,
+                    system=system,
+                    toolchain_token=token,
+                    omit_os=omit_os,
+            )
+            candidates.append( ( stem, filename, url, token ) )
     return candidates
 
 
@@ -454,7 +509,11 @@ class GitlabPackagePublisher:
 
         self._target_lib_dir    = env.Dir( os.path.join( env['final_dir'], self._package_folder, "lib" ) )
         self._package_variant   = tool_variant( env, variant=variant )
-        self._package_file_name = package_file_name( env, package=package, variant=variant )
+        from cuppa.toolchains.identity import OS_IDENTITY_OMIT, package_os_identity
+        omit_os = package_os_identity( env ) == OS_IDENTITY_OMIT
+        self._package_file_name = package_file_name(
+                env, package=package, variant=variant, omit_os=omit_os
+        )
         self._package_archive = env.File(
                 os.path.join( env['abs_final_dir'], self._package_file_name )
         )
@@ -468,7 +527,13 @@ class GitlabPackagePublisher:
         self._curl_command = 'curl --fail-with-body --header "{token}" --upload-file {package_file} "{package_location}"'.format(
                 token = get_header_token( custom_token ),
                 package_file = str( self._package_archive ),
-                package_location = package_url( env, registry=registry, package=package, version=version )
+                package_location = package_url(
+                        env,
+                        registry=registry,
+                        package=package,
+                        version=version,
+                        omit_os=omit_os,
+                )
         )
 
         self._package_file_path = os.path.join( self._package_folder, self._package_file_name )
@@ -872,6 +937,7 @@ class GitlabPackageDependency:
         from cuppa.toolchains.identity import (
             option_text,
             package_identity_fallback_enabled,
+            package_os_identity,
             package_os_override,
         )
 
@@ -886,6 +952,7 @@ class GitlabPackageDependency:
             option_text( getattr( package, '_toolchain_override', None ) ),
             package_os_override( env ),
             package_identity_fallback_enabled( env ),
+            package_os_identity( env ),
         )
 
         short_id = cls._id( package._package, package._version, package._variant )

--- a/cuppa/toolchains/identity.py
+++ b/cuppa/toolchains/identity.py
@@ -33,6 +33,10 @@ TOOLCHAIN_IDENTITY_KEY = 'toolchain_identity'
 PACKAGE_OS_OVERRIDE_KEY = 'package_gitlab_os_override'
 PACKAGE_IDENTITY_FALLBACK_KEY = 'package_gitlab_identity_fallback'
 PACKAGE_IDENTITY_FALLBACK_CHOICES = ( 'on', 'off' )
+PACKAGE_OS_IDENTITY_KEY = 'package_gitlab_os_identity'
+OS_IDENTITY_INCLUDE = 'include'
+OS_IDENTITY_OMIT = 'omit'
+PACKAGE_OS_IDENTITY_CHOICES = ( OS_IDENTITY_INCLUDE, OS_IDENTITY_OMIT )
 
 _GNU_PACKAGE_TOKEN = re.compile( r'^(gcc|clang)(\d+)(?:-(.+))?$' )
 _MSVC_PACKAGE_TOKEN = re.compile( r'^vc(\d+)(e)?$', re.I )
@@ -62,7 +66,7 @@ class ToolchainIdentity( object ):
 
 
 class PackageConsumeIdentity( object ):
-    """Registers consume-side GitLab lookup overrides; not a compiler toolchain."""
+    """Registers GitLab package OS/toolchain lookup and OS-identity options."""
 
     @classmethod
     def add_options( cls, add_option ):
@@ -84,8 +88,20 @@ class PackageConsumeIdentity( object ):
             nargs=1,
             action='store',
             help="When a GitLab archive 404s, try the other toolchain identity "
-                 "(full vs major) with the same OS. Default on. Dual-try is consume-only; "
+                 "(full vs major) with the same OS shape, then the other OS encoding "
+                 "(include vs omit). Default on. Dual-try is consume-only; "
                  "a successful fallback is an ABI bet the project owns.",
+        )
+        add_option(
+            '--package-gitlab-os-identity',
+            dest=PACKAGE_OS_IDENTITY_KEY,
+            choices=list( PACKAGE_OS_IDENTITY_CHOICES ),
+            nargs=1,
+            action='store',
+            help="Whether GitLab package archive stems include the OS id "
+                 "({package}_{os}_{tool}) or omit it ({package}_{tool}). "
+                 "Default include. Omit is a publish-time ABI bet; consume "
+                 "uses the same flag for the preferred lookup stem.",
         )
 
     @classmethod
@@ -251,6 +267,17 @@ def package_identity_fallback_enabled( env=None ):
     if text in ( 'on', 'true', '1', 'yes' ):
         return True
     return True
+
+
+def package_os_identity( env=None ):
+    """``include`` (default) or ``omit`` for GitLab archive OS segments."""
+    raw = _option_from_env( env, PACKAGE_OS_IDENTITY_KEY )
+    if raw is None:
+        return OS_IDENTITY_INCLUDE
+    text = raw.lower()
+    if text in PACKAGE_OS_IDENTITY_CHOICES:
+        return text
+    return OS_IDENTITY_INCLUDE
 
 
 def host_package_identity_tokens( toolchain ):

--- a/design/plans/build-and-package-identity.md
+++ b/design/plans/build-and-package-identity.md
@@ -119,8 +119,8 @@ Publish emits **one** stem (`include` or `omit`). Dual-try is **consume-only**. 
 | `tc-id-tests` | Unit + integration: full vs major; conf cases | Shipped in PR A |
 | `tc-id-docs` | Toolchains + Packages; CHANGELOG; 2.0 outlook one sentence | Shipped in PR A |
 | `pkg-consume-override` | Per-dep OS/toolchain lookup; dual-stem 404 fallback | Shipped in PR B |
-| `pkg-os-apply` | Publish-time include \| omit; parsers accept both shapes | This PR (PR C) |
-| `pkg-os-docs` | Builder confidence; when omit/cross-OS is sane | This PR (PR C) |
+| `pkg-os-apply` | Publish-time include \| omit; parsers accept both shapes | Landing in [#245](https://github.com/ja11sop/cuppa/pull/245) |
+| `pkg-os-docs` | Builder confidence; when omit/cross-OS is sane | Landing in [#245](https://github.com/ja11sop/cuppa/pull/245) |
 
 ## Implementation PRs
 
@@ -128,7 +128,7 @@ Publish emits **one** stem (`include` or `omit`). Dual-try is **consume-only**. 
 
 **PR B** (`minor`) — consume overrides + dual-stem lookup. **Shipped.**
 
-**PR C** (`minor`) — package OS omit at publish; consume accepts both stem shapes. **This PR.**
+**PR C** (`minor`) — package OS omit at publish; consume accepts both stem shapes. **[#245](https://github.com/ja11sop/cuppa/pull/245).**
 
 ## Refusal rules
 

--- a/design/plans/build-and-package-identity.md
+++ b/design/plans/build-and-package-identity.md
@@ -2,7 +2,7 @@
 
 - **Status:** in progress
 - **Related:** [`ROADMAP.md`](../../ROADMAP.md) — `tc-identity-coarsen`; original point-release problem [`ignore-toolchain-point-release.md`](ignore-toolchain-point-release.md); package stems [`cuppa/package_managers/gitlab.py`](../../cuppa/package_managers/gitlab.py); layout [`cuppa/core/build_layout.py`](../../cuppa/core/build_layout.py) / [`cuppa/construct.py`](../../cuppa/construct.py); global conf [`cuppa/configure.py`](../../cuppa/configure.py)
-- **Updated:** 2026-09-01
+- **Updated:** 2026-09-02
 - **Impact:** minor — new identity policy and GitLab lookup overrides; existing globals grandfather `full`
 
 This document is the **settled product shape** for 1.9. Point-release encoding, vocabulary, and code hooks stay in [`ignore-toolchain-point-release.md`](ignore-toolchain-point-release.md); do not duplicate that problem statement here.
@@ -75,7 +75,7 @@ Notes:
 |----------|--------|
 | Values | `include` (default) \| `omit` |
 | When chosen | **At package build/publish time** when the builder is confident the artefact is not OS-scoped (or consumers will override OS on lookup) |
-| CLI / config | `--package-gitlab-os-identity=` / `package_gitlab_os_identity=` (and/or `PublishPackage` argument — settle in PR C) |
+| CLI / config | `--package-gitlab-os-identity=` / `package_gitlab_os_identity=` in `cuppa.run` / `configure.conf` (no `PublishPackage` constructor argument in v1) |
 | Omit stem | `{package}_{tool_variant}` (no empty OS segment) |
 
 **Often workable:** ABI-stable static lib / headers; controlled fleets; ubuntu↔debian via **explicit** consume override; Windows/macOS already coarse.
@@ -94,18 +94,19 @@ names and future top-level option families:
 | `--package-gitlab-os-override-<name>=<id>` | Force OS segment for one dependency (e.g. `debian` while host is `ubuntu`) |
 | `--package-gitlab-toolchain-override-<name>=<token>` | Force toolchain token for one dependency (e.g. `gcc152` or `gcc15`) |
 
-Dual-lookup during toolchain transition: if the preferred stem 404s, try the other toolchain
-identity (full vs major) before failing — on by default
-(`--package-gitlab-identity-fallback=on|off`, default `on`).
+Dual-lookup during toolchain and OS-shape transition: if the preferred stem 404s, try the other
+toolchain identity (full vs major) with the same OS encoding, then the other OS encoding
+(include vs omit) — on by default (`--package-gitlab-identity-fallback=on|off`, default `on`).
 
 **Resolution order:**
 
-1. Explicit per-dependency toolchain / OS override (then project-wide OS override if set)
-2. Stem from current effective toolchain identity + host OS (or omitted OS if that is the published shape)
-3. Fallback: alternate toolchain token (full ↔ major) with same OS choice
-4. Fail listing stems tried
+1. Explicit per-dependency toolchain / OS override (then project-wide OS override if set). An OS override always uses the **include** shape.
+2. Stem from current effective toolchain identity + preferred OS encoding (`--package-gitlab-os-identity`, default include / host OS)
+3. Fallback: alternate toolchain token (full ↔ major) with the same OS encoding
+4. Fallback: the other OS encoding (include ↔ omit) with the same toolchain tokens
+5. Fail listing stems tried
 
-Publish emits **one** stem. Dual-try is **consume-only**. Success is an ABI bet the project owns.
+Publish emits **one** stem (`include` or `omit`). Dual-try is **consume-only**. Success is an ABI bet the project owns. No `PublishPackage` constructor argument in v1.
 
 ## Work slices
 
@@ -117,17 +118,17 @@ Publish emits **one** stem. Dual-try is **consume-only**. Success is an ABI bet 
 | `tc-id-config-migrate` | Absent `~/.cuppaconfig` → create `major`; existing missing key → backfill `full` | Shipped in PR A |
 | `tc-id-tests` | Unit + integration: full vs major; conf cases | Shipped in PR A |
 | `tc-id-docs` | Toolchains + Packages; CHANGELOG; 2.0 outlook one sentence | Shipped in PR A |
-| `pkg-consume-override` | Per-dep OS/toolchain lookup; dual-stem 404 fallback | This PR (PR B) |
-| `pkg-os-apply` | Publish-time include \| omit; parsers accept both shapes | After consume overrides |
-| `pkg-os-docs` | Builder confidence; when omit/cross-OS is sane | Antora |
+| `pkg-consume-override` | Per-dep OS/toolchain lookup; dual-stem 404 fallback | Shipped in PR B |
+| `pkg-os-apply` | Publish-time include \| omit; parsers accept both shapes | This PR (PR C) |
+| `pkg-os-docs` | Builder confidence; when omit/cross-OS is sane | This PR (PR C) |
 
 ## Implementation PRs
 
 **PR A** (`minor`) — toolchain identity + global config migration (primary win). **Shipped.**
 
-**PR B** (`minor`) — consume overrides + dual-stem lookup. **This PR.**
+**PR B** (`minor`) — consume overrides + dual-stem lookup. **Shipped.**
 
-**PR C** (`minor`) — package OS omit at publish; align with OS override from B.
+**PR C** (`minor`) — package OS omit at publish; consume accepts both stem shapes. **This PR.**
 
 ## Refusal rules
 
@@ -160,3 +161,11 @@ Publish emits **one** stem. Dual-try is **consume-only**. Success is an ABI bet 
 4. Failure messages list every stem attempted.
 5. `--package-gitlab-identity-fallback=off` disables dual-try.
 6. Publish still emits a single stem.
+
+## Acceptance (PR C)
+
+1. `--package-gitlab-os-identity=include` (default) publishes `{package}_{os}_{tool}`.
+2. `--package-gitlab-os-identity=omit` publishes `{package}_{tool}` with no empty OS segment.
+3. Consume prefers that encoding; with fallback on, a `404` also tries the other encoding.
+4. An explicit OS override never looks up an omit stem.
+5. Docs: omit is a builder ABI bet, not the 1.x default.

--- a/docs/modules/ROOT/pages/cli/dependencies-and-develop.adoc
+++ b/docs/modules/ROOT/pages/cli/dependencies-and-develop.adoc
@@ -114,8 +114,10 @@ also registers this family:
 
 == Package lookup (all GitLab packages)
 
-These flags apply to consume, not publish. A `404` on the preferred stem retries the other
-toolchain identity (full vs major) unless fallback is off. See
+These flags apply to GitLab generic archives. Lookup overrides do not change published stems.
+`--package-gitlab-os-identity` does: it selects the stem shape used at **publish** and as the
+preferred **lookup** shape. A `404` on the preferred stem retries the other toolchain identity
+and the other OS encoding unless fallback is off. See
 xref:dependencies/gitlab.adoc#consume-overrides[GitLab lookup overrides].
 
 [cols="3,4"]
@@ -126,6 +128,7 @@ xref:dependencies/gitlab.adoc#consume-overrides[GitLab lookup overrides].
 | `--package-gitlab-os-override-<name>=ID` | OS segment for one named dependency; takes precedence over the project-wide override
 | `--package-gitlab-toolchain-override-<name>=TOKEN` | Toolchain token for one named dependency (`gcc152` or `gcc15`)
 | `--package-gitlab-identity-fallback=on\|off` | Dual-stem `404` retry (default `on`)
+| `--package-gitlab-os-identity=include\|omit` | Include the OS id in the stem (default) or omit it
 |===
 
 Prefer `GITLAB_REGISTRY_TOKEN` or `CI_JOB_TOKEN` when one credential serves the registry. The

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -90,15 +90,18 @@ publishes. Coarsening means you treat 15.2 and 15.3 objects as interchangeable f
 xref:toolchains/overview.adoc#toolchain-identity[Toolchains overview] has the layout examples.
 
 [#package-consume-identity]
-=== GitLab package lookup (`package_gitlab_os_override`, `package_gitlab_identity_fallback`)
+=== GitLab package lookup (`package_gitlab_os_override`, `package_gitlab_identity_fallback`, `package_gitlab_os_identity`)
 
 `--package-gitlab-os-override=` forces the OS segment used when **fetching** GitLab generic
-archives. `--package-gitlab-identity-fallback=on|off` controls whether a missing preferred stem
-(`404`) retries the other toolchain identity (full vs major). Default is `on`. Neither flag
-changes published stems. Per-package `--package-gitlab-os-override-<name>=` and
-`--package-gitlab-toolchain-override-<name>=` win over the project OS override. Keys in
-`configure.conf` / `cuppa.run` `default_options` are `package_gitlab_os_override` and
-`package_gitlab_identity_fallback`.
+archives. `--package-gitlab-os-identity=include|omit` selects whether stems include that OS id
+(default `include`). The same flag is used at **publish** and as the preferred consume shape.
+`--package-gitlab-identity-fallback=on|off` controls whether a missing preferred stem (`404`)
+retries the other toolchain identity (full vs major) and the other OS encoding. Default is `on`.
+Lookup overrides do not rename published stems; `os-identity` does. Per-package
+`--package-gitlab-os-override-<name>=` and `--package-gitlab-toolchain-override-<name>=` win over
+the project OS override. Keys in `configure.conf` / `cuppa.run` `default_options` are
+`package_gitlab_os_override`, `package_gitlab_identity_fallback`, and
+`package_gitlab_os_identity`.
 
 See xref:dependencies/gitlab.adoc#consume-overrides[GitLab lookup overrides].
 

--- a/docs/modules/ROOT/pages/dependencies/gitlab.adoc
+++ b/docs/modules/ROOT/pages/dependencies/gitlab.adoc
@@ -25,15 +25,20 @@ To **publish** a Cuppa-built library to the same registry, see
 xref:packages.adoc[Publishing packages].
 Archive stems include `toolchain.package_name()`, so `--toolchain-identity=major` looks for
 `gcc15_…` rather than `gcc153_…` unless you keep `full`. If the preferred stem is missing
-(`404`), Cuppa tries the other identity (full vs major) with the same OS before failing, and
-logs every stem it attempted. Disable that with
+(`404`), Cuppa tries the other identity (full vs major) and the other OS encoding
+(include vs omit) before failing, and logs every stem it attempted. Disable that with
 `--package-gitlab-identity-fallback=off`. Publish still emits one stem.
+
+Publish with `--package-gitlab-os-identity=omit` writes `{package}_{tool_variant}` (no OS
+segment). Consume prefers that shape when the same flag is set, and with fallback on also
+tries the include form after a `404`. An explicit `--package-gitlab-os-override` always
+looks up the include shape for that OS id.
 
 [#consume-overrides]
 == Lookup overrides
 
-Host identity does not have to match the archive you fetch. These options change **lookup** only;
-they do not rename what `env.PublishPackage` writes.
+Host identity does not have to match the archive you fetch. OS and toolchain overrides change
+**lookup** only. `--package-gitlab-os-identity` also changes what `env.PublishPackage` writes.
 
 [cols="3,7"]
 |===
@@ -42,17 +47,19 @@ they do not rename what `env.PublishPackage` writes.
 | `--package-gitlab-os-override=<id>` | Force the OS segment for every GitLab package
 | `--package-gitlab-os-override-<name>=<id>` | Force the OS segment for one named dependency (`debian` while the host is `ubuntu`)
 | `--package-gitlab-toolchain-override-<name>=<token>` | Force the toolchain token for one named dependency (`gcc152` or `gcc15`)
-| `--package-gitlab-identity-fallback=on\|off` | Try the other toolchain identity after a `404` (default `on`)
+| `--package-gitlab-identity-fallback=on\|off` | After a `404`, try the other toolchain identity and the other OS encoding (include vs omit). Default `on`
+| `--package-gitlab-os-identity=include\|omit` | Preferred stem shape: include OS id (default) or omit it
 |===
 
 Resolution order is: explicit per-package OS and toolchain overrides (then the project-wide OS
-override), then the current toolchain identity plus host OS, then the alternate full vs major
-token. Success is an ABI bet the project owns — Cuppa does not treat Debian archives as
-equivalent to Ubuntu ones unless you ask for that stem.
+override), then the current toolchain identity plus the preferred OS encoding (host OS, or omit),
+then the alternate full vs major token with that encoding, then the other OS encoding. Success is
+an ABI bet the project owns — Cuppa does not treat Debian archives as equivalent to Ubuntu ones
+unless you ask for that stem.
 
 xref:cli/dependencies-and-develop.adoc[Dependencies and develop] lists the flags.
 xref:toolchains/overview.adoc#toolchain-identity[Build and package identity] covers layout
-identity. OS omit at **publish** time is a later slice.
+identity. Publishing with omit is documented in xref:packages.adoc[Publishing packages].
 
 [#boost-package]
 == Boost package

--- a/docs/modules/ROOT/pages/integration-tests.adoc
+++ b/docs/modules/ROOT/pages/integration-tests.adoc
@@ -133,7 +133,7 @@ cuppa.run(default_variants=['dbg'])
 | `--list-available-reports`, canonical `_artefacts/` collate wiring
 | xref:integration/test-available-reports.adoc[]
 
-| `PublishPackage`, `InstallPackage` (registration only)
+| `PublishPackage`, `InstallPackage` (registration); GitLab archive OS include vs omit (no registry upload)
 | xref:integration/test-packages.adoc[]
 
 | `GenerateHtmlTestReport`, `CollateTestReportIndex`, `GenerateBittenReport`
@@ -142,4 +142,4 @@ cuppa.run(default_variants=['dbg'])
 
 === Deferred
 
-Full offline publish/install E2E against a live GitLab registry remains deferred (see xref:integration/test-packages.adoc[]).
+Full consume/upload E2E against a live GitLab registry remains deferred (see xref:integration/test-packages.adoc[]). Local archive naming for `--package-gitlab-os-identity` is covered there.

--- a/docs/modules/ROOT/pages/integration/test-packages.adoc
+++ b/docs/modules/ROOT/pages/integration/test-packages.adoc
@@ -1,10 +1,14 @@
-= `test_packages` — `PublishPackage` / `InstallPackage` registration
+= `test_packages` — `PublishPackage` / `InstallPackage` and GitLab archive names
 :description: Cuppa integration test documentation for test_packages
 
 
 == What is tested
 
-Package methods are registered on the environment. Full offline publish/install E2E against a live GitLab registry is deferred.
+* Package methods are registered on the environment.
+* `GitlabPackagePublisher` stages a local archive (no `--publish-package`, so no registry
+  upload). Default stems include the host OS id; `--package-gitlab-os-identity=omit` drops it.
+
+Full consume/upload E2E against a live GitLab registry is still deferred.
 
 == Generated files
 
@@ -17,7 +21,7 @@ import cuppa
 cuppa.run(default_variants=['dbg'])
 ----
 
-=== `sconscript`
+=== Registration `sconscript`
 
 [source,python]
 ----
@@ -29,16 +33,39 @@ assert callable(env.InstallPackage)
 env.BuildTest('hello_test', 'tests/hello_test.cpp')
 ----
 
-== Command
+=== Publish `sconscript`
+
+[source,python]
+----
+Import('env')
+from cuppa.package_managers.gitlab import GitlabPackagePublisher
+env.AppendUnique(CPPPATH=['#/include'])
+lib = env.BuildStaticLib('widget', 'src/hello.cpp')
+publisher = GitlabPackagePublisher(
+    env,
+    source_include_dir='#/include',
+    source_lib_dir=env['abs_final_dir'],
+    registry='https://gitlab.example/api/v4/projects/1',
+    package='widget',
+    version='1.0.0',
+)
+env.PublishPackage(lib, publisher)
+----
+
+== Commands
 
 [source,sh]
 ----
 cuppa -D --offline --toolchains=gcc --dbg --test
+cuppa -D --offline --toolchains=gcc --dbg
+cuppa -D --offline --toolchains=gcc --dbg --package-gitlab-os-identity=omit
 ----
 
 == Expectations
 
-Sconscript asserts pass; exit 0.
+* Registration sconscript asserts pass; exit 0.
+* Default publish writes one `widget_<os>_…` archive under `_build/` (`.tar.gz` or `.zip`).
+* With `omit`, that archive does not use the `widget_<os>_` prefix.
 
 '''
 

--- a/docs/modules/ROOT/pages/packages.adoc
+++ b/docs/modules/ROOT/pages/packages.adoc
@@ -19,7 +19,12 @@ xref:toolchains/overview.adoc#toolchain-identity[Build and package identity]). S
 does not rename archives already in a registry; republish or use consume-side lookup
 (`--package-gitlab-toolchain-override-<name>=`,
 `--package-gitlab-identity-fallback`) described in
-xref:dependencies/gitlab.adoc#consume-overrides[GitLab lookup overrides]. When staged headers and libs are not newer than the
+xref:dependencies/gitlab.adoc#consume-overrides[GitLab lookup overrides].
+`--package-gitlab-os-identity=include|omit` (default `include`) controls whether the
+published basename includes the OS id (`widget_debian_gcc15_…`) or omits it
+(`widget_gcc15_…`). Omit is an ABI bet that the artefact is not OS-scoped; it is not
+the product default. Consume prefers the same encoding when the flag is set, and with
+fallback on also tries the other shape after a `404`. When staged headers and libs are not newer than the
 existing archive, cuppa skips recreating the tarball — so a follow-up ``cuppa --rel --publish-package`` can
 upload without re-tarring multi-gigabyte trees.
 Add `--publish-package` to upload it to the GitLab generic registry.

--- a/docs/modules/ROOT/pages/toolchains/overview.adoc
+++ b/docs/modules/ROOT/pages/toolchains/overview.adoc
@@ -61,8 +61,9 @@ default; 1.x does not change existing global files that already store `full`.
 If a published archive uses a different OS or identity than this machine, consume overrides
 select the stem to download (`--package-gitlab-os-override[-<name>]=`,
 `--package-gitlab-toolchain-override-<name>=`) and, on `404`, the other full vs major token
-(`--package-gitlab-identity-fallback`, default on). That is lookup, not a claim that two
-distros are the same ABI. See
+and the other OS encoding (`--package-gitlab-identity-fallback`, default on).
+`--package-gitlab-os-identity=omit` publishes and prefers `{package}_{tool}` stems. That is
+lookup or an explicit publish bet, not a claim that two distros are the same ABI. See
 xref:dependencies/gitlab.adoc#consume-overrides[GitLab lookup overrides].
 
 See xref:configuration.adoc#toolchain-identity[Configuration] and

--- a/tests/integration/methods/test_packages.py
+++ b/tests/integration/methods/test_packages.py
@@ -1,13 +1,41 @@
-import logging
-
 import pytest
 
+from cuppa.package_managers.gitlab import os_release_id
 from tests.helpers.cuppa_runner import assert_success, run_cuppa
 from tests.helpers.project import copy_dummy_project, write_sconstruct, write_sconscript
 
 
 pytestmark = pytest.mark.integration
-logger = logging.getLogger(__name__)
+
+
+_PUBLISH_SCONSCRIPT = """\
+Import('env')
+from cuppa.package_managers.gitlab import GitlabPackagePublisher
+env.AppendUnique(CPPPATH=['#/include'])
+lib = env.BuildStaticLib('widget', 'src/hello.cpp')
+publisher = GitlabPackagePublisher(
+    env,
+    source_include_dir='#/include',
+    source_lib_dir=env['abs_final_dir'],
+    registry='https://gitlab.example/api/v4/projects/1',
+    package='widget',
+    version='1.0.0',
+)
+env.PublishPackage(lib, publisher)
+"""
+
+
+def _widget_archives(project):
+    names = []
+    for path in project.rglob("*"):
+        if not path.is_file():
+            continue
+        name = path.name
+        if name.startswith("widget_") and (
+            name.endswith(".tar.gz") or name.endswith(".zip")
+        ):
+            names.append(name)
+    return sorted(names)
 
 
 def test_package_methods_are_registered(tmp_path):
@@ -28,4 +56,28 @@ def test_package_methods_are_registered(tmp_path):
     )
     result = run_cuppa(project, "--dbg", "--test")
     assert_success(result)
-    logger.info("PublishPackage/InstallPackage registered on env (offline registry E2E deferred)")
+
+
+def test_gitlab_publish_archive_includes_os_by_default(tmp_path):
+    project = copy_dummy_project(tmp_path)
+    write_sconstruct(project)
+    write_sconscript(project, _PUBLISH_SCONSCRIPT)
+    result = run_cuppa(project, "--dbg")
+    assert_success(result)
+    names = _widget_archives(project)
+    assert len(names) == 1, names
+    os_id = os_release_id()
+    assert names[0].startswith("widget_{}_".format(os_id)), names[0]
+
+
+def test_gitlab_publish_archive_omits_os_when_requested(tmp_path):
+    project = copy_dummy_project(tmp_path)
+    write_sconstruct(project)
+    write_sconscript(project, _PUBLISH_SCONSCRIPT)
+    result = run_cuppa(project, "--dbg", "--package-gitlab-os-identity=omit")
+    assert_success(result)
+    names = _widget_archives(project)
+    assert len(names) == 1, names
+    os_id = os_release_id()
+    assert not names[0].startswith("widget_{}_".format(os_id)), names[0]
+    assert names[0].startswith("widget_"), names[0]

--- a/tests/unit/test_dependency_identity.py
+++ b/tests/unit/test_dependency_identity.py
@@ -741,6 +741,9 @@ def test_with_vcs_qualifier_appends_branch():
 def test_gitlab_archive_name():
     assert gitlab_archive_name( 'boost', 'gcc153_rel_x86_64_cxx2c', system='debian' ) == \
         'boost_debian_gcc153_rel_x86_64_cxx2c.tar.gz'
+    assert gitlab_archive_name(
+            'boost', 'gcc153_rel_x86_64_cxx2c', omit_os=True
+    ) == 'boost_gcc153_rel_x86_64_cxx2c.tar.gz'
 
 
 def test_gitlab_remote_for_version_substitutes_segment():

--- a/tests/unit/test_gitlab_naming.py
+++ b/tests/unit/test_gitlab_naming.py
@@ -58,6 +58,8 @@ def test_tool_variant_and_package_names(monkeypatch):
     )
     name = package_file_name(env, package="widget")
     assert name == "widget_debian_gcc15_rel_x86_64_cxx2c.tar.gz"
+    omit = package_file_name(env, package="widget", omit_os=True)
+    assert omit == "widget_gcc15_rel_x86_64_cxx2c.tar.gz"
     url = package_url(
         env,
         registry="https://gitlab.example/api/v4/projects/1",
@@ -149,7 +151,7 @@ def test_parse_pkg_config_runs_when_not_cleaning(tmp_path):
     assert "widget_kms" in dependency._env.parsed[0]
 
 
-def _lookup_env( package_name="gcc153", os_override=None, fallback=None ):
+def _lookup_env( package_name="gcc153", os_override=None, fallback=None, os_identity=None ):
     class Env( dict ):
         def get_option( self, key, default=None ):
             return self.get( key, default )
@@ -170,6 +172,8 @@ def _lookup_env( package_name="gcc153", os_override=None, fallback=None ):
         env["package_gitlab_os_override"] = os_override
     if fallback is not None:
         env["package_gitlab_identity_fallback"] = fallback
+    if os_identity is not None:
+        env["package_gitlab_os_identity"] = os_identity
     return env
 
 
@@ -187,6 +191,8 @@ def test_consume_stems_host_os_and_identity_pair( monkeypatch ):
     assert stems == [
         "widget_ubuntu_gcc153_rel_x86_64_cxx2c",
         "widget_ubuntu_gcc15_rel_x86_64_cxx2c",
+        "widget_gcc153_rel_x86_64_cxx2c",
+        "widget_gcc15_rel_x86_64_cxx2c",
     ]
 
 
@@ -223,6 +229,32 @@ def test_consume_stems_fallback_off( monkeypatch ):
     env = _lookup_env( fallback="off" )
     stems = consume_package_file_stems( env, package="widget", variant="rel" )
     assert stems == [ "widget_debian_gcc153_rel_x86_64_cxx2c" ]
+
+
+def test_consume_stems_omit_os_identity( monkeypatch ):
+    monkeypatch.setattr(
+        "cuppa.package_managers.gitlab.platform.freedesktop_os_release",
+        lambda: { "ID": "ubuntu" },
+    )
+    monkeypatch.setattr(
+        "cuppa.package_managers.gitlab.platform.system",
+        lambda: "Linux",
+    )
+    env = _lookup_env( os_identity="omit", fallback="off" )
+    stems = consume_package_file_stems( env, package="widget", variant="rel" )
+    assert stems == [ "widget_gcc153_rel_x86_64_cxx2c" ]
+    env = _lookup_env( os_identity="omit" )
+    stems = consume_package_file_stems( env, package="widget", variant="rel" )
+    assert stems == [
+        "widget_gcc153_rel_x86_64_cxx2c",
+        "widget_gcc15_rel_x86_64_cxx2c",
+        "widget_ubuntu_gcc153_rel_x86_64_cxx2c",
+        "widget_ubuntu_gcc15_rel_x86_64_cxx2c",
+    ]
+    env = _lookup_env( os_override="debian", os_identity="omit" )
+    stems = consume_package_file_stems( env, package="widget", variant="rel" )
+    assert stems[0] == "widget_debian_gcc153_rel_x86_64_cxx2c"
+    assert all( "_debian_" in stem for stem in stems )
 
 
 def test_download_first_skips_404_then_succeeds( tmp_path ):

--- a/tests/unit/test_gitlab_package_publisher.py
+++ b/tests/unit/test_gitlab_package_publisher.py
@@ -24,6 +24,31 @@ def _publisher_env( tmp_path, touched=None ):
     return Env()
 
 
+def test_lib_copy_ignore_names_skips_staging_and_archives():
+    ignored = gitlab.lib_copy_ignore_names(
+            [
+                    'libwidget.a',
+                    'modules',
+                    'widget',
+                    'widget_debian_gcc15_rel.tar.gz',
+                    'stamp.packaged',
+                    'stamp.published',
+                    'other.zip',
+            ],
+            'widget',
+            'widget_debian_gcc15_rel.tar.gz',
+    )
+    assert ignored == {
+            'modules',
+            'widget',
+            'widget_debian_gcc15_rel.tar.gz',
+            'stamp.packaged',
+            'stamp.published',
+            'other.zip',
+    }
+    assert 'libwidget.a' not in ignored
+
+
 def test_package_sidecar_id():
     path = "widget/2.0.0/widget_debian_gcc15_rel_x86_64_cxx2c.tar.gz"
     assert gitlab.package_sidecar_id( path, '.packaged' ) == (

--- a/tests/unit/test_toolchain_identity_policy.py
+++ b/tests/unit/test_toolchain_identity_policy.py
@@ -145,6 +145,15 @@ def test_coarsen_msvc_token():
     assert identity.coarsen_package_token( 'vc14' ) is None
 
 
+def test_package_os_identity_defaults_to_include():
+    assert identity.package_os_identity( {} ) == 'include'
+    env = SimpleNamespace(
+        get_option=lambda key, default=None:
+            ['omit'] if key == 'package_gitlab_os_identity' else None
+    )
+    assert identity.package_os_identity( env ) == 'omit'
+
+
 def test_package_identity_fallback_default_on():
     assert identity.package_identity_fallback_enabled( {} ) is True
     env = SimpleNamespace(
@@ -167,6 +176,10 @@ def test_package_consume_identity_registers_gitlab_namespace():
         (
             "--package-gitlab-identity-fallback",
             "package_gitlab_identity_fallback",
+        ),
+        (
+            "--package-gitlab-os-identity",
+            "package_gitlab_os_identity",
         ),
     ]
 


### PR DESCRIPTION
## Summary

Adds `--package-gitlab-os-identity=include|omit` (default include) so GitLab generic package archive stems can drop the OS id when the publisher is sure the artefact is not OS-scoped. Consume prefers that encoding; with identity fallback a 404 also tries the other OS encoding. Explicit OS overrides still use the include shape. Slice of #243; does not close that issue.

Local integration tests stage a GitLab archive without `--publish-package` and assert include vs omit filenames. The publisher now skips the package staging directory when copying `source_lib_dir` from `abs_final_dir`, matching the documented layout.

## Test plan

- [x] `venv/bin/flake8 cuppa` and `venv/bin/pylint -E cuppa`
- [x] `venv/bin/pytest -m unit`
- [x] `venv/bin/pytest -m integration` (includes `test_packages` include/omit archive names)
- [x] CI green on the matrix
