### PR TITLE
Add --cxx-disable-lto for release builds without LTO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- ``--cxx-disable-lto``: omit release LTO flags (``-flto`` / ``-flto=auto`` /
+  ``-ffat-lto-objects``) from compile and link and skip LTO-specific archivers
+  (``gcc-ar`` / ``llvm-ar``). ``--rel`` still applies ``-O3`` / ``-DNDEBUG``.
+  Intended for diagnosing spurious ``--rel`` re-links
+  ([#267](https://github.com/ja11sop/cuppa/issues/267)).
 - Integration guard ``test_rel_lto_incremental``: a second ``--rel --test`` after
   ``--rel --parallel`` must not re-archive or re-link a minimal static-lib +
   ``BuildTest`` tree under GCC/Clang LTO

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,7 @@ Minor cycle after **1.9.1**. Prefer work that changes opt-in toolchain or packag
 
 | Area | Intent in 1.10.0 |
 |------|------------------|
-| GCC `--rel` LTO archiver / fat objects + spurious re-link investigation | [#262](https://github.com/ja11sop/cuppa/issues/262): **parity** (`gcc-ar` / `gcc-ranlib` + `-ffat-lto-objects`) lands in this cycle; consumer re-link cause still open (`--debug=explain`) |
+| GCC `--rel` LTO archiver / fat objects + spurious re-link investigation | [#262](https://github.com/ja11sop/cuppa/issues/262) parity shipped in [#266](https://github.com/ja11sop/cuppa/pull/266); re-links tracked in [#267](https://github.com/ja11sop/cuppa/issues/267) (`--cxx-disable-lto` diagnostic) |
 | GitLab CMake staging | [#209](https://github.com/ja11sop/cuppa/issues/209) |
 | Boost package patched/clean identity + Quince session Boost | [`boost-updates.md`](design/plans/boost-updates.md); [#250](https://github.com/ja11sop/cuppa/issues/250) |
 | Artefact removal design | [#135](https://github.com/ja11sop/cuppa/issues/135) |

--- a/cuppa/methods/cxx_lto.py
+++ b/cuppa/methods/cxx_lto.py
@@ -1,0 +1,57 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   C++ LTO policy (--cxx-disable-lto)
+#-------------------------------------------------------------------------------
+
+import SCons.Script
+
+from cuppa.colourise import as_info
+from cuppa.log import logger
+
+_disable_lto_logged = False
+
+
+def is_lto_disabled():
+    """True when ``--cxx-disable-lto`` was passed on the Cuppa/SCons command line.
+
+    Safe to call during toolchain initialise and from unit tests that never
+    registered the option (returns False).
+    """
+    try:
+        return bool( SCons.Script.GetOption( 'cxx_disable_lto' ) )
+    except Exception:
+        return False
+
+
+def note_lto_disabled_once():
+    global _disable_lto_logged
+    if _disable_lto_logged:
+        return
+    _disable_lto_logged = True
+    logger.info(
+        "LTO disabled by [{}]: --rel compile/link omit -flto* / -ffat-lto-objects "
+        "and LTO-specific archivers (gcc-ar / llvm-ar)".format( as_info( '--cxx-disable-lto' ) )
+    )
+
+
+class CxxDisableLtoMethod:
+
+    @classmethod
+    def add_options( cls, add_option ):
+        add_option(
+            '--cxx-disable-lto',
+            dest='cxx_disable_lto',
+            action='store_true',
+            help="Omit release LTO flags (-flto / -flto=auto / -ffat-lto-objects) from "
+                 "compile and link, and do not switch to gcc-ar / llvm-ar. Useful for "
+                 "diagnosing --rel incremental rebuilds; --rel still uses -O3 -DNDEBUG",
+        )
+
+    @classmethod
+    def add_to_env( cls, cuppa_env ):
+        # Option-only surface; no env.* method required.
+        pass

--- a/cuppa/toolchains/clang.py
+++ b/cuppa/toolchains/clang.py
@@ -745,7 +745,12 @@ class Clang(object):
         Include `-ffat-lto-objects` so static archives remain usable when the
         archiver is binutils `ar` (system LLVMgold is often an older LLVM than
         the active clang++, which otherwise drops bitcode members).
+        Honours ``--cxx-disable-lto`` (empty list; no llvm-ar / -fuse-ld=lld either).
         """
+        from cuppa.methods.cxx_lto import is_lto_disabled, note_lto_disabled_once
+        if is_lto_disabled():
+            note_lto_disabled_once()
+            return []
         major_ver = self._reported_version['major']
         if major_ver >= 17:
             return ['-flto=auto', '-ffat-lto-objects']

--- a/cuppa/toolchains/gcc.py
+++ b/cuppa/toolchains/gcc.py
@@ -620,7 +620,12 @@ class Gcc(object):
 
         Include ``-ffat-lto-objects`` so static archives remain usable when the
         archiver falls back to binutils ``ar`` (parity with Clang release LTO).
+        Honours ``--cxx-disable-lto`` (empty list; no LTO archiver switch either).
         """
+        from cuppa.methods.cxx_lto import is_lto_disabled, note_lto_disabled_once
+        if is_lto_disabled():
+            note_lto_disabled_once()
+            return []
         major_ver = self._reported_version['major']
         if major_ver >= 12:
             return ['-flto=auto', '-ffat-lto-objects']

--- a/docs/modules/ROOT/pages/cli/toolchains-and-features.adoc
+++ b/docs/modules/ROOT/pages/cli/toolchains-and-features.adoc
@@ -96,6 +96,22 @@ xref:toolchains/msvc.adoc[MSVC] family pages for exact emitted flags.
 
 For library/link details and platform defaults, see xref:toolchains/clang.adoc[Clang].
 
+== Release LTO
+
+On `--rel`, GCC and Clang enable link-time optimisation (see the family toolchain pages).
+Use this switch when you need `--rel` optimisations **without** LTO — for example to compare
+incremental rebuild behaviour against a full LTO `--rel` build.
+
+[cols="3,7"]
+|===
+| Option | Effect
+
+| `--cxx-disable-lto`
+| Omit `-flto` / `-flto=auto` / `-ffat-lto-objects` from `--rel` compile and link, and do not
+  switch to `gcc-ar` / `llvm-ar` (or Clang `-fuse-ld=lld` for LTO). `--rel` still uses
+  `-O3` and `-DNDEBUG`.
+|===
+
 == {cpp} modules
 
 [cols="3,7"]

--- a/docs/modules/ROOT/pages/toolchains/clang.adoc
+++ b/docs/modules/ROOT/pages/toolchains/clang.adoc
@@ -173,6 +173,8 @@ When LTO is enabled, cuppa also:
 
 `-ffat-lto-objects` keeps archives usable even if the system archiver falls back to binutils `ar`.
 
+Pass `--cxx-disable-lto` to build `--rel` without LTO (still `-O3` / `-DNDEBUG`) when comparing incremental behaviour; see xref:cli/toolchains-and-features.adoc[Toolchains and features].
+
 [#clang-default-linux-libraries]
 == Default Linux libraries
 

--- a/docs/modules/ROOT/pages/toolchains/gcc.adoc
+++ b/docs/modules/ROOT/pages/toolchains/gcc.adoc
@@ -229,6 +229,8 @@ When LTO is enabled, cuppa also prefers a version-matched `gcc-ar` / `gcc-ranlib
 
 `-ffat-lto-objects` keeps archives usable even if the system archiver falls back to binutils `ar`.
 
+Pass `--cxx-disable-lto` to build `--rel` without LTO (still `-O3` / `-DNDEBUG`) when comparing incremental behaviour; see xref:cli/toolchains-and-features.adoc[Toolchains and features].
+
 == Stdlib
 
 GCC uses the system **libstdc{plus}{plus}**.

--- a/tests/unit/test_toolchain_lto_flags.py
+++ b/tests/unit/test_toolchain_lto_flags.py
@@ -178,3 +178,9 @@ def test_clang_resolve_versioned_tool_joins_where_is_directory(tmp_path):
 def test_gcc_dialect_flags_no_longer_embed_lto():
     assert "-flto" not in _gcc(10)._Gcc__default_dialect_flags()
     assert "-flto=auto" not in _gcc(14)._Gcc__default_dialect_flags()
+
+
+def test_cxx_disable_lto_clears_gcc_and_clang_flags():
+    with patch("cuppa.methods.cxx_lto.is_lto_disabled", return_value=True):
+        assert _gcc(15)._Gcc__lto_flags() == []
+        assert _clang(21)._Clang__lto_flags() == []


### PR DESCRIPTION
## Summary

- Adds `--cxx-disable-lto`: `--rel` keeps `-O3` / `-DNDEBUG` but drops `-flto` / `-flto=auto` / `-ffat-lto-objects` on compile and link, and skips `gcc-ar` / `llvm-ar` (and Clang’s LTO `-fuse-ld=lld`).
- Documents the flag on the CLI toolchains page and GCC/Clang LTO sections.
- Consumer A/B for [#267](https://github.com/ja11sop/cuppa/issues/267): `--rel` **with** LTO persistently relinks every test program on a later `--test` process; `--rel --cxx-disable-lto` matches the `--dbg` control (0 program rebuilds). Dirtiness is the LTO surface, not “release vs debug” in general.

## Test plan

- [x] `flake8 cuppa` / `pylint -E cuppa`
- [x] `pytest -m unit` (incl. `test_cxx_disable_lto_clears_gcc_and_clang_flags`)
- [x] `CUPPA_TEST_TOOLCHAIN=gcc pytest -m integration`
- [x] Consumer A/B: `--rel --cxx-disable-lto` build then `--test` stays incremental
- [x] CI green on the matrix