### PR TITLE
Warn when coverage collection runs under SCons -j

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -526,10 +526,11 @@ for the installed version. Task pages live under `docs/modules/ROOT/pages/cli/` 
 
 - `--offline` — after the first fetch in a session; skips PyPI version check and remote location updates
 - `--develop` — when using configured local develop paths for location/package deps
-- `--parallel` — for compile-only speed; avoid when diagnosing failures or often when running tests/coverage
+- `--parallel` — for compile-only speed; avoid when diagnosing failures or when running tests/coverage collection
 - `--verbosity=exception` or `--verbosity=debug` — when configure/sconscript load fails
 
-**Coverage:** always pass both `--cov` and `--test`. `--cov` alone does not run tests.
+**Coverage:** always pass both `--cov` and `--test` to *collect*. `--cov` alone does not run tests.
+Supported large-project recipe: `cuppa -D --cov --parallel` then `cuppa -D --cov --test` (no `--parallel` on the second step). Cuppa warns if `--parallel` / `-j` > 1 is combined with `--cov --test`. See [#236](https://github.com/ja11sop/cuppa/issues/236).
 
 ## Where to change behaviour in this repo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Profiles report documentation links use the versioned Pages tree
   (``/cuppa/latest/…``) instead of unversioned ``/cuppa/cuppa/cxx-profiles/…``
-  paths that 404 after the multi-version docs site.
+  paths that 404 after the multi-version docs site
+  ([#261](https://github.com/ja11sop/cuppa/issues/261)).
+- ``BuildTest`` / ``BuildBenchmark`` order Coverage after the Test or Benchmark
+  node so gcov waits for that run instead of racing an independent default
+  target ([#236](https://github.com/ja11sop/cuppa/issues/236)).
+- Combining ``--cov`` with ``--test`` / ``--force-test`` / ``--benchmark`` /
+  ``--force-benchmark`` and SCons ``-j`` greater than 1 (including
+  ``--parallel``) warns that coverage collection is not reliable; the
+  supported recipe remains a parallel instrumented compile then a serial
+  collect ([#236](https://github.com/ja11sop/cuppa/issues/236)).
 
 ### Security
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,8 +22,8 @@ Patch follow-ons after **1.9.0**. Keep this cycle small so **1.10.0** can take t
 | Area | Intent in 1.9.1 |
 |------|-----------------|
 | Pages deploy from Actions **publish** | Shipped [#258](https://github.com/ja11sop/cuppa/pull/258) — `GITHUB_TOKEN` GitHub Releases do not start `docs.yml` |
-| Profiles report links to published rule docs | `/cuppa/latest/cxx-profiles/…` (unversioned URLs 404) |
-| Small product/docs fixes that land before 1.10.0 | As they come |
+| Profiles report links to published rule docs | Shipped — `/cuppa/latest/cxx-profiles/…` ([#261](https://github.com/ja11sop/cuppa/issues/261)) |
+| Coverage vs `--parallel` | Warn on collect + `-j`; `BuildTest` Coverage waits for Test; analysis [`coverage-parallel.md`](design/plans/coverage-parallel.md) ([#236](https://github.com/ja11sop/cuppa/issues/236)) |
 
 **1.10.0 candidates:** GitLab CMake staging ([#209](https://github.com/ja11sop/cuppa/issues/209)); Boost package patched/clean identity ([`boost-updates.md`](design/plans/boost-updates.md)) and Quince ([#250](https://github.com/ja11sop/cuppa/issues/250)); artefact removal design ([#135](https://github.com/ja11sop/cuppa/issues/135)); console bundle (`--terse-output`, log hygiene, `cuppa --info`).
 
@@ -353,6 +353,8 @@ making `--cov --test` cheap enough to run routinely on large codebases.
 
 Measurements, analysis of the current implementation, and the ordered list of candidate changes:
 [`design/plans/coverage-performance.md`](design/plans/coverage-performance.md).
+Parallel `--cov --test` (what is feasible, `.gcda` sharing, 1.9.1 warning):
+[`design/plans/coverage-parallel.md`](design/plans/coverage-parallel.md) / [#236](https://github.com/ja11sop/cuppa/issues/236).
 
 ### Today
 
@@ -381,6 +383,7 @@ another project is unconfirmed.
 | `cov-union-incremental` | Cache the union on JSON mtime / size and skip unchanged work | Medium | Biggest win on repeat runs |
 | `cov-branch-index` | Group branches by line once rather than scanning per line | Low | Removes an O(lines × branches) scan |
 | `cov-second-project-ab` | Repeat the A/B measurement on the project the regression was reported from (**project B**) | High | Fewer, larger test binaries and much longer coverage runs than project A |
+| `cov-gcov-prefix` | Per-test `GCOV_PREFIX` so parallel tests do not share `.gcda` | Later | Required before `--cov --test --parallel` can be correct; see [`coverage-parallel.md`](design/plans/coverage-parallel.md) |
 
 ### Out of scope (coverage)
 
@@ -388,6 +391,7 @@ another project is unconfirmed.
 |----|------|--------|
 | `cov-by-source-flag` | A permanent flag to disable by-source reporting | Measurement does not support it; make the report cheap instead. The temporary `--cov-by-source` used for the experiment has been reverted |
 | `cov-msvc` | Coverage on MSVC | gcov-based; GCC and Clang only |
+| `cov-parallel-collect` | Treat `--cov --test --parallel` as a supported correct mode | Shared `.gcda` / gcov races; 1.9.1 warns instead ([#236](https://github.com/ja11sop/cuppa/issues/236)) |
 
 ---
 

--- a/cuppa/construct.py
+++ b/cuppa/construct.py
@@ -37,6 +37,7 @@ import cuppa.configure
 import cuppa.version
 import cuppa.scms
 import cuppa.develop
+from cuppa.cpp.coverage_workflow import maybe_warn_parallel_coverage_collection
 #import cuppa.progress
 #import cuppa.tree
 #import cuppa.cpp.stdcpp
@@ -646,6 +647,14 @@ class Construct(object):
                         as_emphasised(parallel_mode),
                         as_info( str( SCons.Script.GetOption( 'num_jobs') ) )
                 ) )
+            maybe_warn_parallel_coverage_collection(
+                job_count=job_count,
+                cov=bool( cuppa_env.get_option( 'cov' ) ),
+                test=bool( cuppa_env.get_option( 'test' ) ),
+                force_test=bool( cuppa_env.get_option( 'force_test' ) ),
+                benchmark=bool( cuppa_env.get_option( 'benchmark' ) ),
+                force_benchmark=bool( cuppa_env.get_option( 'force_benchmark' ) ),
+            )
 
         if not help and self._configure.handle_conf_only():
             self._configure.save()

--- a/cuppa/cpp/coverage_workflow.py
+++ b/cuppa/cpp/coverage_workflow.py
@@ -1,0 +1,70 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   Coverage workflow helpers (parallel collection policy)
+#-------------------------------------------------------------------------------
+
+from cuppa.log import logger
+
+
+# Stable token for tests and log greps (must appear in the warning even when colourised).
+PARALLEL_COVERAGE_COLLECTION_WARNING = (
+    "Collecting coverage with SCons -j is not reliable"
+)
+
+
+def should_warn_parallel_coverage_collection(
+        job_count,
+        cov=False,
+        test=False,
+        force_test=False,
+        benchmark=False,
+        force_benchmark=False,
+):
+    """True when instrumented tests or benchmarks will run with more than one SCons job.
+
+    Parallel *compile* of the coverage variant (``--cov`` without ``--test``) is
+    fine. Parallel *collection* is not: ``.gcda`` files sit beside object files,
+    often shared across binaries, and Coverage actions are not isolated per test.
+    See ``design/plans/coverage-parallel.md``.
+    """
+    if not job_count or int( job_count ) <= 1:
+        return False
+    if not cov:
+        return False
+    return bool( test or force_test or benchmark or force_benchmark )
+
+
+def parallel_coverage_collection_warning_text():
+    return (
+        "{token}. GCC/Clang write .gcda beside object files; those notes are "
+        "shared when tests link the same library, and Coverage() can race the "
+        "test process that produces them. Build the instrumented tree in parallel, "
+        "then collect serially: cuppa -D --cov --parallel then "
+        "cuppa -D --cov --test (no --parallel). "
+        "https://github.com/ja11sop/cuppa/issues/236"
+    ).format( token=PARALLEL_COVERAGE_COLLECTION_WARNING )
+
+
+def maybe_warn_parallel_coverage_collection(
+        job_count,
+        cov=False,
+        test=False,
+        force_test=False,
+        benchmark=False,
+        force_benchmark=False,
+):
+    if should_warn_parallel_coverage_collection(
+            job_count,
+            cov=cov,
+            test=test,
+            force_test=force_test,
+            benchmark=benchmark,
+            force_benchmark=force_benchmark,
+    ):
+        logger.warn( parallel_coverage_collection_warning_text() )
+        return True
+    return False

--- a/cuppa/methods/build_benchmark.py
+++ b/cuppa/methods/build_benchmark.py
@@ -76,6 +76,8 @@ class BuildBenchmarkMethod:
             nodes.append( benchmark )
             if 'cov' in actions:
                 coverage = env.Coverage( program, source, final_dir=final_dir, exclude_dependencies=cov_exclude_dependencies, exclude_patterns=cov_exclude_patterns )
+                if coverage:
+                    env.Depends( coverage, benchmark )
                 nodes.append( coverage )
 
         return Flatten( nodes )

--- a/cuppa/methods/build_test.py
+++ b/cuppa/methods/build_test.py
@@ -76,6 +76,8 @@ class BuildTestMethod:
             nodes.append( test )
             if 'cov' in actions:
                 coverage = env.Coverage( program, source, final_dir=final_dir, exclude_dependencies=cov_exclude_dependencies, exclude_patterns=cov_exclude_patterns )
+                if coverage:
+                    env.Depends( coverage, test )
                 nodes.append( coverage )
 
         return Flatten( nodes )

--- a/design/README.md
+++ b/design/README.md
@@ -24,6 +24,7 @@ maintainer workflow evolved.
 | [`plans/boost-updates.md`](plans/boost-updates.md) | proposal | Boost source vs GitLab `boost_package` identity; #206 `use_libs`; #248/#249 test-runner `session_boost` shipped; #250 Quince session Boost |
 | [`plans/shiki-syntax-highlighting.md`](plans/shiki-syntax-highlighting.md) | proposal | Build-time Shiki for Antora listings; ANSI preview only — ROADMAP `doc-shiki` |
 | [`plans/coverage-performance.md`](plans/coverage-performance.md) | proposal | Where `--cov --test` time actually goes, what the A/B measurement ruled out, and the remaining suspects |
+| [`plans/coverage-parallel.md`](plans/coverage-parallel.md) | in progress | What `--cov --test --parallel` can and cannot do; 1.9.1 warn + Depends; `GCOV_PREFIX` deferred — [#236](https://github.com/ja11sop/cuppa/issues/236) |
 | [`plans/list-toolchains-verbose.md`](plans/list-toolchains-verbose.md) | in progress | Verbose `describe()` shipped ([#172](https://github.com/ja11sop/cuppa/issues/172) / [#170](https://github.com/ja11sop/cuppa/pull/170)); deferred table-driven init |
 | [`plans/antora-ui-bundle.md`](plans/antora-ui-bundle.md) | in progress | Supplemental CSS + Boost/Material look catalogue; default bundle kept — ROADMAP `doc-antora-ui`; [#229](https://github.com/ja11sop/cuppa/issues/229) / [#228](https://github.com/ja11sop/cuppa/pull/228) |
 | [`plans/methods-pages-split.md`](plans/methods-pages-split.md) | in progress | Hub + job-named `methods/*` (discovery, templates, CreateVersion, staging-files, test-reporting, …) — ROADMAP `doc-methods-split`; #234 |

--- a/design/plans/coverage-parallel.md
+++ b/design/plans/coverage-parallel.md
@@ -1,0 +1,237 @@
+# Coverage collection and SCons parallelism
+
+- **Status:** in progress
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Coverage reporting and performance; [#236](https://github.com/ja11sop/cuppa/issues/236); [`coverage-performance.md`](coverage-performance.md)
+- **Updated:** 2026-09-04
+- **Impact:** patch — warn + `Depends` ordering; parallel collection remains unsupported
+
+This records how Cuppa coverage works today, which parallel combinations are safe, and what
+would be required to make `--cov --test --parallel` correct. It is the analysis behind the
+[#236](https://github.com/ja11sop/cuppa/issues/236) warning and docs; it is **not** a performance
+plan (that remains [`coverage-performance.md`](coverage-performance.md)).
+
+## Settled decisions (1.9.1)
+
+| Decision | Choice |
+|----------|--------|
+| Parallel instrumented **compile** (`--cov --parallel`, no `--test`) | **Supported** — `--cov` does not run tests; `BuildTest` does not attach Coverage/Test nodes without `--test` |
+| Parallel **coverage collection** (`--cov --test` with `--parallel` or `-j` > 1) | **Not supported** as a correct workflow |
+| Operator signal in 1.9.1 | **Warn** (do not fail the build). A hard refuse would break trees that currently “get lucky” |
+| `BuildTest` / `BuildBenchmark` graph | Coverage **Depends** on the Test/Benchmark node only — see [Appendix A](#appendix-a-coverage-depends) |
+| `Coverage(program, sources)` | `program` is the executable from `Build()`, not the flattened `BuildTest` return list — [Appendix A](#appendix-a-coverage-depends) |
+| Isolate `.gcda` per test (`GCOV_PREFIX`) | **Deferred** — this is the real path to safe parallel tests-with-coverage |
+| gcovr `-j` during report generation | **Deferred** — independent of test-process races; see `cov-parallel-gcovr` in the performance plan |
+
+## How coverage runs today
+
+### Variant vs action
+
+`--cov` is both a **variant** (instrumented compile/link: `--coverage`) and an **action**
+(`cuppa/variants/cov.py` calls `add_variant` and `add_action`). `--test` is an action only.
+
+`BuildTest()`:
+
+1. Always `env.Build()` (program).
+2. If `test` or `force_test` is active: `env.Test(program, …)`.
+3. If that ran **and** `cov` is active: `env.Coverage(program, sources, …)`.
+
+So the documented two-step recipe is real for `BuildTest`:
+
+```sh
+cuppa -D --cov --parallel    # compile/link only
+cuppa -D --cov --test        # run tests, then gcov/gcovr, then collate
+```
+
+A bare `env.Coverage(program, sources)` in a sconscript is created whenever `cov` **or** `test`
+is in `variant_actions`. That path can run gcov on a `--cov` compile-only invocation. Prefer
+`BuildTest` (or `Depends` the Coverage node on the Test node yourself).
+
+### Where the notes live
+
+GCC/Clang `--coverage` writes:
+
+- `.gcno` at compile, beside the `.o` under the mirrored `working/` tree
+- `.gcda` at **process exit** of the instrumented binary, beside the same `.o`
+
+Cuppa does not set `GCOV_PREFIX` / `GCOV_PREFIX_STRIP`. Every binary that links a given object
+updates **that object’s** `.gcda`. A static library compiled once and linked into many tests
+shares one note file per member.
+
+`RunGcovCoverage` then:
+
+1. Invokes `gcov` / `llvm-cov gcov` with `-o <object-dir>` per source of that Coverage builder.
+2. Globs `*.gcov` in the sconscript working directory and **renames** them with a program-id
+   suffix.
+3. Calls `gcovr` (`-g`, HTML details, JSON) — historically **inside** the per-source loop
+   (performance issue; see `cov-once-per-test`).
+4. Collation copies HTML/JSON and builds by-source union indexes.
+
+Coverage builder **sources** are the C++ sources, not the Test stamp. SCons therefore treated
+Test and Coverage as independent default targets until `BuildTest` added `Depends(coverage, test)`
+([Appendix A](#appendix-a-coverage-depends)).
+
+### What `--parallel` actually does
+
+`--parallel` with `num_jobs == 1` sets SCons `-j` to `cpu_count()`. An explicit `-j N` with
+`N > 1` is the same concurrency without the Cuppa flag. Both are “parallel collection” if tests
+and coverage actions are in the graph.
+
+## What is, and is not, feasible
+
+### Safe today
+
+| Combination | Why |
+|-------------|-----|
+| `--cov --parallel` without `--test` / `--benchmark` | No Test/Coverage nodes from `BuildTest`; objects are independent compile jobs |
+| `--dbg --test --parallel` (no `--cov`) | No `.gcda`; tests are separate processes. Console/TestSuite summaries can still interleave |
+| Serial `--cov --test` | One test, then its Coverage (after 1.9.1 `Depends`), then the next |
+| Two-step: parallel `--cov`, then serial `--cov --test` | Intended large-project workflow |
+
+### Unsafe without new machinery
+
+| Combination | Why |
+|-------------|-----|
+| `--cov --test --parallel` (or `-j` > 1) | (1) **Shared `.gcda`**: concurrent tests that link the same objects corrupt counters (classic gcov). (2) **Coverage vs Test race** if Coverage is not ordered after Test (fixed for `BuildTest` in 1.9.1). (3) **gcov glob/rename** in a shared working directory. (4) **gcovr / collation** reading notes or writing indexes while another job still updates them. (5) Interleaved stdout |
+| Parallel tests that share a static/shared lib, even after `Depends(coverage, test)` | Ordering fixes *per binary*; it does **not** isolate library `.gcda` across binaries |
+
+Independent single-file tests with **no shared instrumented library** can appear to work under
+`-j` (the integration suite checks that this still exits 0). That is not a correctness
+guarantee for consumer trees.
+
+### What would make parallel collection feasible
+
+The usual GCC approach is **per-test note isolation**:
+
+1. Set `GCOV_PREFIX` (and often `GCOV_PREFIX_STRIP`) uniquely for each test process.
+2. Point `gcov`/`gcovr` at that prefix when collecting that binary.
+3. Merge JSON (Cuppa already unions `coverage--*.json` for by-source) rather than merging
+   `.gcda` in place.
+
+That is a real product slice (`cov-gcov-prefix`): env plumbing on the test runner, Coverage
+runner awareness, and tests that share a static lib. It is **not** a 1.9.1 patch.
+
+Serializing all Test+Coverage behind one SCons `SideEffect` lock would make `-j` safe but
+would also make `--parallel` pointless for the collect step.
+
+gcovr `-j` only parallelises **report generation** after notes are stable. It does not fix
+test-process races.
+
+## 1.9.1 product behaviour
+
+- Warn at configure when `job_count > 1` and `--cov` is on and `--test` / `--force-test` /
+  `--benchmark` / `--force-benchmark` is on (`cuppa/cpp/coverage_workflow.py`).
+- `BuildTest` / `BuildBenchmark` `Depends` coverage on the Test/Benchmark node
+  ([Appendix A](#appendix-a-coverage-depends)).
+- Docs state the two-step recipe as the supported contract, with the reasons above instead of
+  “historically flaky”.
+
+## Tests that qualify the assumptions
+
+| Test | What it locks |
+|------|----------------|
+| `tests/unit/test_coverage_workflow.py` | Warn predicate: compile-only `--cov --parallel` is silent; collect + `-j` warns |
+| `tests/integration/methods/test_coverage.py` (`test_coverage_parallel_independent_tests`) | Two single-file tests under `--cov --test --parallel` still succeed (no shared lib) |
+| Same module (`test_coverage_parallel_collection_warns`) | Warning text appears when the run actually enters parallel mode |
+
+A shared-library `.gcda` race is **not** asserted: it would be flaky by construction.
+
+## Follow-ons (not this cycle)
+
+| ID | Work |
+|----|------|
+| `cov-gcov-prefix` | Per-test `GCOV_PREFIX` + gcov/gcovr inputs; then revisit the warning (maybe keep it until proven) |
+| `cov-once-per-test` | Hoist gcovr out of the per-source loop ([`coverage-performance.md`](coverage-performance.md)) |
+| `cov-parallel-gcovr` | gcovr `-j` after notes are isolated or after a serial test pass |
+
+## Reference
+
+- `cuppa/methods/build_test.py`, `cuppa/methods/coverage.py`
+- `cuppa/cpp/run_gcov_coverage.py`, `cuppa/cpp/coverage_workflow.py`
+- `cuppa/variants/cov.py`, `cuppa/construct.py` (job count / `--parallel`)
+- GCC `--coverage` / `GCOV_PREFIX` in the GCC instrumentation docs
+- [Appendix A](#appendix-a-coverage-depends) — SCons graph for `Depends(coverage, test)` vs a cycle on the `BuildTest` return list
+
+<a id="appendix-a-coverage-depends"></a>
+## Appendix A — Why Coverage Depends on the Test node, not the BuildTest return list
+
+`BuildTest` returns a **bundle** of SCons nodes. Coverage collection is a **second builder** whose
+outputs have **fixed names** derived from the binary. Those two facts collide if Coverage
+`Depends` on the bundle.
+
+### What `BuildTest` returns
+
+With `--cov --test` it constructs three things, then `Flatten`s them into one list
+(`cuppa/methods/build_test.py`):
+
+1. **Program** — `final/hello_test` (from `env.Build`).
+2. **Test stamps** — `hello_test.success`, stdout/stderr logs, JSON report (from `env.Test`).
+3. **Coverage artefacts** — `coverage--hello_test.html`, `.json`, `.log`, `.cov_filter`, plus
+   `*_gcov.log` beside the sources (from `env.Coverage`).
+
+So `prog = env.BuildTest('hello_test', …)` is not “the executable”. It is that whole list.
+
+`env.Coverage` does **not** take those stamps as builder sources. The Coverage builder is fed
+the **C++ sources**; the `program` argument is only used to name gcov/gcovr files (`hello_test`
+→ `coverage--hello_test.*`). Before `Depends(coverage, test)`, SCons saw two independent default
+targets: “run the test” and “run gcov on these `.cpp` files”. Nothing required gcov to wait for
+the process that writes `.gcda`. Serial `-j1` often lucked into the right order; `-j` did not.
+
+### The Depends that is acyclic
+
+`env.Depends(coverage, test)` means every Coverage **target** waits for the Test **stamp**
+(`.success` / logs). The graph is a line:
+
+```
+hello_test (exe)
+    → Test (run, writes .gcda)
+        → Coverage (gcov / gcovr)
+```
+
+That is ordered and acyclic. `BuildBenchmark` does the same with the Benchmark node.
+
+### Why `Depends` on the whole `BuildTest` return list cycles
+
+A natural extra would be “also `Depends` Coverage on `program`”, so gcov cannot run before
+link. Inside `Coverage()`, `program` is whatever the **caller** passed.
+
+`BuildTest` already passes the **executable** into `Coverage(program, source)` — that call is
+fine. Cuppa’s own integration fixture then does this (`tests/integration/methods/test_coverage.py`,
+`test_coverage_method`):
+
+```python
+prog = env.BuildTest('hello_test', 'tests/hello_test.cpp')
+env.Coverage(prog, 'tests/hello_test.cpp')
+```
+
+That is **two** Coverage builders for the **same** binary:
+
+1. `BuildTest` already called `Coverage(hello_test, hello_test.cpp)` → targets
+   `coverage--hello_test.html` and siblings.
+2. The sconscript calls `Coverage(prog, …)` again. `prog` is the **flattened bundle**, which
+   **includes those same coverage files**.
+
+If `Coverage()` did `Depends(coverage, Flatten(program))` with that bundle:
+
+- The second builder’s targets are again `coverage--hello_test.html` (same paths; SCons treats
+  them as the same nodes).
+- Those nodes would `Depends` on a list that **already contains** `coverage--hello_test.html`.
+
+That is a **self-edge**: the node is a prerequisite of itself. SCons reports:
+
+`coverage--hello_test.html -> … -> coverage--hello_test.html`
+
+(and the same for `.json` / `.log` / `.cov_filter` / the gcov log).
+
+### Rule of thumb
+
+- **Do** `Depends` Coverage on the **Test** (or Benchmark) node — a different file (`.success`),
+  so no loop.
+- **Do not** `Depends` Coverage on the **whole `BuildTest` return list**, because that list
+  already contains Coverage’s own outputs.
+- If a sconscript calls `env.Coverage` itself, pass the **executable** (`Build()` / the program
+  node), not `prog = BuildTest(...)`.
+
+That is why 1.9.1 only adds `Depends(coverage, test)` inside `BuildTest` / `BuildBenchmark`, and
+does **not** add `Depends(coverage, program)` inside `Coverage()`: the latter would break any
+sconscript that passes the `BuildTest` bundle back into `Coverage()`, including Cuppa’s coverage
+integration test.

--- a/design/plans/coverage-performance.md
+++ b/design/plans/coverage-performance.md
@@ -1,8 +1,8 @@
 # Coverage performance: measurements, analysis, and plan
 
 - **Status:** proposal
-- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Coverage reporting and performance
-- **Updated:** 2026-07-31
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Coverage reporting and performance; parallel collection is [`coverage-parallel.md`](coverage-parallel.md) / [#236](https://github.com/ja11sop/cuppa/issues/236)
+- **Updated:** 2026-09-04
 
 No performance work has been done yet. This records what we measured, what the measurement ruled out, and where the remaining
 suspects are, so the work can be picked up later without repeating the investigation.

--- a/docs/modules/ROOT/pages/cli-reference.adoc
+++ b/docs/modules/ROOT/pages/cli-reference.adoc
@@ -130,7 +130,7 @@ In the examples that follow we use this convention.
 | `--toolchains=LIST` | Select discovered toolchains by comma-separated name or wildcard
 | `--test` / `--run` / `--benchmark` | Execute the corresponding targets after building
 | `--scripts=LIST` | Limit which sconscripts contribute targets
-| `--parallel` | Choose a hardware-sized SCons job count
+| `--parallel` | Choose a hardware-sized SCons job count (do not combine with `--cov --test`)
 | `--develop` | Prefer configured local dependency copies
 | `--offline` | Avoid PyPI checks and remote location updates
 | `-n` / `--no-exec` | Preview build or maintenance actions

--- a/docs/modules/ROOT/pages/cli/building.adoc
+++ b/docs/modules/ROOT/pages/cli/building.adoc
@@ -23,7 +23,7 @@ you can see which layer owns each decision.
 | `--toolchains=LIST` | Select comma-separated toolchain names or fnmatch patterns such as `gcc*`
 | `--scripts=LIST` | Limit graph construction to the named, comma-separated sconscripts
 | `--projects=LIST` | Alias for `--scripts`
-| `--parallel` | Set SCons' job count from available hardware; the wrapper may also restrict CPU affinity
+| `--parallel` | Set SCons' job count from available hardware; the wrapper may also restrict CPU affinity. Do not combine with `--cov --test` (Cuppa warns; collect serially)
 | `--offline` | Skip the PyPI version check and remote location updates
 | `--develop` | Prefer configured local develop paths for dependencies
 |===

--- a/docs/modules/ROOT/pages/integration/test-coverage.adoc
+++ b/docs/modules/ROOT/pages/integration/test-coverage.adoc
@@ -8,6 +8,7 @@ With `--cov --test`:
 
 * `Coverage` runs gcov-based coverage for a `BuildTest` binary.
 * `CollateCoverageFiles` / `CollateCoverageIndex` collate per-test coverage into a shared `#_artefacts/coverage/` tree from two sibling sconscripts (regression for mid-action `Install` clashes on `by-source` pages).
+* Two independent `BuildTest` binaries under `--cov --test --parallel` still succeed, and Cuppa warns when that invocation actually uses `-j` > 1; `--cov --parallel` without `--test` does not warn.
 
 Skipped (with log) if `gcov` / `gcovr` are not on PATH, or when `CUPPA_TEST_TOOLCHAIN` is MSVC (`vc` / `cl` / `msvc`).
 
@@ -52,10 +53,27 @@ env.CollateCoverageIndex(cov, destination='#_artefacts/coverage/')
 cuppa -D --offline --toolchains=gcc --cov --test
 ----
 
+Parallel collection (two independent single-file tests, no shared library):
+
+[source,sh]
+----
+cuppa -D --offline --toolchains=gcc --cov --test --parallel
+----
+
+Instrumented compile only (must not warn about coverage collection):
+
+[source,sh]
+----
+cuppa -D --offline --toolchains=gcc --cov --parallel
+----
+
 == Expectations
 
 * Exit 0; coverage artifacts under `_build` and/or `COVERAGE` in stdout for the `Coverage` scenario.
 * For the collate scenario: `coverage-index--*.html` under `_artefacts/coverage/`, with by-source pages namespaced as `by-source/<index-stem>/...html` so sibling sconscripts can share the destination safely.
+* Two independent tests under `--cov --test --parallel` still exit 0 (this does not prove shared-library `.gcda` safety).
+* If that run enters Cuppa parallel mode (`-j` > 1), stdout contains `Collecting coverage with SCons -j is not reliable`.
+* `--cov --parallel` without `--test` does not emit that warning.
 
 '''
 

--- a/docs/modules/ROOT/pages/methods.adoc
+++ b/docs/modules/ROOT/pages/methods.adoc
@@ -234,7 +234,8 @@ See also xref:cxx-modules.adoc[{cpp} Modules] and xref:cxx-profiles.adoc[{cpp} P
 Detailed tutorials: xref:methods/coverage.adoc[Coverage methods].
 
 IMPORTANT: `--cov` does not imply `--test`. Prefer a parallel instrumented build, then a serial
-`--cov --test` collect step — see the Coverage page (and https://github.com/ja11sop/cuppa/issues/236[#236]).
+`--cov --test` collect step (Cuppa warns if you combine `--parallel` with coverage collection) —
+see the Coverage page and https://github.com/ja11sop/cuppa/issues/236[#236].
 
 == Packages
 

--- a/docs/modules/ROOT/pages/methods/coverage.adoc
+++ b/docs/modules/ROOT/pages/methods/coverage.adoc
@@ -52,10 +52,11 @@ cuppa -D --cov --parallel --offline
 cuppa -D --cov --test --offline --toolchains=gcc
 ----
 
-Running `--cov --test` together with `--parallel` is unreliable: interleaved test and gcov/gcovr
-output is hard to read, and parallel coverage collection has historically been flaky. Prefer the
-two-step recipe above for large projects. See also
-https://github.com/ja11sop/cuppa/issues/236[#236].
+`--cov --test` together with `--parallel` (or SCons `-j` > 1) is **not a supported way to
+collect coverage**. Cuppa warns at configure. Notes sit beside objects and are shared across
+binaries that link the same library; concurrent tests corrupt `.gcda`, and gcov/gcovr can race
+the processes that write them. `BuildTest` orders Coverage after that test's run; it does not
+isolate notes between tests. See https://github.com/ja11sop/cuppa/issues/236[#236].
 
 For a small tree where you do not need `--parallel`, a single serial command is fine:
 

--- a/docs/modules/ROOT/pages/testing-coverage.adoc
+++ b/docs/modules/ROOT/pages/testing-coverage.adoc
@@ -66,7 +66,7 @@ flowchart TD
   `BuildTest` targets.
 
 That split lets you build a large instrumented tree with `--parallel`, then collect coverage
-serially:
+**serially**:
 
 [source,sh]
 ----
@@ -74,10 +74,15 @@ cuppa -D --cov --parallel --offline
 cuppa -D --cov --test --offline
 ----
 
-Typically the instrumented build dominates wall time; the serial test/coverage step is shorter.
-Avoid `--parallel` on the `--cov --test` step — interleaved runner and gcov/gcovr output is hard
-to follow, and parallel collection has historically been unreliable. See
-https://github.com/ja11sop/cuppa/issues/236[#236] and xref:methods/coverage.adoc[Coverage methods].
+Do **not** pass `--parallel` (or SCons `-j` greater than 1) on the `--cov --test` step.
+
+Cuppa warns when those are combined. Coverage notes (`.gcda`) live beside object files and are
+shared whenever tests link the same library; `gcov` / `gcovr` are not isolated per test.
+`BuildTest` waits for that test to finish before collecting, but that does not make concurrent
+tests safe. Parallel *compile* of `--cov` without `--test` is fine.
+
+See xref:methods/coverage.adoc[Coverage methods] and
+https://github.com/ja11sop/cuppa/issues/236[#236].
 ====
 
 Cuppa uses toolchain gcov support plus https://gcovr.com/[gcovr] to emit HTML/JSON beside the variant output (and optionally collated destinations).

--- a/tests/integration/methods/test_coverage.py
+++ b/tests/integration/methods/test_coverage.py
@@ -7,6 +7,7 @@ import pytest
 
 from tests.helpers.cuppa_runner import assert_success, find_under_build, run_cuppa
 from tests.helpers.project import copy_dummy_project, write_sconstruct, write_sconscript
+from cuppa.cpp.coverage_workflow import PARALLEL_COVERAGE_COLLECTION_WARNING
 
 
 pytestmark = pytest.mark.integration
@@ -142,3 +143,64 @@ def test_coverage_with_mirrored_nested_source(tmp_path):
         "expected .gcda beside the mirrored object under working/src/detail/"
     )
     assert find_under_build(project, "*coverage*") or "COVERAGE" in result.stdout
+
+
+def _two_independent_coverage_tests(project):
+    write_sconstruct(project)
+    hello = (
+        "#include <cstdlib>\n"
+        "int main()\n"
+        "{\n"
+        "    return EXIT_SUCCESS;\n"
+        "}\n"
+    )
+    tests_dir = Path(project) / "tests"
+    tests_dir.mkdir(exist_ok=True)
+    (tests_dir / "alpha_cov.cpp").write_text(hello, encoding="utf-8")
+    (tests_dir / "beta_cov.cpp").write_text(hello, encoding="utf-8")
+    write_sconscript(
+        project,
+        "Import('env')\n"
+        "env.BuildTest('alpha_cov', 'tests/alpha_cov.cpp')\n"
+        "env.BuildTest('beta_cov', 'tests/beta_cov.cpp')\n",
+    )
+
+
+def test_coverage_parallel_independent_tests(tmp_path):
+    """Two single-file tests (no shared lib) still succeed under --cov --test --parallel."""
+    _skip_if_no_gcov_coverage()
+
+    project = copy_dummy_project(tmp_path)
+    _two_independent_coverage_tests(project)
+    result = run_cuppa(project, "--cov", "--test", "--parallel", timeout=300)
+    assert_success(result)
+    assert find_under_build(project, "*coverage*") or "COVERAGE" in result.stdout
+
+
+def test_coverage_parallel_collection_warns(tmp_path):
+    """--cov --test --parallel warns when SCons actually runs with -j > 1."""
+    _skip_if_no_gcov_coverage()
+
+    project = copy_dummy_project(tmp_path)
+    _two_independent_coverage_tests(project)
+    result = run_cuppa(project, "--cov", "--test", "--parallel", timeout=300)
+    assert_success(result)
+    entered_parallel = "parallel mode" in result.stdout
+    if entered_parallel:
+        assert PARALLEL_COVERAGE_COLLECTION_WARNING in result.stdout
+    else:
+        assert PARALLEL_COVERAGE_COLLECTION_WARNING not in result.stdout
+
+
+def test_coverage_parallel_compile_only_does_not_warn(tmp_path):
+    """Instrumented compile with --parallel (no --test) is the supported first step."""
+    project = copy_dummy_project(tmp_path)
+    write_sconstruct(project)
+    write_sconscript(
+        project,
+        "Import('env')\n"
+        "env.BuildTest('hello_test', 'tests/hello_test.cpp')\n",
+    )
+    result = run_cuppa(project, "--cov", "--parallel", timeout=300)
+    assert_success(result)
+    assert PARALLEL_COVERAGE_COLLECTION_WARNING not in result.stdout

--- a/tests/unit/test_coverage_workflow.py
+++ b/tests/unit/test_coverage_workflow.py
@@ -1,0 +1,49 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+import pytest
+
+from cuppa.cpp.coverage_workflow import (
+    PARALLEL_COVERAGE_COLLECTION_WARNING,
+    maybe_warn_parallel_coverage_collection,
+    parallel_coverage_collection_warning_text,
+    should_warn_parallel_coverage_collection,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ( dict( job_count=8, cov=True, test=True ), True ),
+        ( dict( job_count=8, cov=True, force_test=True ), True ),
+        ( dict( job_count=8, cov=True, benchmark=True ), True ),
+        ( dict( job_count=8, cov=True, force_benchmark=True ), True ),
+        ( dict( job_count=1, cov=True, test=True ), False ),
+        ( dict( job_count=8, cov=True, test=False ), False ),
+        ( dict( job_count=8, cov=False, test=True ), False ),
+        ( dict( job_count=0, cov=True, test=True ), False ),
+    ],
+)
+def test_should_warn_parallel_coverage_collection( kwargs, expected ):
+    assert should_warn_parallel_coverage_collection( **kwargs ) is expected
+
+
+def test_warning_text_keeps_stable_token():
+    text = parallel_coverage_collection_warning_text()
+    assert PARALLEL_COVERAGE_COLLECTION_WARNING in text
+    assert "--cov --parallel" in text
+    assert "--cov --test" in text
+
+
+def test_maybe_warn_emits_once_when_collecting( caplog ):
+    caplog.set_level( "WARNING", logger="cuppa" )
+    asserted = maybe_warn_parallel_coverage_collection( job_count=4, cov=True, test=True )
+    silent = maybe_warn_parallel_coverage_collection( job_count=4, cov=True )
+    assert asserted is True
+    assert silent is False
+    assert PARALLEL_COVERAGE_COLLECTION_WARNING in caplog.text


### PR DESCRIPTION
## Summary

Closes the 1.9.1 product slice for [#236](https://github.com/ja11sop/cuppa/issues/236): coverage collection under SCons `-j` is not a supported correct workflow.

- Warn at configure when `--cov` is combined with `--test` / `--force-test` / `--benchmark` / `--force-benchmark` and `-j` > 1 (including `--parallel`). Instrumented compile-only (`--cov --parallel`) stays silent.
- `BuildTest` / `BuildBenchmark` `Depends` Coverage on the Test/Benchmark node so gcov waits for that run.
- Analysis of what is and is not feasible (shared `.gcda`, graph cycles if Coverage `Depends` on the whole `BuildTest` return list) in `design/plans/coverage-parallel.md`. Per-test `GCOV_PREFIX` remains a later follow-on.

[#261](https://github.com/ja11sop/cuppa/issues/261) Profiles docs URLs already landed on `master`. This PR is the remaining 1.9.1 changelog work before Actions **prepare**.

## Test plan

- [x] `flake8 cuppa` / `pylint -E cuppa`
- [x] `pytest -m unit`
- [x] `pytest -m integration` (including `test_coverage.py` parallel warn / compile-only / independent tests)
- [x] CI green on the matrix
