### PR TITLE
Give GCC --rel LTO the same archive tools as Clang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Integration guard ``test_rel_lto_incremental``: a second ``--rel --test`` after
+  ``--rel --parallel`` must not re-archive or re-link a minimal static-lib +
+  ``BuildTest`` tree under GCC/Clang LTO
+  ([#262](https://github.com/ja11sop/cuppa/issues/262)).
+
 ### Changed
+
+- GCC ``--rel`` LTO matches Clang's archive story: emit ``-ffat-lto-objects`` and
+  prefer version-matched ``gcc-ar`` / ``gcc-ranlib`` when available
+  ([#262](https://github.com/ja11sop/cuppa/issues/262)).
+  This does **not** claim a fix for consumer-tree spurious re-links; that still
+  needs ``--debug=explain`` on the affected project.
 
 ### Deprecated
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,7 @@ Minor cycle after **1.9.1**. Prefer work that changes opt-in toolchain or packag
 
 | Area | Intent in 1.10.0 |
 |------|------------------|
-| GCC `--rel` LTO archiver / fat objects + spurious re-link investigation | [#262](https://github.com/ja11sop/cuppa/issues/262); analysis still needed (`--debug=explain`) |
+| GCC `--rel` LTO archiver / fat objects + spurious re-link investigation | [#262](https://github.com/ja11sop/cuppa/issues/262): **parity** (`gcc-ar` / `gcc-ranlib` + `-ffat-lto-objects`) lands in this cycle; consumer re-link cause still open (`--debug=explain`) |
 | GitLab CMake staging | [#209](https://github.com/ja11sop/cuppa/issues/209) |
 | Boost package patched/clean identity + Quince session Boost | [`boost-updates.md`](design/plans/boost-updates.md); [#250](https://github.com/ja11sop/cuppa/issues/250) |
 | Artefact removal design | [#135](https://github.com/ja11sop/cuppa/issues/135) |

--- a/cuppa/toolchains/gcc.py
+++ b/cuppa/toolchains/gcc.py
@@ -346,6 +346,29 @@ class Gcc(object):
         return name
 
 
+    def _resolve_versioned_tool( self, base_name ):
+        """Prefer a major-versioned sibling of this GCC (e.g. gcc-ar-16), else base_name.
+
+        ``cuppa.build_platform.where_is`` returns the *directory* containing the
+        program (SCons WhereIs + dirname). Join the tool name back on before use.
+        """
+        major = self._reported_version['major']
+        names = [
+            "{}-{}".format( base_name, major ),
+            base_name,
+        ]
+        for name in names:
+            resolved = self._resolve_driver( name )
+            if os.path.isabs( resolved ) and os.path.isfile( resolved ):
+                return resolved
+            found_dir = cuppa.build_platform.where_is( name )
+            if found_dir:
+                candidate = os.path.join( found_dir, name )
+                if os.path.isfile( candidate ):
+                    return candidate
+        return None
+
+
     def make_env( self, cuppa_env, variant, target_arch ):
 
         env = None
@@ -377,6 +400,16 @@ class Gcc(object):
         env['LIBS']         = []
         env['STATICLIBS']   = []
         env['DYNAMICLIBS']  = self.values['dynamic_libraries']
+
+        # GCC LTO slim objects in static archives need gcc-ar / gcc-ranlib so the
+        # plugin matches this compiler. Binutils ar alone is a common mismatch.
+        if self.__lto_flags():
+            gcc_ar = self._resolve_versioned_tool( 'gcc-ar' )
+            if gcc_ar:
+                env['AR'] = gcc_ar
+            gcc_ranlib = self._resolve_versioned_tool( 'gcc-ranlib' )
+            if gcc_ranlib:
+                env['RANLIB'] = gcc_ranlib
 
         self.update_variant( env, variant.name() )
 
@@ -583,12 +616,16 @@ class Gcc(object):
 
 
     def __lto_flags( self ):
-        """Release-only LTO flags (compile and link). Empty before GCC 8."""
+        """Release-only LTO flags (compile and link). Empty before GCC 8.
+
+        Include ``-ffat-lto-objects`` so static archives remain usable when the
+        archiver falls back to binutils ``ar`` (parity with Clang release LTO).
+        """
         major_ver = self._reported_version['major']
         if major_ver >= 12:
-            return ['-flto=auto']
+            return ['-flto=auto', '-ffat-lto-objects']
         if major_ver >= 8:
-            return ['-flto']
+            return ['-flto', '-ffat-lto-objects']
         return []
 
 

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -90,6 +90,7 @@
 ** xref:integration/test-build.adoc[Build]
 ** xref:integration/test-build-test.adoc[BuildTest and Test]
 ** xref:integration/test-build-library.adoc[Libraries]
+** xref:integration/test-rel-lto-incremental.adoc[Release LTO incremental]
 ** xref:integration/test-compile.adoc[Compile]
 ** xref:integration/test-glob.adoc[Glob]
 ** xref:integration/test-run-actions.adoc[Run and Benchmark]

--- a/docs/modules/ROOT/pages/integration-tests.adoc
+++ b/docs/modules/ROOT/pages/integration-tests.adoc
@@ -70,6 +70,9 @@ cuppa.run(default_variants=['dbg'])
 | `BuildStaticLib`, `BuildSharedLib`
 | xref:integration/test-build-library.adoc[]
 
+| Second `--rel --test` after `--rel --parallel` stays incremental (LTO guard)
+| xref:integration/test-rel-lto-incremental.adoc[]
+
 | `CompileStatic`, `CompileShared`
 | xref:integration/test-compile.adoc[]
 

--- a/docs/modules/ROOT/pages/integration/test-rel-lto-incremental.adoc
+++ b/docs/modules/ROOT/pages/integration/test-rel-lto-incremental.adoc
@@ -1,0 +1,29 @@
+= `test_rel_lto_incremental` — second `--rel` stays incremental
+:description: Cuppa integration test documentation for test_rel_lto_incremental
+
+
+== What is tested
+
+A small static library linked by two `BuildTest` binaries under **`--rel`** (LTO).
+After `cuppa -D --rel --parallel`, a second process `cuppa -D --rel --test` must not
+recompile, re-archive, or re-link: archive and test binary mtimes stay unchanged, and
+stdout shows no `g++` / `ar` / `ranlib` rebuild lines.
+
+This is a regression guard for GCC/Clang release LTO tooling
+(xref:toolchains/gcc.adoc[GCC] / xref:toolchains/clang.adoc[Clang]).
+It does **not** prove that a large consumer tree will never re-link; that needs
+`--debug=explain` on the affected project ([#262](https://github.com/ja11sop/cuppa/issues/262)).
+
+Skipped when `CUPPA_TEST_TOOLCHAIN` selects MSVC.
+
+== Command shape
+
+[source,sh]
+----
+cuppa -D --offline --toolchains=gcc --rel --parallel
+cuppa -D --offline --toolchains=gcc --rel --test
+----
+
+== Expectations
+
+Exit 0 on both runs; second run is fully incremental for `final/` archive and test binaries.

--- a/docs/modules/ROOT/pages/toolchains/gcc.adoc
+++ b/docs/modules/ROOT/pages/toolchains/gcc.adoc
@@ -112,6 +112,10 @@ Variant-specific additions:
 | `-flto` / `-flto=auto`
 | Link-time optimisation on `--rel` only (see LTO table)
 | https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-flto[Optimize Options]
+
+| `-ffat-lto-objects`
+| Emit fat LTO objects so archives stay usable with binutils `ar`
+| https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-ffat-lto-objects[Optimize Options]
 |===
 
 On Linux, link lines also receive:
@@ -212,14 +216,18 @@ It is not enabled for `--dbg` or `--cov`: LTO raises peak link memory and slows 
 | GCC version | `--rel` LTO flags
 
 | 12+
-| `-flto=auto`
+| `-flto=auto`, `-ffat-lto-objects`
 
 | 8–11
-| `-flto`
+| `-flto`, `-ffat-lto-objects`
 
 | before 8
 | _(none)_
 |===
+
+When LTO is enabled, cuppa also prefers a version-matched `gcc-ar` / `gcc-ranlib` (for example `gcc-ar-16`) so static archives keep GCC LTO objects correctly.
+
+`-ffat-lto-objects` keeps archives usable even if the system archiver falls back to binutils `ar`.
 
 == Stdlib
 

--- a/tests/integration/methods/test_rel_lto_incremental.py
+++ b/tests/integration/methods/test_rel_lto_incremental.py
@@ -1,0 +1,177 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+"""Two Cuppa --rel processes: second should not re-archive or re-link (#262).
+
+Minimal static-lib + BuildTest tree. Passed on pre-parity GCC; kept as a
+regression guard for gcc-ar / -ffat-lto-objects and Clang's matching story.
+Does not claim a large consumer re-link is fixed.
+"""
+
+import logging
+import os
+import re
+
+import pytest
+
+from tests.helpers.cuppa_runner import assert_success, find_under_build, run_cuppa
+from tests.helpers.project import write_sconstruct, write_sconscript
+
+
+pytestmark = pytest.mark.integration
+logger = logging.getLogger(__name__)
+
+
+def _skip_if_msvc():
+    forced = os.environ.get("CUPPA_TEST_TOOLCHAIN", "").strip().lower()
+    if forced in ("vc", "cl", "msvc"):
+        message = "MSVC has no Cuppa GCC/Clang LTO path; skipping --rel LTO incremental test"
+        logger.warning(message)
+        pytest.skip(message)
+
+
+def _write_lto_shared_lib_project(project):
+    """Static lib linked by two BuildTest binaries (shared .a is the interesting case)."""
+    (project / "lib").mkdir()
+    (project / "tests").mkdir()
+    (project / "lib" / "answer.cpp").write_text(
+        "int answer()\n"
+        "{\n"
+        "    return 42;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    for name in ("alpha_test", "beta_test"):
+        (project / "tests" / "{}.cpp".format(name)).write_text(
+            "int answer();\n"
+            "int main()\n"
+            "{\n"
+            "    return answer() == 42 ? 0 : 1;\n"
+            "}\n",
+            encoding="utf-8",
+        )
+    write_sconstruct(project, default_variants=["rel"])
+    write_sconscript(
+        project,
+        "Import('env')\n"
+        "lib = env.BuildStaticLib('answer', 'lib/answer.cpp')\n"
+        "env.AppendUnique(LIBPATH=[env['abs_final_dir']])\n"
+        "alpha = env.BuildTest('alpha_test', 'tests/alpha_test.cpp', LIBS=[lib])\n"
+        "beta = env.BuildTest('beta_test', 'tests/beta_test.cpp', LIBS=[lib])\n"
+        "env.Depends(alpha, lib)\n"
+        "env.Depends(beta, lib)\n",
+    )
+
+
+def _final_artefacts(project):
+    binaries = []
+    archives = []
+    for path in find_under_build(project):
+        if "final" not in path.parts or not path.is_file():
+            continue
+        if path.suffix in (".a", ".lib"):
+            archives.append(path)
+        elif path.suffix in ("", ".exe") or path.name in ("alpha_test", "beta_test"):
+            if path.suffix in (".stdout.log", ".stderr.log", ".success", ".json"):
+                continue
+            if path.name.endswith(".stdout.log") or path.name.endswith(".stderr.log"):
+                continue
+            if ".report." in path.name or path.name.endswith(".success"):
+                continue
+            if path.name.startswith("alpha_test") or path.name.startswith("beta_test"):
+                if path.suffix in ("", ".exe"):
+                    binaries.append(path)
+    return sorted(binaries), sorted(archives)
+
+
+def _mtime_map(paths):
+    return {str(path): path.stat().st_mtime_ns for path in paths}
+
+
+def _rebuild_lines(stdout):
+    """Return stdout lines that look like compile/archive/link work (not Progress)."""
+    lines = []
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("Progress(") or stripped.startswith("scons:"):
+            continue
+        if stripped.startswith("cuppa:"):
+            continue
+        if "Starting Test Suite" in stripped or "Test [" in stripped:
+            continue
+        if "= PASSED =" in stripped or "= FAILED =" in stripped:
+            continue
+        if "Time: Wall" in stripped:
+            continue
+        # Colourised paths aside, builders usually show the tool name early.
+        if re.search(
+            r"(^|/|\s)(g\+\+|clang\+\+|gcc-ar|llvm-ar|ar\b|ranlib\b|lib\.exe)",
+            stripped,
+        ):
+            lines.append(stripped)
+        elif " -o " in stripped and "/final/" in stripped.replace("\\", "/"):
+            lines.append(stripped)
+        elif " -c " in stripped and (".o " in stripped or ".o$" in stripped or stripped.endswith(".o")):
+            lines.append(stripped)
+    return lines
+
+
+def test_rel_lto_second_invocation_does_not_relink(tmp_path):
+    """Two Cuppa --rel processes: second should not re-archive or re-link (#262).
+
+    Guard for release LTO tooling. Minimal trees may already be incremental;
+    consumer re-links still need ``--debug=explain`` on the affected project.
+    """
+    _skip_if_msvc()
+
+    project = tmp_path / "lto_incremental"
+    project.mkdir()
+    _write_lto_shared_lib_project(project)
+
+    first = run_cuppa(project, "--rel", "--parallel", timeout=300)
+    assert_success(first)
+
+    binaries, archives = _final_artefacts(project)
+    assert archives, "expected a static archive under final/"
+    assert len(binaries) >= 2, "expected alpha_test and beta_test under final/, got {}".format(
+        binaries
+    )
+
+    before_bin = _mtime_map(binaries)
+    before_ar = _mtime_map(archives)
+
+    second = run_cuppa(project, "--rel", "--test", timeout=300)
+    assert_success(second)
+
+    rebuild = _rebuild_lines(second.stdout)
+    after_bin = _mtime_map(binaries)
+    after_ar = _mtime_map(archives)
+
+    changed_binaries = [path for path, mtime in before_bin.items() if after_bin.get(path) != mtime]
+    changed_archives = [path for path, mtime in before_ar.items() if after_ar.get(path) != mtime]
+
+    if rebuild or changed_binaries or changed_archives:
+        logger.warning(
+            "Second --rel --test was not fully incremental (spike for #262).\n"
+            "rebuild lines (%s):\n%s\nchanged binaries: %s\nchanged archives: %s\n"
+            "stdout tail:\n%s",
+            len(rebuild),
+            "\n".join(rebuild[:40]),
+            changed_binaries,
+            changed_archives,
+            "\n".join(second.stdout.splitlines()[-80:]),
+        )
+
+    assert not changed_archives, (
+        "static archive mtime changed on second --rel --test: {}".format(changed_archives)
+    )
+    assert not changed_binaries, (
+        "test binary mtime changed on second --rel --test: {}".format(changed_binaries)
+    )
+    assert not rebuild, (
+        "second --rel --test recompiled/archived/linked:\n{}".format("\n".join(rebuild))
+    )

--- a/tests/unit/test_toolchain_lto_flags.py
+++ b/tests/unit/test_toolchain_lto_flags.py
@@ -14,7 +14,7 @@ from cuppa.toolchains.gcc import Gcc
 pytestmark = pytest.mark.unit
 
 
-def _gcc(major, minor=0):
+def _gcc(major, minor=0, cxx_path=None):
     toolchain = Gcc.__new__(Gcc)
     toolchain._reported_version = {
         "major": major,
@@ -23,6 +23,7 @@ def _gcc(major, minor=0):
         "version": "{}.{}".format(major, minor),
         "short_version": str(major),
     }
+    toolchain._cxx_path = cxx_path
     toolchain.values = {}
     return toolchain
 
@@ -48,10 +49,10 @@ def _clang(major, minor=0, name=None, cxx_path=None):
     "major,expected",
     [
         (7, []),
-        (8, ["-flto"]),
-        (11, ["-flto"]),
-        (12, ["-flto=auto"]),
-        (15, ["-flto=auto"]),
+        (8, ["-flto", "-ffat-lto-objects"]),
+        (11, ["-flto", "-ffat-lto-objects"]),
+        (12, ["-flto=auto", "-ffat-lto-objects"]),
+        (15, ["-flto=auto", "-ffat-lto-objects"]),
     ],
 )
 def test_gcc_lto_flags_by_version(major, expected):
@@ -80,13 +81,36 @@ def test_gcc_lto_is_release_only():
     assert "-flto=auto" not in toolchain.values["debug_cxx_flags"]
     assert "-flto=auto" not in toolchain.values["coverage_cxx_flags"]
     assert "-flto=auto" in toolchain.values["release_cxx_flags"]
+    assert "-ffat-lto-objects" in toolchain.values["release_cxx_flags"]
     assert "-flto=auto" not in toolchain.values["debug_link_cxx_flags"]
     assert "-flto=auto" not in toolchain.values["coverage_link_cxx_flags"]
     assert "-flto=auto" in toolchain.values["release_link_cxx_flags"]
+    assert "-ffat-lto-objects" in toolchain.values["release_link_cxx_flags"]
     assert "-std=c++2c" in toolchain.values["debug_cxx_flags"]
     # GCC 11+: concepts/coroutines are in the dialect — no redundant -f* gates.
     assert "-fconcepts" not in toolchain.values["debug_cxx_flags"]
     assert "-fcoroutines" not in toolchain.values["debug_cxx_flags"]
+
+
+def test_gcc_resolve_versioned_tool_prefers_major_suffix(tmp_path):
+    gcc_ar = tmp_path / "gcc-ar-16"
+    gcc_ar.write_text("", encoding="utf-8")
+    gcc_ar.chmod(0o755)
+    toolchain = _gcc(16, cxx_path=str(tmp_path))
+    assert toolchain._resolve_versioned_tool("gcc-ar") == str(gcc_ar)
+
+
+def test_gcc_resolve_versioned_tool_joins_where_is_directory(tmp_path):
+    """where_is() returns a directory; AR must be the tool path, not the dir."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    gcc_ar = bindir / "gcc-ar"
+    gcc_ar.write_text("", encoding="utf-8")
+    gcc_ar.chmod(0o755)
+    toolchain = _gcc(15, cxx_path=str(tmp_path / "empty"))
+    (tmp_path / "empty").mkdir()
+    with patch("cuppa.build_platform.where_is", return_value=str(bindir)):
+        assert toolchain._resolve_versioned_tool("gcc-ar") == str(gcc_ar)
 
 
 def test_gcc_feature_flags_only_when_dialect_lacks_them():


### PR DESCRIPTION
## Summary

- GCC `--rel` LTO now emits `-ffat-lto-objects` and prefers version-matched `gcc-ar` / `gcc-ranlib`, matching Clang’s archive story ([#262](https://github.com/ja11sop/cuppa/issues/262)).
- Adds `test_rel_lto_incremental`: a second `--rel --test` after `--rel --parallel` must not re-archive or re-link a minimal static-lib + `BuildTest` tree (passed on pre-parity GCC; kept as a guard).
- Docs / CHANGELOG / ROADMAP updated. Consumer-tree spurious re-links are **not** fixed by this PR; confirmed with `--debug=explain` and tracked in [#267](https://github.com/ja11sop/cuppa/issues/267).

## Test plan

- [x] `flake8 cuppa` / `pylint -E cuppa`
- [x] `pytest -m unit`
- [x] `CUPPA_TEST_TOOLCHAIN=gcc pytest -m integration` (incl. `test_rel_lto_incremental`)
- [x] Spot-check: live `--rel` uses `gcc-ar-16` and `-ffat-lto-objects`
- [x] CI green on the matrix