### PR TITLE
Call documentation deploy from release publish

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,10 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  # Publish creates the GitHub Release with GITHUB_TOKEN, which does not
+  # start other workflows on `release: published`. release.yml calls this
+  # workflow after the tag exists.
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,6 +238,15 @@ jobs:
           # New tags via the API do not re-trigger this workflow's push:tags path.
           make_latest: true
 
+  # GITHUB_TOKEN-created releases do not fire docs.yml's `release: published`.
+  documentation:
+    needs: github-release
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/docs.yml
+
   pypi:
     needs: [ resolve, build, github-release ]
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -638,6 +638,7 @@ Release checklist: see `release.txt` (Actions **prepare** → merge → **publis
 - Lint settings / ignore rationale: `docs/modules/ROOT/pages/linting.adoc`
 - Preview docs (current checkout as `next`): `cd docs && npm ci && npm run build` → `_docs_build/site/` (Lunr search via `@antora/lunr-extension`; Mermaid via `@sntke/antora-mermaid-extension`)
 - Public multi-version site (stable from latest `v*` tag + `next`): `cd docs && npm run build:site` (needs git tags; `npm run build:site:all` also emits `llms.txt` / agent Markdown — requires `pandoc` and `lxml`)
+- Pages deploy: `docs.yml` on `docs/**` pushes, manual **documentation** dispatch, and **publish** via `workflow_call`. Do not expect `on: release` after Actions **publish** — `GITHUB_TOKEN` GitHub Releases do not start other workflows.
 - Product agent index on Pages: `https://ja11sop.github.io/cuppa/llms.txt` (product docs for agents). Repo `AGENTS.md` is for contributors working *on* cuppa — different audience; do not treat one as a substitute for the other.
 - **Docs visual review:** capturing a PNG (for example Chromium `--screenshot`) is cheap; **reading the image into the agent context is expensive.** Build Antora, tell the human what to check in the local preview, and iterate from CSS/HTML plus their notes. Capture or scan screenshots only when they ask, or when they cannot check locally. Prefer one targeted crop over a full-page dump.
 - Report listing samples: `python -m scripts.generate_doc_samples` writes

--- a/design/plans/docs-site-release-default.md
+++ b/design/plans/docs-site-release-default.md
@@ -2,7 +2,7 @@
 
 - **Status:** in progress
 - **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Documentation tooling (`doc-site-release-default`); [`docs/playbook.yml`](../../docs/playbook.yml); [`.github/workflows/docs.yml`](../../.github/workflows/docs.yml); [`docs/antora.yml`](../../docs/antora.yml); Methods baseline [`methods-pages-split.md`](methods-pages-split.md) / [#234](https://github.com/ja11sop/cuppa/pull/234); agent Markdown [`docs-llms-txt.md`](docs-llms-txt.md) (**same PR**); UI companion [`antora-ui-bundle.md`](antora-ui-bundle.md)
-- **Updated:** 2026-08-31
+- **Updated:** 2026-09-03
 - **Impact:** none — site publish / Antora versioning only (no Cuppa CLI behaviour)
 
 ## Problem
@@ -87,7 +87,7 @@ latest routing moves `latest` to that line.
 |----|-------------|-------|--------|
 | `doc-site-model` | Version naming + `latest` segment (table above) | Settled 2026-08-31 | **Done** |
 | `doc-site-playbook` | Multi-version playbook; drop silent `version: ~` as public default | Tags + `next`; `latest_version_segment`; prepare script | **Done** |
-| `doc-site-ci` | Adjust `docs.yml` and/or `release.yml` so stable site updates on publish | `release: published` + fetch tags + `build:site:all` | **Done** |
+| `doc-site-ci` | Adjust `docs.yml` and/or `release.yml` so stable site updates on publish | `workflow_call` from **publish** after the tag exists (`GITHUB_TOKEN` `release: published` does not start other workflows); also `workflow_dispatch` | **Done** |
 | `doc-site-local` | Contributor notes: preview current branch vs build release set | Contributing / AGENTS | **Done** |
 | `doc-site-verify` | After first release with the model: homepage / `/latest/` shows released text | Manual check after merge/deploy | Open |
 

--- a/design/process/agent-workflow-journey.md
+++ b/design/process/agent-workflow-journey.md
@@ -2,7 +2,7 @@
 
 - **Status:** living
 - **Related:** [`AGENTS.md`](../../AGENTS.md) (agent ops); Antora Contributing (human versioning/release)
-- **Updated:** 2026-09-01
+- **Updated:** 2026-09-03
 - **Maintainer:** primary author of this journey; others append only (see `AGENTS.md`)
 - **Privacy:** obey the private-projects rule; never copy names from `INTERNAL_PROJECTS.local.md`
 - **Source:** Cursor sessions spanning roughly mid-July → 2026-08-07 on cuppa
@@ -198,6 +198,8 @@ Use this as an ordered checklist. Cuppa did not follow it perfectly (see §5); t
 - [ ] Wire Trusted Publishing *after* the workflow file is on the default branch; name a GitHub
       Environment with required reviewers before the first real upload.
 - [ ] Document order clearly: merge finish PR → publish from **master tip** → approve PyPI.
+- [ ] Do not rely on `on: release` after a `GITHUB_TOKEN` GitHub Release — GitHub will not
+      start other workflows. Call the documentation workflow from **publish** (`workflow_call`).
 - [ ] Gate must fail if VERSION is still `.dev` or CHANGELOG is still `unreleased`.
 - [ ] Publish must refuse a tag that already points at the wrong commit.
 - [ ] Put the happy path on the docs site with Mermaid (`gitGraph` + sequence + flowchart);
@@ -328,6 +330,7 @@ These are recommendations for the next project, not self-flagellation.
 | `check_release` before build/publish | Catches `.dev` / unreleased before PyPI |
 | prepare / publish `workflow_dispatch` | Removes hand-tag ordering mistakes |
 | Tag via GitHub API from publish job | Avoids double-firing `push: tags` when softprops creates the tag |
+| Call docs from publish (`workflow_call`) | `GITHUB_TOKEN` `release: published` never starts `docs.yml` |
 | Environment approval on `pypi` | Human gate without long-lived Twine tokens |
 | Contributing Antora + `release.txt` + `AGENTS.md` | Humans get diagrams; agents get ops; checklist stays short |
 | Local gate via checkout `venv/` + `requirements.txt` | Avoids broken host flake8/pylint shims and missing test extras |

--- a/docs/modules/ROOT/pages/contributing/release.adoc
+++ b/docs/modules/ROOT/pages/contributing/release.adoc
@@ -20,6 +20,7 @@ Two Actions runs and one merge — no local `git tag` push.
 . Merge the pull request CI opens (`finish_release`, usually labelled `impact:none`).
 . Actions → **release** → Run workflow → action **publish** (leave **tag** blank).
 . Approve the `pypi` environment when the workflow asks.
+  Pages deploy is part of **publish** (it does not wait for PyPI approval).
 
 [mermaid]
 ....
@@ -80,6 +81,7 @@ sequenceDiagram
     participant PR as finish_release PR
     participant Master as master
     participant GH as GitHub Release
+    participant Pages as GitHub Pages
     participant Env as pypi environment
     participant PyPI
 
@@ -90,6 +92,7 @@ sequenceDiagram
     You->>Actions: publish (tag blank)
     Actions->>Master: checkout tip, gate, build
     Actions->>GH: create release + tag vX.Y.Z
+    Actions->>Pages: call documentation workflow
     Actions->>Env: wait for approval
     You->>Env: approve
     Env->>PyPI: OIDC upload
@@ -110,6 +113,11 @@ flowchart TD
 
 **publish** from master also refuses if `vX.Y.Z` already exists but points at a different commit.
 Delete the bad tag (`git push origin :refs/tags/vX.Y.Z`) and run publish again.
+
+A GitHub Release created with `GITHUB_TOKEN` does **not** start other workflows
+(`release: published` on the documentation workflow never fires). **publish** therefore
+calls the documentation workflow directly after it creates the tag. To refresh Pages
+without another publish, Actions → **documentation** → Run workflow.
 
 == Escape hatches
 

--- a/release.txt
+++ b/release.txt
@@ -18,8 +18,8 @@
 #      Opens a PR that runs finish_release (VERSION + dated CHANGELOG, impact:none).
 # 2. Merge that PR when CI is green.
 # 3. Actions → release → Run workflow → action: **publish** (leave tag blank)
-#      Builds from master tip, creates the GitHub Release + tag via API, then waits for
-#      approval on the `pypi` environment before uploading.
+#      Builds from master tip, creates the GitHub Release + tag via API, deploys GitHub
+#      Pages (documentation workflow), then waits for approval on the `pypi` environment.
 # 4. Approve the `pypi` deployment.
 #
 # Do not push a v* tag by hand unless you mean to; publish from master is the supported path.


### PR DESCRIPTION
## Summary

Actions **publish** creates the GitHub Release with `GITHUB_TOKEN`. GitHub does not start other workflows from those events, so `docs.yml`'s `release: published` never ran for `v1.9.0`.

**publish** now calls the documentation workflow (`workflow_call`) after the tag exists. Pages still also deploys on `docs/**` pushes and manual **documentation** dispatch.

For **1.9.0 right now**: Actions → **documentation** → Run workflow (this PR is only for the next cut).

## Test plan

- [x] Local `flake8 cuppa` and `pylint -E cuppa`
- [x] Local `pytest -m unit` / `pytest -m integration`
- [x] CI green on the matrix
- [x] After merge, 1.9.0 Pages refresh via **documentation** dispatch (or confirm `/cuppa/latest/` once that run finishes)
