### PR TITLE
Fix package staging for generated VariantDir library paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- GitLab and Conan package publishing stage a generated relative library
+  directory from its variant build path instead of unconditionally resolving
+  it through the nonexistent source-tree counterpart (``srcnode()``). This
+  restores clean parallel package builds whose libraries are assembled under
+  ``working/<package>/<version>/lib`` or a custom ``final_dir``. Both
+  publishers share ``cuppa.utility.scons_nodes.resolve_existing_node_path``
+  ([#255](https://github.com/ja11sop/cuppa/issues/255)).
 - Boost.Test runners prefer declared ``boost_package`` for version and patched-test
   flags and no longer instantiate built-in source Boost first. That extract raced
   under ``--parallel`` on a clean tree (``version.hpp`` missing mid-extract)

--- a/cuppa/package_managers/conan.py
+++ b/cuppa/package_managers/conan.py
@@ -30,6 +30,7 @@ from cuppa.build_with_conan import (
 )
 from cuppa.colourise import as_error, as_info, as_notice
 from cuppa.log import logger
+from cuppa.utility.scons_nodes import resolve_existing_node_path as _resolve_node_path
 
 
 _CONANFILE_TEMPLATE = '''\
@@ -172,13 +173,6 @@ def write_conan_profile( path, settings ):
     lines.append( '' )
     with open( path, 'w', encoding='utf-8' ) as handle:
         handle.write( '\n'.join( lines ) )
-    return path
-
-
-def _resolve_node_path( node ):
-    path = str( node )
-    if hasattr( node, 'srcnode' ):
-        path = str( node.srcnode() )
     return path
 
 

--- a/cuppa/package_managers/gitlab.py
+++ b/cuppa/package_managers/gitlab.py
@@ -21,13 +21,7 @@ import cuppa.core.storage_options
 
 from cuppa.log import logger, register_secret
 from cuppa.colourise import as_error, as_info, as_notice, as_info_label
-
-
-def _resolve_node_path( node ):
-    path = str( node )
-    if hasattr( node, 'srcnode' ):
-        path = str( node.srcnode() )
-    return path
+from cuppa.utility.scons_nodes import resolve_existing_node_path as _resolve_node_path
 
 
 def lib_copy_ignore_names( names, package_dir_name, package_file_name ):

--- a/cuppa/utility/scons_nodes.py
+++ b/cuppa/utility/scons_nodes.py
@@ -1,0 +1,43 @@
+
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   Resolve SCons nodes that live under VariantDir
+#-------------------------------------------------------------------------------
+
+"""Map a SCons node to a filesystem path that actually exists.
+
+A relative generated directory (for example ``boost/1.92/lib`` or a
+``BuildStaticLib(..., final_dir='package_lib')`` output) has ``str(node)``
+under the variant ``working/`` tree. ``node.srcnode()`` is the project-root
+counterpart, which often does not exist for build products.
+
+Package publishers must copy from the generated tree when it is present.
+Unconditionally using ``srcnode()`` is the usual failure mode under
+``--parallel`` package builds.
+"""
+
+import os
+
+
+def resolve_existing_node_path( node ):
+    """Return an existing generated node path, or its source-tree counterpart.
+
+    Preference:
+
+    1. ``str(node)`` when that path exists (variant / generated).
+    2. ``srcnode()`` when that path exists (headers / source tree).
+    3. ``str(node)`` otherwise, so missing-path errors name the generated side.
+    """
+    path = str( node )
+    if os.path.exists( path ):
+        return path
+    srcnode = getattr( node, 'srcnode', None )
+    if callable( srcnode ):
+        source_path = str( srcnode() )
+        if os.path.exists( source_path ):
+            return source_path
+    return path

--- a/docs/modules/ROOT/pages/integration-tests.adoc
+++ b/docs/modules/ROOT/pages/integration-tests.adoc
@@ -133,7 +133,7 @@ cuppa.run(default_variants=['dbg'])
 | `--list-available-reports`, canonical `_artefacts/` collate wiring
 | xref:integration/test-available-reports.adoc[]
 
-| `PublishPackage`, `InstallPackage` (registration); GitLab archive OS include vs omit (no registry upload)
+| `PublishPackage`, `InstallPackage` (registration); GitLab archive OS include vs omit; relative generated `source_lib_dir` under `--rel --parallel` (no registry upload)
 | xref:integration/test-packages.adoc[]
 
 | `GenerateHtmlTestReport`, `CollateTestReportIndex`, `GenerateBittenReport`

--- a/docs/modules/ROOT/pages/integration/test-conan.adoc
+++ b/docs/modules/ROOT/pages/integration/test-conan.adoc
@@ -11,6 +11,7 @@ Optional Conan 2 consumer support via `cuppa.conan_deps` / `cuppa.conan_dependen
 * **Pip plugin** — `examples/conan_fmt_plugin` installed via `pip install --no-user --target`; Cuppa discovers `fmt` through `cuppa.dependency.plugins` with only `default_dependencies=['fmt']`
 * **Offline miss** — empty Conan home + Cuppa `--offline` fails clearly when the package is not cached
 * **Publish round-trip** — `BuildStaticLib` + `ConanPackagePublisher` / `PublishPackage` (`export-pkg` only) into an isolated `CONAN_HOME`, then a second project consumes via `conan_deps` under `--offline`
+* **Publish relative generated lib dir** — `BuildStaticLib(..., final_dir='package_lib')` with `source_lib_dir='package_lib'` under `--rel --parallel`; consumer links the exported static lib under `--offline`
 * **Publish `conanfile=` + requires** — leaf package, then wrapper with hand-written recipe requiring the leaf; consumer builds against the wrapper under `--offline`
 * **Publish generated `requires=`** — same leaf/wrapper shape as above, but the wrapper uses the generated recipe's `requires=` (no `conanfile=`)
 * **Publish `shared=True`** — `BuildSharedLib` + `shared=True` export-pkg; consumer `BuildTest` exercises runtime library search paths
@@ -121,6 +122,7 @@ cuppa -D --dbg --test --show-test-output
 * Second offline pass after a successful install does not re-run `conan install`
 * Offline miss exits non-zero with a Conan-related error
 * Publish round-trip consumer binary prints `answer=42`
+* Relative generated lib-dir publish consumer binary also prints `answer=42`
 * Override+requires and generated-`requires=` consumers print `wrap=43`
 * Shared publish consumer test output contains `answer=42`
 * Modules/BMI publish (default and `source_modules_dir=`) consumer `math_app` exits 0

--- a/docs/modules/ROOT/pages/integration/test-packages.adoc
+++ b/docs/modules/ROOT/pages/integration/test-packages.adoc
@@ -7,6 +7,9 @@
 * Package methods are registered on the environment.
 * `GitlabPackagePublisher` stages a local archive (no `--publish-package`, so no registry
   upload). Default stems include the host OS id; `--package-gitlab-os-identity=omit` drops it.
+* Relative generated library dirs (`BuildStaticLib(..., final_dir='package_lib')` with
+  `source_lib_dir='package_lib'`) stage from the variant tree under `--rel --parallel`.
+  The archive contains the static library (not only a `.packaged` stamp).
 
 Full consume/upload E2E against a live GitLab registry is still deferred.
 
@@ -52,6 +55,31 @@ publisher = GitlabPackagePublisher(
 env.PublishPackage(lib, publisher)
 ----
 
+=== Relative generated lib dir `sconscript`
+
+SCons mirrors `package_lib` under the variant `working/` tree. The publisher must copy from that generated path, not `srcnode()` (which would be a missing project-root `package_lib/`).
+
+[source,python]
+----
+Import('env')
+from cuppa.package_managers.gitlab import GitlabPackagePublisher
+env.AppendUnique(CPPPATH=['#/include'])
+lib = env.BuildStaticLib(
+    'widget',
+    'src/hello.cpp',
+    final_dir='package_lib',
+)
+publisher = GitlabPackagePublisher(
+    env,
+    source_include_dir='#/include',
+    source_lib_dir='package_lib',
+    registry='https://gitlab.example/api/v4/projects/1',
+    package='widget',
+    version='1.0.0',
+)
+env.PublishPackage(lib, publisher)
+----
+
 == Commands
 
 [source,sh]
@@ -59,6 +87,7 @@ env.PublishPackage(lib, publisher)
 cuppa -D --offline --toolchains=gcc --dbg --test
 cuppa -D --offline --toolchains=gcc --dbg
 cuppa -D --offline --toolchains=gcc --dbg --package-gitlab-os-identity=omit
+cuppa -D --offline --toolchains=gcc --rel --parallel
 ----
 
 == Expectations
@@ -66,6 +95,7 @@ cuppa -D --offline --toolchains=gcc --dbg --package-gitlab-os-identity=omit
 * Registration sconscript asserts pass; exit 0.
 * Default publish writes one `widget_<os>_…` archive under `_build/` (`.tar.gz` or `.zip`).
 * With `omit`, that archive does not use the `widget_<os>_` prefix.
+* Relative `package_lib` publish under `--rel --parallel` writes the same archive shape and the tarball/zip contains `libwidget.a` (or `widget.lib` on Windows).
 
 '''
 

--- a/docs/modules/ROOT/pages/packages.adoc
+++ b/docs/modules/ROOT/pages/packages.adoc
@@ -30,6 +30,8 @@ upload without re-tarring multi-gigabyte trees.
 Add `--publish-package` to upload it to the GitLab generic registry.
 `env.InstallPackage(...)` installs a package into the local cuppa dependencies layout.
 
+Relative `source_include_dir` / `source_lib_dir` values are SCons nodes under the active variant directory. Cuppa copies from the generated path when it exists, and only falls back to `srcnode()` for a source-tree directory that is present. Always using `srcnode()` would look for a missing project-root copy such as `boost/1.92/lib` and fail the package step, especially under `--parallel`. Use `env['abs_final_dir']` when libraries already land in `final/`. The same resolution is used for Conan publishing (<<conan-package-publishing>>).
+
 Authentication for registry upload uses the same tokens as consume
 (`GITLAB_REGISTRY_TOKEN`, `CI_JOB_TOKEN`, `--<name>-gitlab-custom-token`).
 See xref:dependencies/gitlab.adoc[GitLab packages].
@@ -66,6 +68,8 @@ publisher = ConanPackagePublisher(
 
 env.PublishPackage(lib, publisher)
 ----
+
+`source_include_dir` / `source_lib_dir` (and `source_modules_dir` / `conanfile=`) use the same VariantDir path resolution as GitLab publishing above.
 
 Without `--publish-package`, Cuppa stages headers/libs, writes a minimal `conanfile.py` (unless `conanfile=` is set), and runs `conan export-pkg` into the local Conan cache (settings match the active toolchain and variant via the same mapping as `conan_deps`).
 

--- a/tests/integration/methods/test_conan.py
+++ b/tests/integration/methods/test_conan.py
@@ -596,6 +596,124 @@ def test_conan_publish_export_pkg_round_trip(tmp_path):
     assert "answer=42" in ran.stdout
 
 
+def test_conan_publish_generated_relative_lib_dir_round_trip(tmp_path):
+    """Relative final_dir / source_lib_dir must stage from the variant tree, not srcnode()."""
+    import os
+
+    conan = _require_conan()
+    conan_home = tmp_path / "conan_home"
+    conan_home.mkdir()
+    extra = {"CONAN_HOME": str(conan_home)}
+    detect = subprocess.run(
+        [conan, "profile", "detect", "--force"],
+        env={**os.environ, **extra},
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    if detect.returncode != 0:
+        pytest.fail("conan profile detect failed:\n{}".format(detect.stdout))
+
+    producer = tmp_path / "publisher"
+    producer.mkdir()
+    include = producer / "include" / "cuppa_var_mylib"
+    include.mkdir(parents=True)
+    (include / "answer.hpp").write_text(
+        "#pragma once\n"
+        "int cuppa_var_answer();\n",
+        encoding="utf-8",
+    )
+    (producer / "answer.cpp").write_text(
+        "#include <cuppa_var_mylib/answer.hpp>\n"
+        "int cuppa_var_answer() { return 42; }\n",
+        encoding="utf-8",
+    )
+    write_sconstruct(
+        producer,
+        body=(
+            "import cuppa\n"
+            "cuppa.run(default_variants=['rel'])\n"
+        ),
+    )
+    write_sconscript(
+        producer,
+        "Import('env')\n"
+        "from cuppa.package_managers.conan import ConanPackagePublisher\n"
+        "env.AppendUnique(INCPATH=['include'])\n"
+        "lib = env.BuildStaticLib(\n"
+        "    'cuppa_var_mylib', 'answer.cpp', final_dir='package_lib',\n"
+        ")\n"
+        "publisher = ConanPackagePublisher(\n"
+        "    env,\n"
+        "    name='cuppa_var_mylib',\n"
+        "    version='0.1.0',\n"
+        "    source_include_dir='include',\n"
+        "    source_lib_dir='package_lib',\n"
+        "    libs=['cuppa_var_mylib'],\n"
+        ")\n"
+        "env.PublishPackage(lib, publisher)\n",
+    )
+
+    produced = run_cuppa(
+        producer, "--rel", "--parallel", offline=True, timeout=300, extra_env=extra
+    )
+    assert_success(produced)
+    assert "exported to local cache" in produced.stdout or "export-pkg" in produced.stdout.lower()
+
+    consumer = tmp_path / "consumer"
+    consumer.mkdir()
+    (consumer / "conanfile.txt").write_text(
+        "[requires]\n"
+        "cuppa_var_mylib/0.1.0\n"
+        "\n"
+        "[generators]\n"
+        "SConsDeps\n"
+        "VirtualRunEnv\n",
+        encoding="utf-8",
+    )
+    (consumer / "hello.cpp").write_text(
+        "#include <cuppa_var_mylib/answer.hpp>\n"
+        "#include <cstdio>\n"
+        "int main() {\n"
+        "    std::printf(\"answer=%d\\n\", cuppa_var_answer());\n"
+        "    return cuppa_var_answer() == 42 ? 0 : 1;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    write_sconstruct(
+        consumer,
+        body=(
+            "import cuppa\n"
+            "Conan = cuppa.conan_deps(conanfile='conanfile.txt')\n"
+            "cuppa.run(\n"
+            "    default_variants=['rel'],\n"
+            "    dependencies=[Conan],\n"
+            "    default_dependencies=['conan'],\n"
+            ")\n"
+        ),
+    )
+    write_sconscript(
+        consumer,
+        "Import('env')\n"
+        "env.Build('hello', 'hello.cpp')\n",
+    )
+
+    consumed = run_cuppa(consumer, "--rel", offline=True, timeout=300, extra_env=extra)
+    assert_success(consumed)
+    binaries = find_final_binaries(consumer, "hello")
+    assert binaries
+    ran = subprocess.run(
+        [str(binaries[0])],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    assert ran.returncode == 0, ran.stdout
+    assert "answer=42" in ran.stdout
+
+
 def test_conan_publish_conanfile_override_with_requires(tmp_path):
     """Leaf export-pkg, then wrapper with conanfile= requires leaf; consumer uses wrapper."""
     import os

--- a/tests/integration/methods/test_packages.py
+++ b/tests/integration/methods/test_packages.py
@@ -1,3 +1,6 @@
+import tarfile
+import zipfile
+
 import pytest
 
 from cuppa.package_managers.gitlab import os_release_id
@@ -36,6 +39,33 @@ def _widget_archives(project):
         ):
             names.append(name)
     return sorted(names)
+
+
+def _package_archive_paths(project):
+    paths = []
+    for path in project.rglob("*"):
+        if not path.is_file():
+            continue
+        name = path.name
+        if name.startswith("widget_") and (
+            name.endswith(".tar.gz") or name.endswith(".zip")
+        ):
+            paths.append(path)
+    return paths
+
+
+def _archive_member_names(archive):
+    if archive.name.endswith(".zip"):
+        with zipfile.ZipFile(archive) as zf:
+            return zf.namelist()
+    with tarfile.open(archive, "r:*") as tf:
+        return tf.getnames()
+
+
+def _archive_contains_static_lib(archive, stem="widget"):
+    members = _archive_member_names(archive)
+    suffixes = ("lib{}.a".format(stem), "{}.lib".format(stem))
+    return any(name.replace("\\", "/").endswith(suffix) for name in members for suffix in suffixes)
 
 
 def test_package_methods_are_registered(tmp_path):
@@ -81,3 +111,36 @@ def test_gitlab_publish_archive_omits_os_when_requested(tmp_path):
     os_id = os_release_id()
     assert not names[0].startswith("widget_{}_".format(os_id)), names[0]
     assert names[0].startswith("widget_"), names[0]
+
+
+def test_gitlab_publisher_stages_generated_relative_lib_dir(tmp_path):
+    project = copy_dummy_project(tmp_path)
+    write_sconstruct(project)
+    write_sconscript(
+        project,
+        """\
+Import('env')
+from cuppa.package_managers.gitlab import GitlabPackagePublisher
+env.AppendUnique(CPPPATH=['#/include'])
+lib = env.BuildStaticLib(
+    'widget',
+    'src/hello.cpp',
+    final_dir='package_lib',
+)
+publisher = GitlabPackagePublisher(
+    env,
+    source_include_dir='#/include',
+    source_lib_dir='package_lib',
+    registry='https://gitlab.example/api/v4/projects/1',
+    package='widget',
+    version='1.0.0',
+)
+env.PublishPackage(lib, publisher)
+""",
+    )
+
+    result = run_cuppa(project, "--rel", "--parallel")
+    assert_success(result)
+    archives = _package_archive_paths(project)
+    assert len(archives) == 1, archives
+    assert _archive_contains_static_lib(archives[0])

--- a/tests/unit/test_conan_package_publisher.py
+++ b/tests/unit/test_conan_package_publisher.py
@@ -29,6 +29,18 @@ class _FakeNode(object):
         return self.path
 
 
+class _VariantDirNode(object):
+    def __init__( self, path, source_path ):
+        self.path = str( path )
+        self._source_path = source_path
+
+    def __str__( self ):
+        return self.path
+
+    def srcnode( self ):
+        return self._source_path
+
+
 class PublisherEnv( FakeEnv ):
     def Dir( self, path ):
         return _FakeNode( path )
@@ -229,6 +241,61 @@ def test_build_package_export_pkg_success( tmp_path, monkeypatch ):
     stage = tmp_path / 'final' / 'conan_pkg_mylib_0.1.0'
     assert ( stage / 'conanfile.py' ).is_file()
     assert ( stage / 'lib' / 'libmylib.a' ).is_file()
+
+
+def test_build_package_stages_generated_variant_dir_lib( tmp_path, monkeypatch ):
+    generated = tmp_path / '_build' / 'working' / 'package_lib'
+    generated.mkdir( parents=True )
+    ( generated / 'libmylib.a' ).write_bytes( b'!' )
+    source = tmp_path / 'package_lib'
+
+    class _Env( PublisherEnv ):
+        def Dir( self, path ):
+            path = str( path )
+            if path == str( generated ):
+                return _VariantDirNode( generated, source )
+            return _FakeNode( path )
+
+    env = _Env(
+            final_dir=str( tmp_path / 'final' ),
+            abs_final_dir=str( tmp_path / 'final' ),
+            target_arch='x86_64',
+            stdcpp='c++20',
+            toolchain=_FakeToolchain(),
+            variant=_FakeVariant(),
+    )
+    include = tmp_path / 'include'
+    include.mkdir()
+    ( include / 'h.hpp' ).write_text( '//\n', encoding='utf-8' )
+
+    pub = ConanPackagePublisher(
+            env,
+            name='mylib',
+            version='0.1.0',
+            source_include_dir=str( include ),
+            source_lib_dir=str( generated ),
+            libs=[ 'mylib' ],
+    )
+
+    class _Completed(object):
+        returncode = 0
+        stdout = ''
+        stderr = ''
+
+    monkeypatch.setattr(
+            'cuppa.package_managers.conan._find_conan_executable',
+            lambda: 'conan',
+    )
+    monkeypatch.setattr(
+            'cuppa.package_managers.conan.subprocess.run',
+            lambda *args, **kwargs: _Completed(),
+    )
+
+    stamp = tmp_path / 'final' / 'mylib-0.1.0.conan.pkg'
+    stamp.parent.mkdir( parents=True, exist_ok=True )
+    rc = pub.build_package( [ str( stamp ) ], [], env )
+    assert rc is None
+    assert ( tmp_path / 'final' / 'conan_pkg_mylib_0.1.0' / 'lib' / 'libmylib.a' ).is_file()
 
 
 def test_package_type_for_shared_flag():

--- a/tests/unit/test_scons_nodes.py
+++ b/tests/unit/test_scons_nodes.py
@@ -1,0 +1,85 @@
+
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+import pytest
+
+from cuppa.package_managers import conan as conan_pkg
+from cuppa.package_managers import gitlab
+from cuppa.utility.scons_nodes import resolve_existing_node_path
+
+
+pytestmark = pytest.mark.unit
+
+
+class _VariantDirNode:
+
+    def __init__( self, path, source_path ):
+        self._path = path
+        self._source_path = source_path
+
+    def __str__( self ):
+        return str( self._path )
+
+    def srcnode( self ):
+        return self._source_path
+
+
+def test_prefers_existing_generated_variant_dir( tmp_path ):
+    generated = tmp_path / '_build' / 'working' / 'widget' / 'lib'
+    generated.mkdir( parents=True )
+    source = tmp_path / 'widget' / 'lib'
+    node = _VariantDirNode( generated, source )
+
+    assert resolve_existing_node_path( node ) == str( generated )
+
+
+def test_falls_back_to_existing_source_dir( tmp_path ):
+    generated = tmp_path / '_build' / 'working' / 'include'
+    source = tmp_path / 'include'
+    source.mkdir()
+    node = _VariantDirNode( generated, source )
+
+    assert resolve_existing_node_path( node ) == str( source )
+
+
+def test_prefers_generated_when_both_exist( tmp_path ):
+    generated = tmp_path / '_build' / 'working' / 'include'
+    generated.mkdir( parents=True )
+    source = tmp_path / 'include'
+    source.mkdir()
+    node = _VariantDirNode( generated, source )
+
+    assert resolve_existing_node_path( node ) == str( generated )
+
+
+def test_missing_paths_keep_generated_name( tmp_path ):
+    generated = tmp_path / '_build' / 'working' / 'widget' / 'lib'
+    source = tmp_path / 'widget' / 'lib'
+    node = _VariantDirNode( generated, source )
+
+    assert resolve_existing_node_path( node ) == str( generated )
+
+
+def test_plain_string_path( tmp_path ):
+    existing = tmp_path / 'include'
+    existing.mkdir()
+    assert resolve_existing_node_path( str( existing ) ) == str( existing )
+    missing = tmp_path / 'nope'
+    assert resolve_existing_node_path( str( missing ) ) == str( missing )
+
+
+def test_srcnode_may_return_a_node( tmp_path ):
+    generated = tmp_path / '_build' / 'working' / 'include'
+    source = tmp_path / 'include'
+    source.mkdir()
+    node = _VariantDirNode( generated, _VariantDirNode( source, source ) )
+
+    assert resolve_existing_node_path( node ) == str( source )
+
+
+def test_publishers_share_the_helper():
+    assert gitlab._resolve_node_path is resolve_existing_node_path
+    assert conan_pkg._resolve_node_path is resolve_existing_node_path


### PR DESCRIPTION
## Summary

GitLab and Conan package publishers copied `source_lib_dir` through `srcnode()`, which is the missing project-root counterpart of a generated VariantDir (for example `boost/1.92/lib` or a custom `final_dir`). Staging then failed on a clean tree, often under `--parallel`.

Both publishers now share `resolve_existing_node_path`: use the generated path when it exists, fall back to `srcnode()` only when that source-tree path exists.

Closes #255.

## Test plan

- [x] Local `flake8 cuppa` and `pylint -E cuppa`
- [x] Local `pytest -m unit` (1404 passed)
- [x] Local `pytest -m integration` (178 passed, 4 skipped)
- [x] CI green on the matrix
