### PR TITLE
Stop Boost.Test runners extracting source Boost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Boost.Test runners prefer declared ``boost_package`` for version and patched-test
+  flags and no longer instantiate built-in source Boost first. That extract raced
+  under ``--parallel`` on a clean tree (``version.hpp`` missing mid-extract)
+  ([#248](https://github.com/ja11sop/cuppa/issues/248)). Source Boost location
+  lookup is serialised when the source factory *is* used.
 - Method-only ``CollateCxxProfilesIndex()`` rebinds the sconscript ``SPAWN``
   processor (and registers the env-ready hook even without
   ``--cxx-profiles-report``) so captured diagnostics keep the declaring

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -220,6 +220,7 @@ Design: [`design/plans/boost-updates.md`](design/plans/boost-updates.md).
 | Package archive / extract / version distinguish patched vs clean | No — same `boost` + `1.91` + tool variant |
 | Package `use_libs` passes `patched_test=` into library deps | No |
 | `boost_package.use_libs` does not invoke built-in source `boost` for ≥ 1.89 `system` drop | Yes ([#206](https://github.com/ja11sop/cuppa/issues/206) / [#207](https://github.com/ja11sop/cuppa/pull/207)) |
+| Boost.Test runners prefer `boost_package` and do not extract source Boost | This PR — [#248](https://github.com/ja11sop/cuppa/issues/248) |
 | Persist Boost latest for offline reuse (`boost_latest_version`, downloads-root–scoped) | Yes — [#171](https://github.com/ja11sop/cuppa/issues/171) / [#170](https://github.com/ja11sop/cuppa/pull/170); unpinned online scrape fix [#201](https://github.com/ja11sop/cuppa/issues/201); design [`boost-latest-persistence.md`](design/archive/boost-latest-persistence.md) |
 
 ### Planned / potential
@@ -230,6 +231,7 @@ Design: [`design/plans/boost-updates.md`](design/plans/boost-updates.md).
 | `boost-pkg-version` | Canonical version `{base}-patched` / `{base}-clean`; publisher + resolve + `package_id` | High | Visible qualifier; avoids extract collision |
 | `boost-pkg-compat` | Patched resolve falls back to unadorned `{base}`; clean does not | High | Existing registry tarballs are patched and unnamed |
 | `boost-pkg-use-libs` | Package `use_libs` passes `patched_test=` | High | Parity with source Boost |
+| `boost-test-runner-no-source` | Test runners prefer `boost_package`; no source extract on first test | High | This PR — [#248](https://github.com/ja11sop/cuppa/issues/248) |
 | `boost-pkg-docs` | Document opposite defaults (source clean / package patched) and identity | Medium | `packages.adoc` / `dependencies.adoc` |
 | `boost-pkg-flag` | Optional: `--boost-patched` selects among declared package flavours | Later | Not required if a project only consumes patched packages |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -232,6 +232,7 @@ Design: [`design/plans/boost-updates.md`](design/plans/boost-updates.md).
 | `boost-pkg-compat` | Patched resolve falls back to unadorned `{base}`; clean does not | High | Existing registry tarballs are patched and unnamed |
 | `boost-pkg-use-libs` | Package `use_libs` passes `patched_test=` | High | Parity with source Boost |
 | `boost-test-runner-no-source` | Test runners prefer `boost_package`; no source extract on first test | High | This PR — [#248](https://github.com/ja11sop/cuppa/issues/248) |
+| `boost-quince-package` | Quince uses session `boost_package` when declared | High | [#250](https://github.com/ja11sop/cuppa/issues/250); [`boost-updates.md`](design/plans/boost-updates.md) §Quince |
 | `boost-pkg-docs` | Document opposite defaults (source clean / package patched) and identity | Medium | `packages.adoc` / `dependencies.adoc` |
 | `boost-pkg-flag` | Optional: `--boost-patched` selects among declared package flavours | Later | Not required if a project only consumes patched packages |
 

--- a/cuppa/cpp/run_boost_test.py
+++ b/cuppa/cpp/run_boost_test.py
@@ -21,6 +21,7 @@ import cuppa.build_platform
 import cuppa.utility.preprocess
 from cuppa.output_processor import IncrementalSubProcess
 from cuppa.colourise import as_emphasised, as_highlighted, as_colour, start_colour, colour_reset, as_error, as_notice
+from cuppa.dependencies.boost.session import session_boost
 from cuppa.log import logger
 
 
@@ -709,15 +710,11 @@ class RunBoostTest:
         preprocess = self.default_preprocess
         argument_prefix = ""
 
-        if 'boost' in env['dependencies']:
-            boost_version = env['dependencies']['boost']( env ).numeric_version()
-            if env['dependencies']['boost']( env ).patched_test():
-                argument_prefix="boost.test."
-
-        if 'boost_package' in env['dependencies']:
-            boost_version = env['dependencies']['boost_package']( env ).numeric_version()
-            if env['dependencies']['boost_package']( env ).patched_test():
-                argument_prefix="boost.test."
+        boost = session_boost( env )
+        if boost is not None:
+            boost_version = boost.numeric_version()
+            if boost.patched_test():
+                argument_prefix = "boost.test."
 
         test_command = executable + " --{0}log_format=hrf --{0}log_level=all --{0}report_level=no".format( argument_prefix )
 

--- a/cuppa/cpp/run_patched_boost_test.py
+++ b/cuppa/cpp/run_patched_boost_test.py
@@ -22,6 +22,7 @@ import cuppa.build_platform
 import cuppa.utility.preprocess
 from cuppa.output_processor import IncrementalSubProcess
 from cuppa.colourise import as_emphasised, as_highlighted, as_colour, emphasise_time_by_digit, start_colour, colour_reset, as_notice
+from cuppa.dependencies.boost.session import session_boost
 from cuppa.log import logger
 
 
@@ -760,15 +761,11 @@ class RunPatchedBoostTest:
         preprocess = self.default_preprocess
         argument_prefix = ""
 
-        if 'boost' in env['dependencies']:
-            boost_version = env['dependencies']['boost']( env ).numeric_version()
-            if env['dependencies']['boost']( env ).patched_test():
-                argument_prefix="boost.test."
-
-        if 'boost_package' in env['dependencies']:
-            boost_version = env['dependencies']['boost_package']( env ).numeric_version()
-            if env['dependencies']['boost_package']( env ).patched_test():
-                argument_prefix="boost.test."
+        boost = session_boost( env )
+        if boost is not None:
+            boost_version = boost.numeric_version()
+            if boost.patched_test():
+                argument_prefix = "boost.test."
 
         test_command = executable + " --{0}log_format=hrf --{0}log_level=test_suite --{0}report_level=no".format( argument_prefix )
 

--- a/cuppa/dependencies/boost/session.py
+++ b/cuppa/dependencies/boost/session.py
@@ -1,0 +1,31 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   Session Boost (source vs package)
+#-------------------------------------------------------------------------------
+
+"""Resolve which Boost instance a session should use.
+
+``env['dependencies']`` is the *factory registry*. The built-in source ``boost``
+factory is always registered, even when the project only declared
+``boost_package``. Calling that factory extracts ``archives.boost.io``.
+"""
+
+
+def session_boost( env ):
+    """Return the Boost dependency for this env, or ``None``.
+
+    Prefer a declared ``boost_package`` so package-only builds never instantiate
+    source Boost. Fall back to the built-in ``boost`` factory.
+    """
+    factories = env.get( 'dependencies' ) or {}
+    package = factories.get( 'boost_package' )
+    if package is not None:
+        return package( env )
+    source = factories.get( 'boost' )
+    if source is not None:
+        return source( env )
+    return None

--- a/cuppa/dependencies/build_with_boost.py
+++ b/cuppa/dependencies/build_with_boost.py
@@ -8,6 +8,7 @@
 #   Boost
 #-------------------------------------------------------------------------------
 import os
+import threading
 
 # Cuppa Imports
 from cuppa.colourise import as_notice
@@ -25,6 +26,7 @@ class Boost(object):
 
     _name = 'boost'
     _cached_boost_locations = {}
+    _location_lock = threading.Lock()
 
     @classmethod
     def add_options( cls, add_option ):
@@ -74,11 +76,11 @@ class Boost(object):
 
         boost_id = boost_location_id( env )
 
-        if not boost_id in cls._cached_boost_locations:
-            logger.debug( "Adding boost [{}] to env".format( as_notice( str(boost_id) ) ) )
-            cls._cached_boost_locations[ boost_id ] = get_boost_location( env, boost_id[0], boost_id[1], boost_id[2], boost_id[3] )
-
-        location = cls._cached_boost_locations[ boost_id ]
+        with cls._location_lock:
+            if boost_id not in cls._cached_boost_locations:
+                logger.debug( "Adding boost [{}] to env".format( as_notice( str(boost_id) ) ) )
+                cls._cached_boost_locations[ boost_id ] = get_boost_location( env, boost_id[0], boost_id[1], boost_id[2], boost_id[3] )
+            location = cls._cached_boost_locations[ boost_id ]
 
         boost = None
         try:

--- a/design/README.md
+++ b/design/README.md
@@ -21,7 +21,7 @@ maintainer workflow evolved.
 
 | Document | Status | Subject |
 |----------|--------|---------|
-| [`plans/boost-updates.md`](plans/boost-updates.md) | proposal | Boost source vs GitLab `boost_package` identity; #206 `use_libs` fix; Quince selector gap |
+| [`plans/boost-updates.md`](plans/boost-updates.md) | proposal | Boost source vs GitLab `boost_package` identity; #206 `use_libs`; #248 test-runner `session_boost`; Quince selector gap |
 | [`plans/colourised-doc-samples.md`](plans/colourised-doc-samples.md) | proposal | Capture cuppa report output as semantic HTML for Antora samples and local preview |
 | [`plans/shiki-syntax-highlighting.md`](plans/shiki-syntax-highlighting.md) | proposal | Build-time Shiki for Antora listings; ANSI preview only — ROADMAP `doc-shiki` |
 | [`plans/coverage-performance.md`](plans/coverage-performance.md) | proposal | Where `--cov --test` time actually goes, what the A/B measurement ruled out, and the remaining suspects |

--- a/design/README.md
+++ b/design/README.md
@@ -21,7 +21,7 @@ maintainer workflow evolved.
 
 | Document | Status | Subject |
 |----------|--------|---------|
-| [`plans/boost-updates.md`](plans/boost-updates.md) | proposal | Boost source vs GitLab `boost_package` identity; #206 `use_libs`; #248 test-runner `session_boost`; Quince selector gap |
+| [`plans/boost-updates.md`](plans/boost-updates.md) | proposal | Boost source vs GitLab `boost_package` identity; #206 `use_libs`; #248 test-runner `session_boost`; #250 Quince session Boost |
 | [`plans/colourised-doc-samples.md`](plans/colourised-doc-samples.md) | proposal | Capture cuppa report output as semantic HTML for Antora samples and local preview |
 | [`plans/shiki-syntax-highlighting.md`](plans/shiki-syntax-highlighting.md) | proposal | Build-time Shiki for Antora listings; ANSI preview only — ROADMAP `doc-shiki` |
 | [`plans/coverage-performance.md`](plans/coverage-performance.md) | proposal | Where `--cov --test` time actually goes, what the A/B measurement ruled out, and the remaining suspects |

--- a/design/plans/boost-updates.md
+++ b/design/plans/boost-updates.md
@@ -1,8 +1,8 @@
 # Plan: Boost source and package updates
 
 - **Status:** proposal
-- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Boost source and packages; [#206](https://github.com/ja11sop/cuppa/issues/206) (package-only builds must not pull source Boost); storage listing/removal stays in [`removal-options.md`](removal-options.md); offline “latest” persistence is [`boost-latest-persistence.md`](../archive/boost-latest-persistence.md) (separate)
-- **Updated:** 2026-08-17
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Boost source and packages; [#206](https://github.com/ja11sop/cuppa/issues/206) (package-only builds must not pull source Boost); [#248](https://github.com/ja11sop/cuppa/issues/248) (test runners must not pull source Boost); storage listing/removal stays in [`removal-options.md`](removal-options.md); offline “latest” persistence is [`boost-latest-persistence.md`](../archive/boost-latest-persistence.md) (separate)
+- **Updated:** 2026-09-02
 
 Source `boost` (b2 / extract homes) and GitLab `boost_package` share Boost.Test patch semantics
 but not storage identity. This plan is the home for those Boost-specific follow-ups. List /
@@ -69,12 +69,16 @@ but also `BuildWith('quince')` (or quince in `default_dependencies`):
 This matches [#206](https://github.com/ja11sop/cuppa/issues/206) comment: Quince should be able to
 use the session’s Boost package instead of always building source libs.
 
-**Not fixed by `use_libs` patch alone.** Follow-on slice (issue TBD after #206 lands):
+**Not fixed by `use_libs` patch alone.** Follow-on slices:
 
-- Resolve “session Boost” once: prefer declared `boost_package` when present and compatible, else
-  fall back to built-in `boost`.
-- Quince `update_env` / `BoostStaticLibs` paths call that resolver instead of unconditional
-  `BuildWith('boost')`.
+- **Test runners ([#248](https://github.com/ja11sop/cuppa/issues/248)):** `RunBoostTest` /
+  `RunPatchedBoostTest` used to call the source `boost` factory whenever it was in the
+  registry (always), then overwrite flags from `boost_package`. Under `--parallel` that
+  started a source extract while another test read `version.hpp`. Runners now use
+  `session_boost()` (package first).
+- **Quince (issue TBD):** Resolve “session Boost” once: prefer declared `boost_package`
+  when present and compatible, else fall back to built-in `boost`. Quince `update_env` /
+  `BoostStaticLibs` paths call that resolver instead of unconditional `BuildWith('boost')`.
 - Optional: Quince links via `boost_package.use_libs()` for the small static set it needs, or a
   shared helper both Quince and sconscripts use.
 
@@ -225,6 +229,7 @@ Still in this plan if we touch source Boost again:
 | ID | Slice | Notes |
 |----|--------|-------|
 | `boost-use-libs-no-source` | `boost_package.use_libs` must not invoke source `boost` factory | **Shipped** — [#206](https://github.com/ja11sop/cuppa/issues/206) / [#207](https://github.com/ja11sop/cuppa/pull/207): pass package version to `remove_system_static_lib` |
+| `boost-test-runner-no-source` | Test runners must not instantiate source `boost` when `boost_package` is declared | **This PR** — [#248](https://github.com/ja11sop/cuppa/issues/248): `session_boost()`; serialise source location cache |
 | `boost-quince-package` | Quince uses session `boost_package` when declared | **Proposal** — see [§Quince and the selector gap](#boost-quince-selector-gap); file follow-on issue after #206 |
 | `boost-pkg-version` | Canonical `{base}-patched` / `{base}-clean`; strip suffix for numeric version; publisher + resolve + `package_id` | Core identity |
 | `boost-pkg-compat` | Patched resolve falls back to bare `{base}`; record actual version; no clean→bare fallback | Needed before flipping publishers |

--- a/design/plans/boost-updates.md
+++ b/design/plans/boost-updates.md
@@ -1,7 +1,7 @@
 # Plan: Boost source and package updates
 
 - **Status:** proposal
-- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Boost source and packages; [#206](https://github.com/ja11sop/cuppa/issues/206) (package-only builds must not pull source Boost); [#248](https://github.com/ja11sop/cuppa/issues/248) (test runners must not pull source Boost); storage listing/removal stays in [`removal-options.md`](removal-options.md); offline “latest” persistence is [`boost-latest-persistence.md`](../archive/boost-latest-persistence.md) (separate)
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Boost source and packages; [#206](https://github.com/ja11sop/cuppa/issues/206) (package-only builds must not pull source Boost); [#248](https://github.com/ja11sop/cuppa/issues/248) (test runners must not pull source Boost); [#250](https://github.com/ja11sop/cuppa/issues/250) (Quince must use session Boost); storage listing/removal stays in [`removal-options.md`](removal-options.md); offline “latest” persistence is [`boost-latest-persistence.md`](../archive/boost-latest-persistence.md) (separate)
 - **Updated:** 2026-09-02
 
 Source `boost` (b2 / extract homes) and GitLab `boost_package` share Boost.Test patch semantics
@@ -76,7 +76,7 @@ use the session’s Boost package instead of always building source libs.
   registry (always), then overwrite flags from `boost_package`. Under `--parallel` that
   started a source extract while another test read `version.hpp`. Runners now use
   `session_boost()` (package first).
-- **Quince (issue TBD):** Resolve “session Boost” once: prefer declared `boost_package`
+- **Quince ([#250](https://github.com/ja11sop/cuppa/issues/250)):** Resolve “session Boost” once: prefer declared `boost_package`
   when present and compatible, else fall back to built-in `boost`. Quince `update_env` /
   `BoostStaticLibs` paths call that resolver instead of unconditional `BuildWith('boost')`.
 - Optional: Quince links via `boost_package.use_libs()` for the small static set it needs, or a
@@ -230,7 +230,7 @@ Still in this plan if we touch source Boost again:
 |----|--------|-------|
 | `boost-use-libs-no-source` | `boost_package.use_libs` must not invoke source `boost` factory | **Shipped** — [#206](https://github.com/ja11sop/cuppa/issues/206) / [#207](https://github.com/ja11sop/cuppa/pull/207): pass package version to `remove_system_static_lib` |
 | `boost-test-runner-no-source` | Test runners must not instantiate source `boost` when `boost_package` is declared | **This PR** — [#248](https://github.com/ja11sop/cuppa/issues/248): `session_boost()`; serialise source location cache |
-| `boost-quince-package` | Quince uses session `boost_package` when declared | **Proposal** — see [§Quince and the selector gap](#boost-quince-selector-gap); file follow-on issue after #206 |
+| `boost-quince-package` | Quince uses session `boost_package` when declared | **Proposal** — [#250](https://github.com/ja11sop/cuppa/issues/250); [§Quince and the selector gap](#boost-quince-selector-gap) |
 | `boost-pkg-version` | Canonical `{base}-patched` / `{base}-clean`; strip suffix for numeric version; publisher + resolve + `package_id` | Core identity |
 | `boost-pkg-compat` | Patched resolve falls back to bare `{base}`; record actual version; no clean→bare fallback | Needed before flipping publishers |
 | `boost-pkg-use-libs` | Pass `patched_test=` from package `use_libs` | Small, can ship with identity or just before |

--- a/docs/modules/ROOT/pages/dependencies/builtins/boost.adoc
+++ b/docs/modules/ROOT/pages/dependencies/builtins/boost.adoc
@@ -4,7 +4,8 @@
 The built-in `boost` dependency builds or uses a Boost tree via Boost.Build (`b2`).
 It is registered as the name `boost`. For prebuilt Boost from a GitLab registry, use
 xref:dependencies/gitlab.adoc#boost-package[`boost_package`] instead — same `use_libs([...])`
-call shape, different supply chain.
+call shape, different supply chain. Boost.Test runners (`RunBoostTest`) also prefer
+`boost_package` when it is declared, so they do not extract source Boost on first test.
 
 == Options
 

--- a/docs/modules/ROOT/pages/dependencies/gitlab.adoc
+++ b/docs/modules/ROOT/pages/dependencies/gitlab.adoc
@@ -72,8 +72,9 @@ source.
 === Consuming in a project
 
 Declare the package in the ``sconstruct`` and list it in ``default_dependencies`` so every
-sconscript can ``BuildWith`` it. Set ``GITLAB_REGISTRY_TOKEN`` (or rely on ``CI_JOB_TOKEN`` in
-GitLab CI) for registry access.
+sconscript can ``BuildWith`` it. Boost.Test runners then take version and patched-test flags
+from this package and do not extract source Boost. Set ``GITLAB_REGISTRY_TOKEN`` (or rely on
+``CI_JOB_TOKEN`` in GitLab CI) for registry access.
 
 [source,python]
 ----

--- a/tests/unit/test_boost_session.py
+++ b/tests/unit/test_boost_session.py
@@ -1,0 +1,66 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+import pytest
+
+from cuppa.dependencies.boost.session import session_boost
+
+pytestmark = pytest.mark.unit
+
+
+class _BoostStub(object):
+    def __init__( self, name, version, patched ):
+        self.name = name
+        self._version = version
+        self._patched = patched
+
+    def numeric_version( self ):
+        return float( self._version )
+
+    def patched_test( self ):
+        return self._patched
+
+
+def test_session_boost_prefers_package_and_skips_source_factory():
+    calls = []
+
+    def source_factory( env ):
+        calls.append( 'boost' )
+        raise AssertionError( 'source boost factory must not run when boost_package is declared' )
+
+    def package_factory( env ):
+        calls.append( 'boost_package' )
+        return _BoostStub( 'boost_package', '1.92', True )
+
+    env = {
+        'dependencies': {
+            'boost': source_factory,
+            'boost_package': package_factory,
+        }
+    }
+
+    boost = session_boost( env )
+
+    assert calls == [ 'boost_package' ]
+    assert boost.numeric_version() == 1.92
+    assert boost.patched_test() is True
+
+
+def test_session_boost_uses_source_when_package_absent():
+    def source_factory( env ):
+        return _BoostStub( 'boost', '1.88', False )
+
+    env = { 'dependencies': { 'boost': source_factory } }
+
+    boost = session_boost( env )
+
+    assert boost.name == 'boost'
+    assert boost.numeric_version() == 1.88
+    assert boost.patched_test() is False
+
+
+def test_session_boost_returns_none_without_factories():
+    assert session_boost( {} ) is None
+    assert session_boost( { 'dependencies': {} } ) is None


### PR DESCRIPTION
## Summary

- Boost.Test runners (`RunBoostTest` / `RunPatchedBoostTest`) now resolve session Boost via `session_boost()`: prefer declared `boost_package` and do not instantiate the always-registered source `boost` factory. That extract raced under `--parallel` on a clean tree (`version.hpp` missing mid-extract) ([#248](https://github.com/ja11sop/cuppa/issues/248)).
- Source Boost location cache fill is serialised when the source factory is actually used.
- Quince follow-on is tracked as [#250](https://github.com/ja11sop/cuppa/issues/250).

## Test plan

- [x] Local `flake8 cuppa`, `pylint -E cuppa`, `pytest -m unit` (1375 passed)
- [x] Local `pytest -m integration` (176 passed, 4 skipped)
- [x] CI green on the matrix
