### PR TITLE
Stabilize Boost static library link order (#267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ``add_dependent_libraries`` emits a stable subset of an expanded
+  ``boost_dependency_order()`` master list (including ``unit_test_framework``
+  at the old ``test`` slot, plus leaf libs such as ``program_options``).
+  Unknown names still append sorted. Previously, names outside the short
+  ordered list were appended by iterating a ``set``, so ``PYTHONHASHSEED``
+  flipped ``STATICLIBS`` / Program dependency order across Cuppa processes and
+  forced every test program to re-link on a later ``--rel --test`` even when
+  objects and archives were unchanged
+  ([#267](https://github.com/ja11sop/cuppa/issues/267)).
+
 ### Security
 
 ## [1.9.1] - 2026-09-04

--- a/cuppa/dependencies/boost/library_dependencies.py
+++ b/cuppa/dependencies/boost/library_dependencies.py
@@ -14,6 +14,11 @@ from cuppa.log       import logger
 
 
 def boost_dependency_order():
+    # Master static-link order: dependents before dependencies for GNU ld.
+    # add_dependent_libraries emits only the subset present in the required
+    # set, preserving relative order from this list. Keep every Boost library
+    # name Cuppa knows about here; unknown names are appended sorted for
+    # signature stability only (#267) and may not link correctly.
     return [
         'graph',
         'regex',
@@ -24,11 +29,27 @@ def boost_dependency_order():
         'date_time',
         'locale',
         'filesystem',
-        'test',
+        # 'test' is remapped to unit_test_framework before ordering
+        'unit_test_framework',
+        'prg_exec_monitor',
+        'test_exec_monitor',
         'timer',
         'chrono',
         'system',
-        'thread'
+        'thread',
+        # Leaf libraries (no inter-boost deps in Cuppa's model). Fixed order
+        # after the dependency-sensitive chain so subsets stay stable.
+        'exception',
+        'graph_parallel',
+        'iostreams',
+        'math',
+        'mpi',
+        'program_options',
+        'python',
+        'random',
+        'serialization',
+        'signals',
+        'wave',
     ]
 
 
@@ -107,13 +128,17 @@ def add_dependent_libraries( version, linktype, libraries, patched_test=False ):
                 required_libraries.update( ['system'] )
 
     libraries = []
+    ordered_names = boost_dependency_set()
 
     for library in boost_dependency_order():
         if library in required_libraries:
             libraries.append( library )
 
-    for library in required_libraries:
-        if library not in boost_dependency_set():
+    # Unknown names only: sorted so STATICLIBS / Program dependency order is
+    # stable across processes (set iteration follows PYTHONHASHSEED). Prefer
+    # extending boost_dependency_order() over relying on this tail (#267).
+    for library in sorted( required_libraries ):
+        if library not in ordered_names:
             libraries.append( library )
 
     return libraries

--- a/tests/unit/test_boost_library_dependencies.py
+++ b/tests/unit/test_boost_library_dependencies.py
@@ -1,0 +1,109 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+"""Unit tests for boost library dependency expansion order."""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from cuppa.dependencies.boost.library_dependencies import (
+    add_dependent_libraries,
+    boost_dependency_order,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+_CONSUMER_STYLE_LIBS = [
+    'log',
+    'log_setup',
+    'program_options',
+    'system',
+    'unit_test_framework',
+]
+
+
+def _assert_master_subset( result ):
+    master = boost_dependency_order()
+    positions = [ master.index( name ) for name in result if name in master ]
+    assert positions == sorted( positions ), result
+
+
+def test_add_dependent_libraries_emits_master_order_subset():
+    """Required libs keep relative order from boost_dependency_order()."""
+    result = add_dependent_libraries( 1.92, 'static', list( _CONSUMER_STYLE_LIBS ) )
+
+    assert result == [
+        'log_setup',
+        'log',
+        'date_time',
+        'filesystem',
+        'unit_test_framework',
+        'system',
+        'thread',
+        'program_options',
+    ]
+    _assert_master_subset( result )
+
+
+def test_add_dependent_libraries_test_alias_uses_unit_test_slot():
+    """Requesting 'test' remaps to unit_test_framework at the master slot."""
+    result = add_dependent_libraries( 1.86, 'static', [ 'filesystem', 'test' ] )
+
+    assert 'test' not in result
+    assert 'unit_test_framework' in result
+    assert result.index( 'filesystem' ) < result.index( 'unit_test_framework' )
+    assert result.index( 'unit_test_framework' ) < result.index( 'system' )
+    _assert_master_subset( result )
+
+
+def test_add_dependent_libraries_patched_test_keeps_timer_after_framework():
+    result = add_dependent_libraries(
+        1.86, 'static', [ 'unit_test_framework' ], patched_test=True
+    )
+
+    assert result.index( 'unit_test_framework' ) < result.index( 'timer' )
+    assert result.index( 'timer' ) < result.index( 'chrono' )
+    assert result.index( 'chrono' ) < result.index( 'system' )
+
+
+def test_add_dependent_libraries_unknown_names_sorted_after_master():
+    result = add_dependent_libraries(
+        1.92, 'static', [ 'system', 'zz_unknown', 'aa_unknown' ]
+    )
+
+    assert result[-2:] == [ 'aa_unknown', 'zz_unknown' ]
+    assert result.index( 'system' ) < result.index( 'aa_unknown' )
+
+
+def test_add_dependent_libraries_order_stable_across_hash_seeds():
+    """Same required set must yield the same link order under any PYTHONHASHSEED."""
+    code = (
+        'from cuppa.dependencies.boost.library_dependencies import '
+        'add_dependent_libraries; '
+        'print(add_dependent_libraries(1.92, "static", '
+        + repr( _CONSUMER_STYLE_LIBS )
+        + '))'
+    )
+    orders = set()
+    env_base = dict( os.environ )
+    env_base['PYTHONPATH'] = os.pathsep.join(
+        [ os.getcwd() ] + env_base.get( 'PYTHONPATH', '' ).split( os.pathsep )
+    )
+    for seed in ( '0', '1', '2', '42', '99', '12345', 'random' ):
+        env = dict( env_base )
+        env['PYTHONHASHSEED'] = seed
+        out = subprocess.check_output(
+            [ sys.executable, '-c', code ],
+            env=env,
+            text=True,
+        ).strip()
+        orders.add( out )
+
+    assert len( orders ) == 1, orders


### PR DESCRIPTION
## Summary

- Fix spurious cross-process Program re-links when Boost `STATICLIBS` order flipped (`#267`).
- Expand `boost_dependency_order()` into a master static-link order and emit a stable subset (including `unit_test_framework` at the old `test` slot, plus leaf libs such as `program_options`).
- Unknown names still append sorted for signature stability only; prefer extending the master list.

Root cause: remainder libs were appended by iterating a `set`, so `PYTHONHASHSEED` changed dependency order between Cuppa processes. SCons then rebuilt every linked Program even when objects and archives were unchanged (not an LTO archive signature issue).

## Test plan

- [x] `flake8 cuppa` / `pylint -E cuppa`
- [x] `pytest -m unit` (includes new `test_boost_library_dependencies`)
- [x] `pytest -m integration`
- [x] CI green on the matrix
- [x] Consumer: `--rel --parallel` then `--rel --test` with this checkout on `PYTHONPATH` — no program re-links

