### PR TITLE
Point Profiles report docs links at /cuppa/latest/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Profiles report documentation links use the versioned Pages tree
+  (``/cuppa/latest/…``) instead of unversioned ``/cuppa/cuppa/cxx-profiles/…``
+  paths that 404 after the multi-version docs site.
+
 ### Security
 
 ## [1.9.0] - 2026-09-03

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,8 @@ Patch follow-ons after **1.9.0**. Keep this cycle small so **1.10.0** can take t
 
 | Area | Intent in 1.9.1 |
 |------|-----------------|
-| Pages deploy from Actions **publish** | Open [#258](https://github.com/ja11sop/cuppa/pull/258) — `GITHUB_TOKEN` GitHub Releases do not start `docs.yml` |
+| Pages deploy from Actions **publish** | Shipped [#258](https://github.com/ja11sop/cuppa/pull/258) — `GITHUB_TOKEN` GitHub Releases do not start `docs.yml` |
+| Profiles report links to published rule docs | `/cuppa/latest/cxx-profiles/…` (unversioned URLs 404) |
 | Small product/docs fixes that land before 1.10.0 | As they come |
 
 **1.10.0 candidates:** GitLab CMake staging ([#209](https://github.com/ja11sop/cuppa/issues/209)); Boost package patched/clean identity ([`boost-updates.md`](design/plans/boost-updates.md)) and Quince ([#250](https://github.com/ja11sop/cuppa/issues/250)); artefact removal design ([#135](https://github.com/ja11sop/cuppa/issues/135)); console bundle (`--terse-output`, log hygiene, `cuppa --info`).

--- a/cuppa/cpp/profiles_report/profiles/std_init.py
+++ b/cuppa/cpp/profiles_report/profiles/std_init.py
@@ -10,6 +10,7 @@
 import re
 
 from cuppa.cpp.profiles_report.constants import UNCLASSIFIED_RULE_ID
+from cuppa.cpp.profiles_report.published_docs import CUPPA_DOCS_STABLE_BASE
 
 PROFILE_NAME = 'std::init'
 
@@ -315,9 +316,7 @@ RULE_DOC_REFERENCES = {
     },
 }
 
-CUPPA_STD_INIT_DOCS_BASE = (
-    'https://ja11sop.github.io/cuppa/cuppa/cxx-profiles/std-init'
-)
+CUPPA_STD_INIT_DOCS_BASE = CUPPA_DOCS_STABLE_BASE + '/cxx-profiles/std-init'
 
 # Antora page slug per rule id (see docs/.../cxx-profiles/std-init.adoc).
 RULE_DOC_PAGES = {

--- a/cuppa/cpp/profiles_report/published_docs.py
+++ b/cuppa/cpp/profiles_report/published_docs.py
@@ -1,0 +1,20 @@
+
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   Stable public Antora URLs for generated Profiles reports
+#-------------------------------------------------------------------------------
+
+"""Canonical published-docs prefix after multi-version Pages.
+
+Unversioned paths such as ``/cuppa/cuppa/cxx-profiles/…`` 404 once the site
+uses ``latest_version_segment: latest``. Reports must link the durable
+``/cuppa/latest/…`` tree so they track the current release, not a missing
+unversioned URL.
+"""
+
+CUPPA_DOCS_SITE = 'https://ja11sop.github.io/cuppa'
+CUPPA_DOCS_STABLE_BASE = CUPPA_DOCS_SITE + '/cuppa/latest'

--- a/cuppa/cpp/profiles_report/report_html.py
+++ b/cuppa/cpp/profiles_report/report_html.py
@@ -19,6 +19,7 @@ from jinja2 import Environment, PackageLoader, select_autoescape
 
 from cuppa.colourise import as_notice
 from cuppa.core.dependency_identity import short_name_from_git_url
+from cuppa.cpp.profiles_report.published_docs import CUPPA_DOCS_STABLE_BASE
 from cuppa.cpp.profiles_report.profiles import std_init
 from cuppa.log import logger
 from cuppa.cpp.profiles_report.breadcrumbs import scope_breadcrumbs
@@ -33,7 +34,7 @@ INDEX_BASENAME = 'cxx-profiles-index.html'
 JSON_BASENAME = 'cxx-profiles-index.json'
 
 CUPPA_PROFILES_REPORT_DOCS_BASE = (
-    'https://ja11sop.github.io/cuppa/cuppa/cxx-profiles/report-overview.html'
+    CUPPA_DOCS_STABLE_BASE + '/cxx-profiles/report-overview.html'
 )
 
 _GIT_DESCRIBE = re.compile(

--- a/docs/modules/ROOT/pages/cxx-profiles/report-introduction.adoc
+++ b/docs/modules/ROOT/pages/cxx-profiles/report-introduction.adoc
@@ -325,7 +325,7 @@ suppresses file hrefs. You can also pass `--anonymised` explicitly (implies
 NOTE: US spellings (`--anonymized`, `metadata.anonymized`, `python -m scripts.anonymize_profiles_report`) remain accepted for compatibility; they are not listed in CLI help.
 
 Rule documentation links (`doc_href` to published cuppa Profiles pages) are kept — they point at
-public rule reference, not your project.
+public rule reference under ``/cuppa/latest/…``, not your project.
 
 === Limits (honest)
 

--- a/tests/unit/test_profiles_report_html.py
+++ b/tests/unit/test_profiles_report_html.py
@@ -62,7 +62,7 @@ def test_rule_link_tooltip_includes_rule_name_and_message():
 
 def test_rule_doc_href_for_std_init():
     assert rule_doc_href( 'std::init', 'uninit_decl' ).endswith(
-        '/cxx-profiles/std-init/uninit-decl.html',
+        '/latest/cxx-profiles/std-init/uninit-decl.html',
     )
     assert rule_doc_href( 'std::future', 'uninit_decl' ) is None
 
@@ -70,7 +70,7 @@ def test_rule_doc_href_for_std_init():
 def test_overview_doc_hrefs():
     from cuppa.cpp.profiles_report.report_html import overview_doc_href, overview_doc_hrefs
 
-    assert overview_doc_href().endswith( '/cxx-profiles/report-overview.html' )
+    assert overview_doc_href().endswith( '/latest/cxx-profiles/report-overview.html' )
     assert overview_doc_href( 'violation-totals' ).endswith( '#violation-totals' )
     hrefs = overview_doc_hrefs()
     assert hrefs[ 'codebase_reach' ].endswith( '#codebase-reach-tier-1' )

--- a/tests/unit/test_profiles_report_std_init.py
+++ b/tests/unit/test_profiles_report_std_init.py
@@ -92,7 +92,7 @@ def test_destroy_rules_documented_before_live_capture():
 def test_std_init_rule_doc_hrefs( rule_id, page_slug ):
     href = std_init.rule_doc_href( rule_id )
     assert href == (
-        'https://ja11sop.github.io/cuppa/cuppa/cxx-profiles/std-init/{}.html'.format(
+        'https://ja11sop.github.io/cuppa/cuppa/latest/cxx-profiles/std-init/{}.html'.format(
             page_slug,
         )
     )
@@ -101,3 +101,12 @@ def test_std_init_rule_doc_hrefs( rule_id, page_slug ):
 
 def test_std_init_rule_doc_href_unknown():
     assert std_init.rule_doc_href( '_unclassified' ) is None
+
+
+def test_std_init_doc_pages_exist_in_antora_tree():
+    pages = (
+        Path( __file__ ).resolve().parents[2]
+        / 'docs' / 'modules' / 'ROOT' / 'pages' / 'cxx-profiles' / 'std-init'
+    )
+    for slug in set( std_init.RULE_DOC_PAGES.values() ):
+        assert ( pages / '{}.adoc'.format( slug ) ).is_file(), slug


### PR DESCRIPTION
## Summary

Profiles report `doc_href` links used unversioned URLs (`/cuppa/cuppa/cxx-profiles/…`). After the multi-version Pages site those paths **404** (blank GitHub Pages 404). The published pages live under `/cuppa/latest/…` and have content.

Point rule and Overview-guide links at `https://ja11sop.github.io/cuppa/cuppa/latest/…`. Existing reports need a regenerate after upgrade.

Closes #261.

## Test plan

- [x] HEAD/GET of live `/latest/` rule pages and Overview anchors (200, real titles)
- [x] Confirm unversioned `/cuppa/cuppa/cxx-profiles/…` is 404
- [x] Local `flake8` / `pylint -E` / `pytest -m unit` / `pytest -m integration`
- [x] CI green on the matrix