### PR TITLE
Mark colourised doc samples as shipped

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -649,7 +649,7 @@ Release checklist: see `release.txt` (Actions **prepare** → merge → **publis
   `purge-gitlab`. Add `--preview` for `_docs_build/samples/*.preview.html`. Do not
   hand-edit committed fragments; regenerate. Keep the `.txt` sibling even when
   the page includes the `.html` (layout tests / `--raw-output`). Colour and
-  console-surface follow-ons: [`design/plans/colourised-doc-samples.md`](design/plans/colourised-doc-samples.md).
+  console-surface follow-ons: [`design/archive/colourised-doc-samples.md`](design/archive/colourised-doc-samples.md).
   Shell command listings (`sh`, `shell`, `bash`, `console`) share the console
   surface/chrome but keep normal listing line height; only report trees use
   `line-height: 1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a panel only slightly wider than its viewport commits to the nearer edge
   rather than oscillating between the two. Code and console type prefer a
   locally installed Hack, then the usual system mono stack — no webfont CDN
-  ([#252](https://github.com/ja11sop/cuppa/issues/252)).
+  ([#252](https://github.com/ja11sop/cuppa/issues/252),
+  [#253](https://github.com/ja11sop/cuppa/pull/253)).
 - Public docs site serves the latest release under ``/cuppa/latest/…`` (Antora
   ``latest_version_segment``) with master tip as prerelease ``next``; agent-oriented
   ``llms.txt`` / per-page Markdown / ``llms-full.txt`` are generated from the stable

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ Cycle opened with docs/site and Profiles follow-ons; identity slices A–C close
 | Profiles `remote` links + inventory error-limit | Shipped [#219](https://github.com/ja11sop/cuppa/pull/219), [#225](https://github.com/ja11sop/cuppa/pull/225) |
 | `--toolchain-identity` + GitLab consume/publish OS identity | Shipped [#242](https://github.com/ja11sop/cuppa/pull/242), [#244](https://github.com/ja11sop/cuppa/pull/244), [#245](https://github.com/ja11sop/cuppa/pull/245) |
 | Profiles collate scope filter | Shipped [#246](https://github.com/ja11sop/cuppa/pull/246) / [#205](https://github.com/ja11sop/cuppa/issues/205) |
-| Colourised Antora report samples | Ready to land — [#252](https://github.com/ja11sop/cuppa/issues/252); [`colourised-doc-samples.md`](design/plans/colourised-doc-samples.md) |
+| Colourised Antora report samples | Shipped [#253](https://github.com/ja11sop/cuppa/pull/253) / [#252](https://github.com/ja11sop/cuppa/issues/252); [`colourised-doc-samples.md`](design/archive/colourised-doc-samples.md) |
 
 **Still open this cycle (not started here):** GitLab CMake staging ([#209](https://github.com/ja11sop/cuppa/issues/209)); Boost package patched/clean identity ([`boost-updates.md`](design/plans/boost-updates.md)); artefact removal design ([#135](https://github.com/ja11sop/cuppa/issues/135)); console bundle (`--terse-output`, log hygiene, `cuppa --info`).
 
@@ -560,7 +560,7 @@ Design: [#213](https://github.com/ja11sop/cuppa/issues/213) (compile object path
 | `doc-site-release-default` | Public docs default to **`/latest/`** (released Cuppa), not `master` tip | High | Implementing on `feature/docs-latest-and-llms` with `doc-llms-txt` — [`docs-site-release-default.md`](design/plans/docs-site-release-default.md) |
 | `doc-llms-txt` | Agent Markdown: `llms.txt` + per-page MD + `llms-full.txt` from Antora HTML (Pandoc) | High | Same branch; corpus on `/latest/` — [`docs-llms-txt.md`](design/plans/docs-llms-txt.md) |
 | `doc-antora-ui` | Supplemental CSS polish (keep default Antora bundle) | Low | [`antora-ui-bundle.md`](design/plans/antora-ui-bundle.md); [#229](https://github.com/ja11sop/cuppa/issues/229); CSS pass in [#228](https://github.com/ja11sop/cuppa/pull/228); `ui-pin` still open; **1.9.0** docs-only |
-| `doc-output-samples` | Capture report output as semantic HTML for Antora and local preview | Low | **Ready to land** [#252](https://github.com/ja11sop/cuppa/issues/252); [`colourised-doc-samples.md`](design/plans/colourised-doc-samples.md); not Shiki `ansi` |
+| `doc-output-samples` | Capture report output as semantic HTML for Antora and local preview | Low | **Shipped** [#253](https://github.com/ja11sop/cuppa/pull/253) / [#252](https://github.com/ja11sop/cuppa/issues/252); [`colourised-doc-samples.md`](design/archive/colourised-doc-samples.md); not Shiki `ansi` |
 | `doc-shiki` | Build-time Shiki for `[source,…]` listings; optional ANSI preview | Low | [`shiki-syntax-highlighting.md`](design/plans/shiki-syntax-highlighting.md); **deferred past 1.9.0** — Phase A spike after UI chrome stable |
 | `doc-folder-layout` | Page folders mirroring nav (dependencies/, cxx-profiles/, toolchains/) | Low | **Shipped** — [`doc-folder-layout.md`](design/archive/doc-folder-layout.md) |
 | `doc-mermaid-theme` | Custom Mermaid theme matching site CSS | Low | After or with UI bundle |

--- a/design/README.md
+++ b/design/README.md
@@ -22,7 +22,6 @@ maintainer workflow evolved.
 | Document | Status | Subject |
 |----------|--------|---------|
 | [`plans/boost-updates.md`](plans/boost-updates.md) | proposal | Boost source vs GitLab `boost_package` identity; #206 `use_libs`; #248/#249 test-runner `session_boost` shipped; #250 Quince session Boost |
-| [`plans/colourised-doc-samples.md`](plans/colourised-doc-samples.md) | in progress | Ready to land — semantic HTML report samples + local preview — [#252](https://github.com/ja11sop/cuppa/issues/252) |
 | [`plans/shiki-syntax-highlighting.md`](plans/shiki-syntax-highlighting.md) | proposal | Build-time Shiki for Antora listings; ANSI preview only — ROADMAP `doc-shiki` |
 | [`plans/coverage-performance.md`](plans/coverage-performance.md) | proposal | Where `--cov --test` time actually goes, what the A/B measurement ruled out, and the remaining suspects |
 | [`plans/list-toolchains-verbose.md`](plans/list-toolchains-verbose.md) | in progress | Verbose `describe()` shipped ([#172](https://github.com/ja11sop/cuppa/issues/172) / [#170](https://github.com/ja11sop/cuppa/pull/170)); deferred table-driven init |
@@ -34,6 +33,7 @@ maintainer workflow evolved.
 | [`plans/cuppa-info.md`](plans/cuppa-info.md) | proposal | `cuppa --info`: version without sconstruct — ROADMAP `cli-info` |
 | [`plans/cxx-profiles-report.md`](plans/cxx-profiles-report.md) | in progress | `--cxx-profiles-report`: classify/dedupe Profiles diagnostics — ROADMAP `profiles-violation-report` — **`prof-report-method-semantics`** [#203](https://github.com/ja11sop/cuppa/pull/203); **`prof-report-remote-links`** [#219](https://github.com/ja11sop/cuppa/pull/219); **`prof-report-error-limit`** [#225](https://github.com/ja11sop/cuppa/pull/225); **`prof-report-scope-filter`** [#246](https://github.com/ja11sop/cuppa/pull/246) — **1.9.0**; full **F** blocked on [#135](https://github.com/ja11sop/cuppa/issues/135) |
 | [`archive/doc-folder-layout.md`](archive/doc-folder-layout.md) | shipped | Antora child pages under `dependencies/`, `cxx-profiles/`, `toolchains/` — ROADMAP `doc-folder-layout` |
+| [`archive/colourised-doc-samples.md`](archive/colourised-doc-samples.md) | shipped | Semantic HTML report samples + local preview — [#252](https://github.com/ja11sop/cuppa/issues/252) / [#253](https://github.com/ja11sop/cuppa/pull/253) |
 | [`archive/boost-latest-persistence.md`](archive/boost-latest-persistence.md) | shipped | Persist Boost latest (downloads-root–scoped conf); unpinned online scrape ([#201](https://github.com/ja11sop/cuppa/issues/201)); offline reuse — [#171](https://github.com/ja11sop/cuppa/issues/171) / [#170](https://github.com/ja11sop/cuppa/pull/170) |
 | [`archive/list-toolchains.md`](archive/list-toolchains.md) | shipped | `--list-toolchains` ruled tree (family→version→driver→names); list-deps leaf = Cuppa session name — [#172](https://github.com/ja11sop/cuppa/issues/172) / [#170](https://github.com/ja11sop/cuppa/pull/170) |
 | [`archive/download-progress.md`](archive/download-progress.md) | shipped | Shared HTTP/transfer progress (download, extract, Conan, git) — [#165](https://github.com/ja11sop/cuppa/pull/165) |

--- a/design/archive/colourised-doc-samples.md
+++ b/design/archive/colourised-doc-samples.md
@@ -1,7 +1,7 @@
 # Plan: colourised sample output for documentation and preview
 
-- **Status:** in progress
-- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Documentation tooling (`doc-output-samples`); [#252](https://github.com/ja11sop/cuppa/issues/252); follows build-report work in [`removal-options.md`](removal-options.md) Phase 2; syntax highlighting [`shiki-syntax-highlighting.md`](shiki-syntax-highlighting.md)
+- **Status:** shipped
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Documentation tooling (`doc-output-samples`); [#252](https://github.com/ja11sop/cuppa/issues/252) closed by [#253](https://github.com/ja11sop/cuppa/pull/253); follows build-report work in [`removal-options.md`](../plans/removal-options.md) Phase 2; syntax highlighting [`shiki-syntax-highlighting.md`](../plans/shiki-syntax-highlighting.md)
 - **Updated:** 2026-09-03
 
 Cuppa already produces rich, colour-coded reports (`--list-builds`, `--list-develop`,
@@ -59,7 +59,7 @@ ANSI conversion remains useful as an **optional preview mode** (“show me exact
 **canonical docs path** should be semantic HTML from the same `as_*` meanings the terminal uses.
 
 Do not fold that canonical path into Shiki's `ansi` language (see
-[`shiki-syntax-highlighting.md`](shiki-syntax-highlighting.md)). Shiki is the right highlighter for
+[`shiki-syntax-highlighting.md`](../plans/shiki-syntax-highlighting.md)). Shiki is the right highlighter for
 `[source,cpp]` / `[source,python]` and a convenient **renderer** for pinned ANSI previews; it does
 not know Cuppa's `as_error` / `as_info` vocabulary, and unpinned SGR still drifts with
 `CUPPA_CONSOLE_BACKGROUND` (ROADMAP `doc-ansi-only`).
@@ -193,7 +193,7 @@ python -m scripts.sample_output list-builds --format=ansi-html
 
 Force `TERM=xterm-256color`, `CUPPA_CONSOLE_BACKGROUND=dark` (or `light`), enable colour, capture
 stdout, convert with a pinned dependency, a minimal SGR→span mapper, or — once
-[`shiki-syntax-highlighting.md`](shiki-syntax-highlighting.md) Phase E exists — Shiki's `ansi`
+[`shiki-syntax-highlighting.md`](../plans/shiki-syntax-highlighting.md) Phase E exists — Shiki's `ansi`
 language. Document that this mode is for preview parity checks, not for committed docs samples,
 unless the env is fully pinned in the recipe.
 
@@ -251,10 +251,10 @@ considered doc fixes in an open release cycle.
 
 ### Progress snapshot (2026-09-03)
 
-This workstream is ready to land for [#252](https://github.com/ja11sop/cuppa/issues/252).
-Keep the plan here until the PR merges, then move it to `design/archive/` (the colouriser,
-console-token, and sample-recipe reasoning stays useful). Do not close #252 from the opening
-PR text unless that merge is meant to close the issue.
+This workstream shipped in [#253](https://github.com/ja11sop/cuppa/pull/253), which closed
+[#252](https://github.com/ja11sop/cuppa/issues/252). ANSI / Shiki preview remains on
+[`shiki-syntax-highlighting.md`](../plans/shiki-syntax-highlighting.md) (`doc-shiki`), not this
+plan.
 
 | Slice | Status |
 |-------|--------|
@@ -356,7 +356,7 @@ the viewport snaps flush only when already within 24px of the left or right edge
 during a gesture or from mid-scroll; reduced-motion users get an immediate snap and other users
 get native smooth motion. This is a general affordance for every wrapped listing, JSON sample,
 and `pre.cuppa-output` — not only colourised reports. It completes
-[`antora-ui-bundle.md`](antora-ui-bundle.md) `ui-scroll-snap`.
+[`antora-ui-bundle.md`](../plans/antora-ui-bundle.md) `ui-scroll-snap`.
 
 A sample only a little wider than its viewport puts both snap zones over the same ground, so the
 naive test made each edge qualify from the other and the panel oscillated left-right-left. Two
@@ -390,7 +390,7 @@ distance to the edge it rejected, so any starting position reaches its edge in a
    meaning-based (`cuppa-warning`); `.cuppa-output` uses `--cuppa-console-*` (including
    surface and ink). Admonition `--cuppa-warning` / `--cuppa-note` unchanged. Hues remain
    tunable against Colorama.
-5. **Tracking** — [#252](https://github.com/ja11sop/cuppa/issues/252).
+5. **Tracking** — [#252](https://github.com/ja11sop/cuppa/issues/252) closed by [#253](https://github.com/ja11sop/cuppa/pull/253).
 
 ---
 

--- a/design/plans/antora-ui-bundle.md
+++ b/design/plans/antora-ui-bundle.md
@@ -1,7 +1,7 @@
 # Plan: custom Antora UI bundle
 
 - **Status:** in progress
-- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Documentation tooling (`doc-antora-ui`); [#229](https://github.com/ja11sop/cuppa/issues/229); PR [#228](https://github.com/ja11sop/cuppa/pull/228); [`docs/playbook.yml`](../../docs/playbook.yml); supplemental UI [`docs/supplemental-ui/`](../../docs/supplemental-ui/); companions [`colourised-doc-samples.md`](colourised-doc-samples.md), [`shiki-syntax-highlighting.md`](shiki-syntax-highlighting.md)
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Documentation tooling (`doc-antora-ui`); [#229](https://github.com/ja11sop/cuppa/issues/229); PR [#228](https://github.com/ja11sop/cuppa/pull/228); [`docs/playbook.yml`](../../docs/playbook.yml); supplemental UI [`docs/supplemental-ui/`](../../docs/supplemental-ui/); companions [`colourised-doc-samples.md`](../archive/colourised-doc-samples.md), [`shiki-syntax-highlighting.md`](shiki-syntax-highlighting.md)
 - **Updated:** 2026-09-03
 - **Impact:** none — site presentation only (unless a UI change breaks the docs CI build)
 
@@ -14,7 +14,7 @@ admonitions read as stock Antora.
 A custom look (inspired by Boost docs or MkDocs Material **appearance**, not their stack) would:
 
 - Improve first impression for new users.
-- Give semantic report samples ([`colourised-doc-samples.md`](colourised-doc-samples.md)) a
+- Give semantic report samples ([`colourised-doc-samples.md`](../archive/colourised-doc-samples.md)) a
   coherent light-theme palette.
 - Host cuppa branding in header/footer (started in `supplemental-ui/` partials).
 
@@ -187,7 +187,7 @@ plan update.
 | `ui-pin` | **Next** — keep separate until a stable default-bundle artifact or vendoring route is selected |
 | `ui-ci` | Local Antora build passes; verify Pages CI on [#228](https://github.com/ja11sop/cuppa/pull/228) |
 | `ui-fork-spike` | Deferred — supplemental pass reaches nav/tables without a fork |
-| `ui-samples-tokens` | **Landed on #252** — console tokens and sample/shell surface; see `colourised-doc-samples.md` |
+| `ui-samples-tokens` | **Landed on #252** — console tokens and sample/shell surface; see [`colourised-doc-samples.md`](../archive/colourised-doc-samples.md) |
 | `ui-scroll-snap` | **Landed on #252** — 24px near-edge snap after pan/scroll settles; all wrapped wide views; immediate under reduced motion, otherwise native smooth scroll. A narrow overflow overlaps both snap zones, so an edge already reached is final and an overlap commits to the nearer edge, instead of oscillating between the two |
 
 ## Files
@@ -205,7 +205,7 @@ plan update.
 | `docs/supplemental-ui/js/cuppa-doc-palette.js` | Palette cycle across the four sheets + localStorage |
 | `docs/supplemental-ui/js/cuppa-scroll-panels.js` | Wide listing scroll affordances and click-drag pan |
 | `docs/modules/ROOT/pages/contributing.adoc` | Pin + preview notes when `ui-pin` lands |
-| `design/plans/colourised-doc-samples.md` | Sample classes follow `--cuppa-*` tokens |
+| `design/archive/colourised-doc-samples.md` | Sample classes follow `--cuppa-*` tokens |
 
 ## Refusal rules
 

--- a/design/plans/cxx-profiles-report.md
+++ b/design/plans/cxx-profiles-report.md
@@ -1657,7 +1657,7 @@ Silently register report producers when cuppa loads (no sconscript edit):
 | C++ Profiles | — | `--cxx-profiles-report` |
 
 Registry records: `kind`, default subdir, CLI flag, manifest kind string. Enables future
-`--list-available-reports` / doc samples in [`colourised-doc-samples.md`](colourised-doc-samples.md).
+`--list-available-reports` / doc samples in [`colourised-doc-samples.md`](../archive/colourised-doc-samples.md).
 
 ## Work slices
 
@@ -1714,7 +1714,7 @@ Target cycle: **1.8.0** for **`prof-report-parser` … `prof-report-manifest`** 
 - Antora: **done** on [#196](https://github.com/ja11sop/cuppa/pull/196) — `report-introduction.adoc` (feature entry), tab guides (`report-overview`, `report-by-rule`, `report-by-file`, `report-by-build`, `report-by-sconscript`, `report.adoc` index), hub updates in `cxx-profiles.adoc`; **Union Refs** / **Peak Refs** / **Build Refs** vocabulary aligned with UI.
 - Antora: **done** on [#197](https://github.com/ja11sop/cuppa/pull/197) — `report-introduction.adoc#sharing-anonymized` (*Sharing an inventory (anonymized JSON)*); hub regen table documents `--anonymized`.
 - Antora: **done** on [#203](https://github.com/ja11sop/cuppa/pull/203) — inventory mode on `cxx-profiles.adoc` and `report-introduction.adoc`; `integration/test-available-reports.adoc` drops manual `-i`.
-- Optional: sample HTML screenshot via [`colourised-doc-samples.md`](colourised-doc-samples.md) pipeline.
+- Optional: sample HTML screenshot via [`colourised-doc-samples.md`](../archive/colourised-doc-samples.md) pipeline.
 - [`archive/cxx-profiles.md`](../archive/cxx-profiles.md): link this plan in follow-ons (already
   cites dedupe/report in §2.3).
 - AGENTS.md consumer tip: `--cxx-profiles-report` one-liner next to coverage commands.

--- a/design/plans/native-toolchain-output.md
+++ b/design/plans/native-toolchain-output.md
@@ -35,7 +35,7 @@ not `--raw-output`, which also disables cuppa's progress wiring and other proces
 
 - Removing `ToolchainProcessor` or regex interpretors (default path stays cuppa-coloured).
 - Native colour for **cuppa-owned reports** (`--list-builds`, wipe trees, coverage summaries).
-- ANSI→HTML doc samples ([`colourised-doc-samples.md`](colourised-doc-samples.md) stays separate).
+- ANSI→HTML doc samples ([`colourised-doc-samples.md`](../archive/colourised-doc-samples.md) stays separate).
 - Guaranteeing native colour on every platform (TTY detection remains the toolchain's job).
 
 ## Settled vocabulary (decide before first PR)

--- a/design/plans/shiki-syntax-highlighting.md
+++ b/design/plans/shiki-syntax-highlighting.md
@@ -1,7 +1,7 @@
 # Plan: Shiki syntax highlighting for Antora
 
 - **Status:** proposal
-- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Documentation tooling (`doc-shiki`); companion [`colourised-doc-samples.md`](colourised-doc-samples.md); site chrome [`antora-ui-bundle.md`](antora-ui-bundle.md)
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Documentation tooling (`doc-shiki`); companion [`colourised-doc-samples.md`](../archive/colourised-doc-samples.md); site chrome [`antora-ui-bundle.md`](antora-ui-bundle.md)
 - **Updated:** 2026-08-25
 - **Impact:** none — docs build tooling only (unless a highlighter swap breaks the docs CI build)
 
@@ -10,7 +10,7 @@
 Source listings on the Antora site are still highlighted **in the browser** by the default UI's
 highlight.js. Shiki can highlight at **site build time**, so pages ship already-coloured HTML,
 line numbers become a first-class option, and a special `ansi` language can colour real terminal
-captures. That last point overlaps [`colourised-doc-samples.md`](colourised-doc-samples.md); this
+captures. That last point overlaps [`colourised-doc-samples.md`](../archive/colourised-doc-samples.md); this
 plan keeps the two jobs distinct.
 
 ---
@@ -59,7 +59,7 @@ Risks to plan around:
 
 **Non-goals**
 
-- Replacing [`colourised-doc-samples.md`](colourised-doc-samples.md) `HtmlColouriser` for Cuppa
+- Replacing [`colourised-doc-samples.md`](../archive/colourised-doc-samples.md) `HtmlColouriser` for Cuppa
   *owned* report samples.
 - Colourising arbitrary tool output Cuppa does not emit (except when an author pastes ANSI into
   an `ansi` listing).
@@ -185,7 +185,7 @@ later, deliberate docs-quality slice (`doc-shiki`).
 ### What Shiki does not solve
 
 Cuppa **report semantics** (`as_error`, `as_info`, judgement trees). That remains
-[`colourised-doc-samples.md`](colourised-doc-samples.md) (`HtmlColouriser` + `cuppa-*` classes).
+[`colourised-doc-samples.md`](../archive/colourised-doc-samples.md) (`HtmlColouriser` + `cuppa-*` classes).
 Shiki's `ansi` language is not a substitute for committed `--list-builds` samples (ROADMAP
 `doc-ansi-only`).
 
@@ -202,7 +202,7 @@ Shiki's `ansi` language is not a substitute for committed `--list-builds` sample
 
 | When | Action |
 |------|--------|
-| **1.9.0 (now)** | Ship Antora UI (`doc-antora-ui`); keep highlight.js; optional colourised **report** samples (`doc-output-samples`) if that slice is prioritised |
+| **1.9.0 (now)** | Ship Antora UI (`doc-antora-ui`); keep highlight.js; colourised **report** samples shipped (`doc-output-samples`, [#253](https://github.com/ja11sop/cuppa/pull/253)) |
 | **After 1.9.0** | Phase A spike only: local Shiki on 2–3 real pages (e.g. quickstart, a CLI page, one C++ snippet); compare readability and CSS effort |
 | **If spike wins clearly** | Phase B–D: migrate listings, disable highlight.js, align tokens with palettes |
 | **If spike is marginal** | Stay on highlight.js until line numbers or palette-aligned code blocks become a reader-facing goal |

--- a/design/plans/terse-build-output.md
+++ b/design/plans/terse-build-output.md
@@ -210,5 +210,5 @@ hook effort. Prefer terse Phase 1 over native output if scope is tight.
 
 ## Related
 
-- [`colourised-doc-samples.md`](colourised-doc-samples.md) — semantic HTML for reports, not live build log.
+- [`colourised-doc-samples.md`](../archive/colourised-doc-samples.md) — semantic HTML for reports, not live build log.
 - Scratchpad **stderr vs stdout** — validate before any global stream split.

--- a/docs/supplemental-ui/css/cuppa-output.css
+++ b/docs/supplemental-ui/css/cuppa-output.css
@@ -3,7 +3,7 @@
  *
  * Meaning classes follow Colouriser._start_colour (Colorama), via
  * --cuppa-console-* tokens. Admonition chrome (--cuppa-warning orange, …)
- * is not used here. See design/plans/colourised-doc-samples.md.
+ * is not used here. See design/archive/colourised-doc-samples.md.
  */
 
 .cuppa-output {


### PR DESCRIPTION
## Summary

- [#253](https://github.com/ja11sop/cuppa/pull/253) merged and closed [#252](https://github.com/ja11sop/cuppa/issues/252).
- Move `colourised-doc-samples.md` to `design/archive/`, mark it shipped, and update `ROADMAP.md`, `design/README.md`, and companion links.

## Test plan

- [x] `pytest -m unit` (1396 passed), including the design-index / changelog checks
- [x] CI green on the matrix
