### PR TITLE
Mark Boost.Test session_boost as shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -220,7 +220,7 @@ Design: [`design/plans/boost-updates.md`](design/plans/boost-updates.md).
 | Package archive / extract / version distinguish patched vs clean | No — same `boost` + `1.91` + tool variant |
 | Package `use_libs` passes `patched_test=` into library deps | No |
 | `boost_package.use_libs` does not invoke built-in source `boost` for ≥ 1.89 `system` drop | Yes ([#206](https://github.com/ja11sop/cuppa/issues/206) / [#207](https://github.com/ja11sop/cuppa/pull/207)) |
-| Boost.Test runners prefer `boost_package` and do not extract source Boost | This PR — [#248](https://github.com/ja11sop/cuppa/issues/248) |
+| Boost.Test runners prefer `boost_package` and do not extract source Boost | Yes ([#249](https://github.com/ja11sop/cuppa/pull/249) / [#248](https://github.com/ja11sop/cuppa/issues/248)) |
 | Persist Boost latest for offline reuse (`boost_latest_version`, downloads-root–scoped) | Yes — [#171](https://github.com/ja11sop/cuppa/issues/171) / [#170](https://github.com/ja11sop/cuppa/pull/170); unpinned online scrape fix [#201](https://github.com/ja11sop/cuppa/issues/201); design [`boost-latest-persistence.md`](design/archive/boost-latest-persistence.md) |
 
 ### Planned / potential
@@ -231,7 +231,7 @@ Design: [`design/plans/boost-updates.md`](design/plans/boost-updates.md).
 | `boost-pkg-version` | Canonical version `{base}-patched` / `{base}-clean`; publisher + resolve + `package_id` | High | Visible qualifier; avoids extract collision |
 | `boost-pkg-compat` | Patched resolve falls back to unadorned `{base}`; clean does not | High | Existing registry tarballs are patched and unnamed |
 | `boost-pkg-use-libs` | Package `use_libs` passes `patched_test=` | High | Parity with source Boost |
-| `boost-test-runner-no-source` | Test runners prefer `boost_package`; no source extract on first test | High | This PR — [#248](https://github.com/ja11sop/cuppa/issues/248) |
+| `boost-test-runner-no-source` | Test runners prefer `boost_package`; no source extract on first test | High | **Shipped** [#249](https://github.com/ja11sop/cuppa/pull/249) / [#248](https://github.com/ja11sop/cuppa/issues/248) |
 | `boost-quince-package` | Quince uses session `boost_package` when declared | High | [#250](https://github.com/ja11sop/cuppa/issues/250); [`boost-updates.md`](design/plans/boost-updates.md) §Quince |
 | `boost-pkg-docs` | Document opposite defaults (source clean / package patched) and identity | Medium | `packages.adoc` / `dependencies.adoc` |
 | `boost-pkg-flag` | Optional: `--boost-patched` selects among declared package flavours | Later | Not required if a project only consumes patched packages |

--- a/design/README.md
+++ b/design/README.md
@@ -21,7 +21,7 @@ maintainer workflow evolved.
 
 | Document | Status | Subject |
 |----------|--------|---------|
-| [`plans/boost-updates.md`](plans/boost-updates.md) | proposal | Boost source vs GitLab `boost_package` identity; #206 `use_libs`; #248 test-runner `session_boost`; #250 Quince session Boost |
+| [`plans/boost-updates.md`](plans/boost-updates.md) | proposal | Boost source vs GitLab `boost_package` identity; #206 `use_libs`; #248/#249 test-runner `session_boost` shipped; #250 Quince session Boost |
 | [`plans/colourised-doc-samples.md`](plans/colourised-doc-samples.md) | proposal | Capture cuppa report output as semantic HTML for Antora samples and local preview |
 | [`plans/shiki-syntax-highlighting.md`](plans/shiki-syntax-highlighting.md) | proposal | Build-time Shiki for Antora listings; ANSI preview only — ROADMAP `doc-shiki` |
 | [`plans/coverage-performance.md`](plans/coverage-performance.md) | proposal | Where `--cov --test` time actually goes, what the A/B measurement ruled out, and the remaining suspects |

--- a/design/plans/boost-updates.md
+++ b/design/plans/boost-updates.md
@@ -71,7 +71,7 @@ use the session’s Boost package instead of always building source libs.
 
 **Not fixed by `use_libs` patch alone.** Follow-on slices:
 
-- **Test runners ([#248](https://github.com/ja11sop/cuppa/issues/248)):** `RunBoostTest` /
+- **Test runners ([#249](https://github.com/ja11sop/cuppa/pull/249) / [#248](https://github.com/ja11sop/cuppa/issues/248)):** `RunBoostTest` /
   `RunPatchedBoostTest` used to call the source `boost` factory whenever it was in the
   registry (always), then overwrite flags from `boost_package`. Under `--parallel` that
   started a source extract while another test read `version.hpp`. Runners now use
@@ -229,7 +229,7 @@ Still in this plan if we touch source Boost again:
 | ID | Slice | Notes |
 |----|--------|-------|
 | `boost-use-libs-no-source` | `boost_package.use_libs` must not invoke source `boost` factory | **Shipped** — [#206](https://github.com/ja11sop/cuppa/issues/206) / [#207](https://github.com/ja11sop/cuppa/pull/207): pass package version to `remove_system_static_lib` |
-| `boost-test-runner-no-source` | Test runners must not instantiate source `boost` when `boost_package` is declared | **This PR** — [#248](https://github.com/ja11sop/cuppa/issues/248): `session_boost()`; serialise source location cache |
+| `boost-test-runner-no-source` | Test runners must not instantiate source `boost` when `boost_package` is declared | **Shipped** — [#249](https://github.com/ja11sop/cuppa/pull/249) / [#248](https://github.com/ja11sop/cuppa/issues/248): `session_boost()`; serialise source location cache |
 | `boost-quince-package` | Quince uses session `boost_package` when declared | **Proposal** — [#250](https://github.com/ja11sop/cuppa/issues/250); [§Quince and the selector gap](#boost-quince-selector-gap) |
 | `boost-pkg-version` | Canonical `{base}-patched` / `{base}-clean`; strip suffix for numeric version; publisher + resolve + `package_id` | Core identity |
 | `boost-pkg-compat` | Patched resolve falls back to bare `{base}`; record actual version; no clean→bare fallback | Needed before flipping publishers |


### PR DESCRIPTION
## Summary

- Mark `boost-test-runner-no-source` as shipped after [#249](https://github.com/ja11sop/cuppa/pull/249) / [#248](https://github.com/ja11sop/cuppa/issues/248). Quince remains [#250](https://github.com/ja11sop/cuppa/issues/250).

## Test plan

- [x] Local `pytest -m unit` including `test_design_index`
- [x] CI green on the matrix
