### PR TITLE
Resolve untyped BuildWith boost; Quince use_libs (#250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- ``BuildWith`` resolves untyped ``boost`` by precedence (project-available
-  ``boost_package`` before built-in archive ``boost``), accepts ``[gitlab]boost`` /
-  ``[archive]boost`` pins, and refuses ``[conan]…`` for now. Quince links only via
+- ``BuildWith`` resolves untyped short names by general precedence (project-available
+  GitLab ``[gitlab]N`` / legacy ``{N}_package`` before archive/short ``N``), accepts
+  type selectors, and refuses ``[conan]…`` for now. Quince links only via
   ``BuildWith('boost').use_libs(...)``. Boost.Test runners use the same resolver
   through ``session_boost``
   ([#250](https://github.com/ja11sop/cuppa/issues/250)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ``BuildWith`` resolves untyped ``boost`` by precedence (project-available
+  ``boost_package`` before built-in archive ``boost``), accepts ``[gitlab]boost`` /
+  ``[archive]boost`` pins, and refuses ``[conan]…`` for now. Quince links only via
+  ``BuildWith('boost').use_libs(...)``. Boost.Test runners use the same resolver
+  through ``session_boost``
+  ([#250](https://github.com/ja11sop/cuppa/issues/250)).
 - ``add_dependent_libraries`` emits a stable subset of an expanded
   ``boost_dependency_order()`` master list (including ``unit_test_framework``
   at the old ``test`` slot, plus leaf libs such as ``program_options``).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,9 +21,9 @@ Minor cycle after **1.9.1**. Prefer work that changes opt-in toolchain or packag
 
 | Area | Intent in 1.10.0 |
 |------|------------------|
-| GCC `--rel` LTO archiver / fat objects + spurious re-link investigation | [#262](https://github.com/ja11sop/cuppa/issues/262) parity shipped in [#266](https://github.com/ja11sop/cuppa/pull/266); re-links tracked in [#267](https://github.com/ja11sop/cuppa/issues/267) (`--cxx-disable-lto` diagnostic) |
+| GCC `--rel` LTO archiver / fat objects + spurious re-links | [#262](https://github.com/ja11sop/cuppa/issues/262) parity shipped in [#266](https://github.com/ja11sop/cuppa/pull/266); re-links fixed in [#269](https://github.com/ja11sop/cuppa/pull/269) / [#267](https://github.com/ja11sop/cuppa/issues/267) (Boost `STATICLIBS` order) |
 | GitLab CMake staging | [#209](https://github.com/ja11sop/cuppa/issues/209) |
-| Boost package patched/clean identity + Quince session Boost | [`boost-updates.md`](design/plans/boost-updates.md); [#250](https://github.com/ja11sop/cuppa/issues/250) |
+| BuildWith dependency resolve + Quince | [`dependency-resolve.md`](design/plans/dependency-resolve.md); [#250](https://github.com/ja11sop/cuppa/issues/250); Boost identity remains [`boost-updates.md`](design/plans/boost-updates.md) |
 | Artefact removal design | [#135](https://github.com/ja11sop/cuppa/issues/135) |
 | Console bundle | `--terse-output`, log hygiene, `cuppa --info` |
 

--- a/cuppa/core/dependency_resolve.py
+++ b/cuppa/core/dependency_resolve.py
@@ -10,6 +10,9 @@
 
 """Resolve ``BuildWith`` dependency tokens to a factory-registry name.
 
+Rules are **name-general**, not Boost-specific. Untyped ``BuildWith('widget_lib')``
+prefers a project-available GitLab candidate over an archive/built-in short name.
+
 See ``design/plans/dependency-resolve.md``. Storage list/remove tokens share
 selector spelling via ``cuppa.core.dependency_tokens``.
 """
@@ -35,15 +38,6 @@ _ALWAYS_ON_BUILTINS = frozenset( {
     'boost',
 } )
 
-# Untyped short name → ordered (registry_name, role) candidates.
-# role: 'gitlab' | 'archive' — used for availability and Conan refusal.
-_UNTYPED_PRECEDENCE = {
-    'boost': (
-        ( 'boost_package', 'gitlab' ),  # legacy GitLab package registry name
-        ( 'boost', 'archive' ),
-    ),
-}
-
 
 def _as_name_set( value ):
     if not value:
@@ -51,13 +45,35 @@ def _as_name_set( value ):
     return set( Flatten( [ value ] ) )
 
 
+def _legacy_package_name( name ):
+    """Historical GitLab registry key when the short name was already taken."""
+    return '{}_package'.format( name )
+
+
+def _gitlab_registry_candidates( name ):
+    """Ordered registry keys that may identify a GitLab package for ``name``."""
+    return (
+        '[gitlab]{}'.format( name ),  # future typed registration
+        _legacy_package_name( name ),  # legacy: boost_package, widget_lib_package, …
+    )
+
+
+def _archive_registry_candidates( name ):
+    """Ordered registry keys that may identify an archive / built-in for ``name``."""
+    return (
+        '[archive]{}'.format( name ),
+        '[source]{}'.format( name ),
+        name,
+    )
+
+
 def is_project_available( env, registry_name ):
     """True when ``registry_name`` may be chosen for untyped / typed resolve.
 
     Declared (``default_dependencies``) or already ``BuildWith``'d this session
     counts. Always-on built-ins also require one of those — registry presence
-    alone is not enough. Other factories (e.g. ``boost_package``) are treated as
-    declared when present in ``env['dependencies']``.
+    alone is not enough. Other factories (e.g. ``widget_lib_package``) are
+    treated as declared when present in ``env['dependencies']``.
     """
     factories = env.get( 'dependencies' ) or {}
     if registry_name not in factories:
@@ -74,9 +90,10 @@ def is_project_available( env, registry_name ):
 def resolve_registry_name( env, token, required=True ):
     """Map a ``BuildWith`` token to an ``env['dependencies']`` factory key.
 
-    Untyped ``boost`` prefers project-available ``boost_package``, then falls
-    back to built-in ``boost``. Explicit ``[gitlab]boost``, ``[archive]boost``,
-    and ``boost_package`` bypass precedence. ``[conan]…`` is refused for now.
+    Untyped ``name`` prefers project-available GitLab candidates
+    (``[gitlab]name``, then legacy ``name_package``), then the short name /
+    archive keys. Explicit ``[gitlab]…`` / ``[archive]…`` pin the supply chain.
+    ``[conan]…`` is refused for now.
 
     Returns the registry name, or ``None`` when ``required`` is false and nothing
     matches. Raises ``DependencyResolveException`` when ``required`` and resolve
@@ -107,41 +124,54 @@ def resolve_registry_name( env, token, required=True ):
 
     factories = env.get( 'dependencies' ) or {}
 
-    if storage_type in ( 'archive', ):
-        return _require_factory( factories, name, token, required )
+    if storage_type == 'archive':
+        return _resolve_archive( factories, name, token, required )
 
     if storage_type == 'gitlab':
-        if name == 'boost':
-            # Canonical GitLab short name maps to legacy registry key today.
-            if 'boost_package' in factories:
-                return 'boost_package'
-            return _missing( token, required )
+        return _resolve_gitlab( factories, name, token, required )
+
+    if storage_type is not None:
+        # Other typed tokens: exact registry name for now.
         return _require_factory( factories, name, token, required )
 
-    # Untyped (or repository/other selectors unused for BuildWith boost yet).
-    if storage_type is not None and storage_type not in ( 'archive', 'gitlab' ):
-        # Allow exact registry lookup for other typed tokens later; for now
-        # require the bare name in the registry.
-        return _require_factory( factories, name, token, required )
+    return _resolve_untyped( env, factories, name, token, required )
 
-    precedence = _UNTYPED_PRECEDENCE.get( name )
-    if precedence:
-        archive_fallback = None
-        for registry_name, role in precedence:
-            if registry_name not in factories:
-                continue
-            if role == 'archive':
-                archive_fallback = registry_name
-                continue
-            if is_project_available( env, registry_name ):
-                return registry_name
-        if archive_fallback is not None:
-            # Built-in archive: final fallback even when not yet project-available
-            # so BuildWith('boost') keeps working as an opt-in to the built-in.
-            return archive_fallback
-        return _missing( token, required )
 
-    return _require_factory( factories, name, token, required )
+def _resolve_gitlab( factories, name, token, required ):
+    for registry_name in _gitlab_registry_candidates( name ):
+        if registry_name in factories:
+            return registry_name
+    # Short name only if it is not an always-on archive built-in.
+    if name in factories and name not in _ALWAYS_ON_BUILTINS:
+        return name
+    return _missing( token, required )
+
+
+def _resolve_archive( factories, name, token, required ):
+    for registry_name in _archive_registry_candidates( name ):
+        if registry_name in factories:
+            return registry_name
+    return _missing( token, required )
+
+
+def _resolve_untyped( env, factories, name, token, required ):
+    for registry_name in _gitlab_registry_candidates( name ):
+        if registry_name in factories and is_project_available( env, registry_name ):
+            return registry_name
+
+    if name in factories and is_project_available( env, name ):
+        return name
+
+    for registry_name in ( '[archive]{}'.format( name ), '[source]{}'.format( name ) ):
+        if registry_name in factories and is_project_available( env, registry_name ):
+            return registry_name
+
+    # Final fallback: short name in the registry (always-on built-in opt-in, or
+    # the only registered identity for this name).
+    if name in factories:
+        return name
+
+    return _missing( token, required )
 
 
 def _require_factory( factories, registry_name, token, required ):

--- a/cuppa/core/dependency_resolve.py
+++ b/cuppa/core/dependency_resolve.py
@@ -1,0 +1,158 @@
+
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   BuildWith dependency resolve (untyped precedence + type selectors)
+#-------------------------------------------------------------------------------
+
+"""Resolve ``BuildWith`` dependency tokens to a factory-registry name.
+
+See ``design/plans/dependency-resolve.md``. Storage list/remove tokens share
+selector spelling via ``cuppa.core.dependency_tokens``.
+"""
+
+from SCons.Script import Flatten
+
+from cuppa.core.dependency_tokens import parse_dependency_token
+from cuppa.utility.types import is_string
+
+
+class DependencyResolveException( Exception ):
+
+    def __init__( self, value ):
+        self.parameter = value
+
+    def __str__( self ):
+        return repr( self.parameter )
+
+
+# Always-on built-in short names: present in the factory registry even when the
+# project did not declare them. Registry presence alone is not project-available.
+_ALWAYS_ON_BUILTINS = frozenset( {
+    'boost',
+} )
+
+# Untyped short name → ordered (registry_name, role) candidates.
+# role: 'gitlab' | 'archive' — used for availability and Conan refusal.
+_UNTYPED_PRECEDENCE = {
+    'boost': (
+        ( 'boost_package', 'gitlab' ),  # legacy GitLab package registry name
+        ( 'boost', 'archive' ),
+    ),
+}
+
+
+def _as_name_set( value ):
+    if not value:
+        return set()
+    return set( Flatten( [ value ] ) )
+
+
+def is_project_available( env, registry_name ):
+    """True when ``registry_name`` may be chosen for untyped / typed resolve.
+
+    Declared (``default_dependencies``) or already ``BuildWith``'d this session
+    counts. Always-on built-ins also require one of those — registry presence
+    alone is not enough. Other factories (e.g. ``boost_package``) are treated as
+    declared when present in ``env['dependencies']``.
+    """
+    factories = env.get( 'dependencies' ) or {}
+    if registry_name not in factories:
+        return False
+    if registry_name in _as_name_set( env.get( 'BUILD_WITH' ) ):
+        return True
+    if registry_name in _as_name_set( env.get( 'default_dependencies' ) ):
+        return True
+    if registry_name in _ALWAYS_ON_BUILTINS:
+        return False
+    return True
+
+
+def resolve_registry_name( env, token, required=True ):
+    """Map a ``BuildWith`` token to an ``env['dependencies']`` factory key.
+
+    Untyped ``boost`` prefers project-available ``boost_package``, then falls
+    back to built-in ``boost``. Explicit ``[gitlab]boost``, ``[archive]boost``,
+    and ``boost_package`` bypass precedence. ``[conan]…`` is refused for now.
+
+    Returns the registry name, or ``None`` when ``required`` is false and nothing
+    matches. Raises ``DependencyResolveException`` when ``required`` and resolve
+    fails.
+    """
+    if not is_string( token ):
+        raise DependencyResolveException(
+                "dependency resolve expects a string token, got {!r}".format( token )
+        )
+
+    parsed, error = parse_dependency_token( token )
+    if error:
+        raise DependencyResolveException( error )
+
+    storage_type, name, qualifier = parsed
+    if qualifier is not None:
+        raise DependencyResolveException(
+                "BuildWith does not accept a /qualifier in dependency token [{}] "
+                "(got qualifier [{}])".format( token, qualifier )
+        )
+
+    if storage_type == 'conan':
+        raise DependencyResolveException(
+                "BuildWith does not support [conan] dependencies yet "
+                "(token [{}]); use an explicit Conan BuildWith name when ready"
+                .format( token )
+        )
+
+    factories = env.get( 'dependencies' ) or {}
+
+    if storage_type in ( 'archive', ):
+        return _require_factory( factories, name, token, required )
+
+    if storage_type == 'gitlab':
+        if name == 'boost':
+            # Canonical GitLab short name maps to legacy registry key today.
+            if 'boost_package' in factories:
+                return 'boost_package'
+            return _missing( token, required )
+        return _require_factory( factories, name, token, required )
+
+    # Untyped (or repository/other selectors unused for BuildWith boost yet).
+    if storage_type is not None and storage_type not in ( 'archive', 'gitlab' ):
+        # Allow exact registry lookup for other typed tokens later; for now
+        # require the bare name in the registry.
+        return _require_factory( factories, name, token, required )
+
+    precedence = _UNTYPED_PRECEDENCE.get( name )
+    if precedence:
+        archive_fallback = None
+        for registry_name, role in precedence:
+            if registry_name not in factories:
+                continue
+            if role == 'archive':
+                archive_fallback = registry_name
+                continue
+            if is_project_available( env, registry_name ):
+                return registry_name
+        if archive_fallback is not None:
+            # Built-in archive: final fallback even when not yet project-available
+            # so BuildWith('boost') keeps working as an opt-in to the built-in.
+            return archive_fallback
+        return _missing( token, required )
+
+    return _require_factory( factories, name, token, required )
+
+
+def _require_factory( factories, registry_name, token, required ):
+    if registry_name in factories:
+        return registry_name
+    return _missing( token, required )
+
+
+def _missing( token, required ):
+    if required:
+        raise DependencyResolveException(
+                "dependency [{}] is not available for BuildWith".format( token )
+        )
+    return None

--- a/cuppa/dependencies/boost/session.py
+++ b/cuppa/dependencies/boost/session.py
@@ -1,3 +1,4 @@
+
 #          Copyright Jamie Allsop 2026-2026
 # Distributed under the Boost Software License, Version 1.0.
 #    (See accompanying file LICENSE_1_0.txt or copy at
@@ -9,23 +10,25 @@
 
 """Resolve which Boost instance a session should use.
 
-``env['dependencies']`` is the *factory registry*. The built-in source ``boost``
-factory is always registered, even when the project only declared
-``boost_package``. Calling that factory extracts ``archives.boost.io``.
+Prefers project-available GitLab ``boost_package`` over built-in archive
+``boost`` via ``cuppa.core.dependency_resolve`` (see
+``design/plans/dependency-resolve.md``).
 """
+
+from cuppa.core.dependency_resolve import resolve_registry_name
 
 
 def session_boost( env ):
     """Return the Boost dependency for this env, or ``None``.
 
-    Prefer a declared ``boost_package`` so package-only builds never instantiate
-    source Boost. Fall back to the built-in ``boost`` factory.
+    Untyped resolve: ``boost_package`` when project-available, else built-in
+    ``boost``. Does not instantiate source Boost when the package wins.
     """
+    registry_name = resolve_registry_name( env, 'boost', required=False )
+    if registry_name is None:
+        return None
     factories = env.get( 'dependencies' ) or {}
-    package = factories.get( 'boost_package' )
-    if package is not None:
-        return package( env )
-    source = factories.get( 'boost' )
-    if source is not None:
-        return source( env )
-    return None
+    factory = factories.get( registry_name )
+    if factory is None:
+        return None
+    return factory( env )

--- a/cuppa/dependencies/boost/session.py
+++ b/cuppa/dependencies/boost/session.py
@@ -10,9 +10,8 @@
 
 """Resolve which Boost instance a session should use.
 
-Prefers project-available GitLab ``boost_package`` over built-in archive
-``boost`` via ``cuppa.core.dependency_resolve`` (see
-``design/plans/dependency-resolve.md``).
+Uses general ``cuppa.core.dependency_resolve`` rules (GitLab / ``{name}_package``
+before archive short name). See ``design/plans/dependency-resolve.md``.
 """
 
 from cuppa.core.dependency_resolve import resolve_registry_name

--- a/cuppa/dependencies/build_with_quince.py
+++ b/cuppa/dependencies/build_with_quince.py
@@ -48,19 +48,13 @@ class build_with_quince( location_dependency( 'quince', sys_include="include", s
     def __call__( self, env, toolchain, variant ):
         super(build_with_quince,self).__call__( env, toolchain, variant )
 
-        static_libs = [
-            'filesystem',
-            'thread'
-        ]
-
-        boost_version = env['dependencies']['boost']( env ).numeric_version()
-
-        if boost_version < 1.89:
-            static_libs.append( 'system' )
-
         env.AppendUnique( STATICLIBS = [
                 env.QuinceLibrary(),
-                env.BoostStaticLibs( static_libs ),
+        ] )
+        env.BuildWith( 'boost' ).use_libs( [
+                'filesystem',
+                'thread',
+                'system',
         ] )
 
 
@@ -100,8 +94,8 @@ class quince_postgresql( location_dependency( 'quince-postgresql', sys_include="
         env.Append( STATICLIBS = [
                 quince_postgresql_lib,
                 quince_lib,
-                env.BoostStaticLibs( [ 'date_time' ] ),
         ] )
+        env.BuildWith( 'boost' ).use_libs( [ 'date_time' ] )
 
         env['dependencies']['quince_date_lib']( env )( env, toolchain, variant )
 
@@ -171,10 +165,10 @@ class quince_sqlite( location_dependency( 'quince-sqlite', sys_include="include"
         env.Append( STATICLIBS  = [
                 quince_sqlite_lib,
                 quince_lib,
-                env.BoostStaticLibs( [
-                    'date_time',
-                    'filesystem',
-                ] ),
+        ] )
+        env.BuildWith( 'boost' ).use_libs( [
+                'date_time',
+                'filesystem',
         ] )
 
 

--- a/cuppa/methods/build_with.py
+++ b/cuppa/methods/build_with.py
@@ -10,6 +10,10 @@
 
 from SCons.Script import Flatten
 from cuppa.utility.types import is_string
+from cuppa.core.dependency_resolve import (
+        DependencyResolveException,
+        resolve_registry_name,
+)
 
 class BuildWithException(Exception):
 
@@ -37,7 +41,10 @@ class BuildWithMethod:
 
             name = None
             if is_string( named_dependency ):
-                name = named_dependency
+                try:
+                    name = resolve_registry_name( env, named_dependency )
+                except DependencyResolveException as error:
+                    raise BuildWithException( error.parameter )
             else:
                 name = named_dependency.name()
 
@@ -75,4 +82,3 @@ class BuildWithMethod:
             env['_pre_sconscript_phase_'] = True
             env.BuildWith( env['default_dependencies'] )
             env['_pre_sconscript_phase_'] = False
-

--- a/design/README.md
+++ b/design/README.md
@@ -21,7 +21,8 @@ maintainer workflow evolved.
 
 | Document | Status | Subject |
 |----------|--------|---------|
-| [`plans/boost-updates.md`](plans/boost-updates.md) | proposal | Boost source vs GitLab `boost_package` identity; #206 `use_libs`; #248/#249 test-runner `session_boost` shipped; #250 Quince session Boost |
+| [`plans/dependency-resolve.md`](plans/dependency-resolve.md) | in progress | BuildWith untyped resolve + type selectors; `use_libs`; Quince first consumer (#250) |
+| [`plans/boost-updates.md`](plans/boost-updates.md) | proposal | Boost source vs GitLab `boost_package` identity; #206 `use_libs`; #248/#249 runners; Quince gap → dependency-resolve |
 | [`plans/shiki-syntax-highlighting.md`](plans/shiki-syntax-highlighting.md) | proposal | Build-time Shiki for Antora listings; ANSI preview only — ROADMAP `doc-shiki` |
 | [`plans/coverage-performance.md`](plans/coverage-performance.md) | proposal | Where `--cov --test` time actually goes, what the A/B measurement ruled out, and the remaining suspects |
 | [`plans/coverage-parallel.md`](plans/coverage-parallel.md) | in progress | What `--cov --test --parallel` can and cannot do; 1.9.1 warn + Depends; `GCOV_PREFIX` deferred — [#236](https://github.com/ja11sop/cuppa/issues/236) |

--- a/design/ideas/scratchpad.md
+++ b/design/ideas/scratchpad.md
@@ -2,7 +2,7 @@
 
 - **Status:** living
 - **Related:** [`ROADMAP.md`](../../ROADMAP.md); [`design/README.md`](../README.md) (graduate notes into `plans/` then ROADMAP)
-- **Updated:** 2026-08-25
+- **Updated:** 2026-09-04
 
 Scratchpad for suggestions that may become new plans or updates to existing ones.
 The goal is to turn these notes into actionable, well-understood plan elements.
@@ -26,39 +26,7 @@ Do not put private project names here; use anonymised labels and
 - Split methods into own pages → [`plans/methods-pages-split.md`](../plans/methods-pages-split.md)
 - Better Antora UI bundle → [`plans/antora-ui-bundle.md`](../plans/antora-ui-bundle.md)
 - Shiki syntax highlighting → [`plans/shiki-syntax-highlighting.md`](../plans/shiki-syntax-highlighting.md)
-
-## Update: plans/boost-updates.md (related — dependency selection)
-
-### Boost name clashes and built-in dependencies (possibly a separate plan)
-
-Built-in dependencies such as `boost` are registered automatically. Consumers then opt in with
-`env.BuildWith()` or `default_dependencies`.
-
-A name taken by a built-in cannot be reused for another dependency. Consumer projects often
-register a GitLab Boost package under a different name (for example `boost_package`) to avoid
-clashing with the built-in `boost`.
-
-Type selectors may help: `[archive]boost`, `[gitlab]boost`, `[conan]boost`.
-
-Open questions:
-
-- Should type selectors be required always, or only when a name is ambiguous?
-- Should selection distinguish more than “available” vs “default”, for example:
-  - known / accessible
-  - imported / made available to this project
-  - used by default
-
-Today every built-in is automatically available (by design, for convenience). The longer-term
-direction is to move built-ins into their own repositories so `pip install` auto-registration
-acts as the “import” step. That is environment-scoped, not `sconstruct`-scoped.
-
-A backwards-compatible approach might keep today’s auto-register behaviour unless an
-`sconstruct` opts into an explicit list (`cuppa.import_dependencies([...])` /
-`cuppa.use_dependencies([...])`, perhaps with `cuppa.explicit_dependencies()` so nothing is
-available until imported). Naming (`env.UseDependency`, `env.Import`, …) is unsettled; “import”
-may be too general.
-
-This may need a broader dependency-selection plan; it surfaces here because of Boost.
+- Boost name clashes / BuildWith type resolve → [`plans/dependency-resolve.md`](../plans/dependency-resolve.md) (Quince #250; boost-updates cross-link)
 
 ## Output processing (follow-on)
 

--- a/design/plans/boost-updates.md
+++ b/design/plans/boost-updates.md
@@ -1,8 +1,8 @@
 # Plan: Boost source and package updates
 
 - **Status:** proposal
-- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Boost source and packages; [#206](https://github.com/ja11sop/cuppa/issues/206) (package-only builds must not pull source Boost); [#248](https://github.com/ja11sop/cuppa/issues/248) (test runners must not pull source Boost); [#250](https://github.com/ja11sop/cuppa/issues/250) (Quince must use session Boost); storage listing/removal stays in [`removal-options.md`](removal-options.md); offline “latest” persistence is [`boost-latest-persistence.md`](../archive/boost-latest-persistence.md) (separate)
-- **Updated:** 2026-09-02
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Boost source and packages; [#206](https://github.com/ja11sop/cuppa/issues/206) (package-only builds must not pull source Boost); [#248](https://github.com/ja11sop/cuppa/issues/248) (test runners must not pull source Boost); [#250](https://github.com/ja11sop/cuppa/issues/250) / [`dependency-resolve.md`](dependency-resolve.md) (Quince + BuildWith resolve); storage listing/removal stays in [`removal-options.md`](removal-options.md); offline “latest” persistence is [`boost-latest-persistence.md`](../archive/boost-latest-persistence.md) (separate)
+- **Updated:** 2026-09-04
 
 Source `boost` (b2 / extract homes) and GitLab `boost_package` share Boost.Test patch semantics
 but not storage identity. This plan is the home for those Boost-specific follow-ups. List /
@@ -36,7 +36,8 @@ re-extracted the full `archives.boost.io` source tree (~224 MB) even though link
 **Quince** is the same class of problem deliberately: built-ins hardcode `env.BuildWith('boost')`
 and `env.BoostStaticLibs(…)` (see [§Quince and the selector gap](#boost-quince-selector-gap)).
 Any project using `boost_package` for its own tests **and** Quince for DB access pays **both**
-supply chains unless we teach Quince (or cuppa generally) which Boost flavour the session chose.
+supply chains until untyped `BuildWith('boost')` resolves by precedence — see
+[`dependency-resolve.md`](dependency-resolve.md).
 
 That is why “name clash” is not only a **list/remove** UX issue — it is a **resolve** bug when
 two registered names (`boost` built-in vs `boost_package`) both mean “Boost” but only one was
@@ -46,10 +47,11 @@ intended.
 
 ## Quince and the selector gap
 
-**Concrete example** for the cross-type selector conversation ([§Related observation](#boost-type-selectors)).
+**Concrete example** for cross-type BuildWith resolve
+([`dependency-resolve.md`](dependency-resolve.md) — canonical plan).
 
-Quince is a built-in location dependency (`cuppa/dependencies/build_with_quince.py`). It has **no**
-`boost_package` awareness:
+Quince is a built-in location dependency (`cuppa/dependencies/build_with_quince.py`). Today it has
+**no** awareness of which Boost supply chain the project chose:
 
 | Built-in | Hard-coded Boost use |
 |----------|----------------------|
@@ -66,24 +68,17 @@ but also `BuildWith('quince')` (or quince in `default_dependencies`):
 3. **Version skew** — Quince reads numeric version from the **source** `boost` factory, not from
    `boost_package._version`; unpinned/latest on either side can diverge silently.
 
-This matches [#206](https://github.com/ja11sop/cuppa/issues/206) comment: Quince should be able to
-use the session’s Boost package instead of always building source libs.
+**Direction (not a Quince-only fork):**
 
-**Not fixed by `use_libs` patch alone.** Follow-on slices:
+- Untyped `BuildWith('boost')` resolves by precedence among project-available candidates
+  (GitLab / legacy `boost_package` before archive). See
+  [`dependency-resolve.md`](dependency-resolve.md) settled decisions.
+- Quince links only via `BuildWith('boost').use_libs([...])` — same API as sconscripts.
+- Test runners already prefer package via `session_boost()` ([#249](https://github.com/ja11sop/cuppa/pull/249));
+  that helper should share the same resolver.
 
-- **Test runners ([#249](https://github.com/ja11sop/cuppa/pull/249) / [#248](https://github.com/ja11sop/cuppa/issues/248)):** `RunBoostTest` /
-  `RunPatchedBoostTest` used to call the source `boost` factory whenever it was in the
-  registry (always), then overwrite flags from `boost_package`. Under `--parallel` that
-  started a source extract while another test read `version.hpp`. Runners now use
-  `session_boost()` (package first).
-- **Quince ([#250](https://github.com/ja11sop/cuppa/issues/250)):** Resolve “session Boost” once: prefer declared `boost_package`
-  when present and compatible, else fall back to built-in `boost`. Quince `update_env` /
-  `BoostStaticLibs` paths call that resolver instead of unconditional `BuildWith('boost')`.
-- Optional: Quince links via `boost_package.use_libs()` for the small static set it needs, or a
-  shared helper both Quince and sconscripts use.
-
-Until then, projects needing Quince **and** `boost_package` should expect duplicate Boost work, or
-must stay on source Boost for everything.
+Tracking issue for the Quince consumer slice:
+[#250](https://github.com/ja11sop/cuppa/issues/250).
 
 <a id="boost-type-selectors"></a>
 
@@ -230,7 +225,7 @@ Still in this plan if we touch source Boost again:
 |----|--------|-------|
 | `boost-use-libs-no-source` | `boost_package.use_libs` must not invoke source `boost` factory | **Shipped** — [#206](https://github.com/ja11sop/cuppa/issues/206) / [#207](https://github.com/ja11sop/cuppa/pull/207): pass package version to `remove_system_static_lib` |
 | `boost-test-runner-no-source` | Test runners must not instantiate source `boost` when `boost_package` is declared | **Shipped** — [#249](https://github.com/ja11sop/cuppa/pull/249) / [#248](https://github.com/ja11sop/cuppa/issues/248): `session_boost()`; serialise source location cache |
-| `boost-quince-package` | Quince uses session `boost_package` when declared | **Proposal** — [#250](https://github.com/ja11sop/cuppa/issues/250); [§Quince and the selector gap](#boost-quince-selector-gap) |
+| `boost-quince-package` | Quince uses session Boost via shared BuildWith resolve + `use_libs` | **Done** in [`dependency-resolve.md`](dependency-resolve.md) / [#250](https://github.com/ja11sop/cuppa/issues/250) |
 | `boost-pkg-version` | Canonical `{base}-patched` / `{base}-clean`; strip suffix for numeric version; publisher + resolve + `package_id` | Core identity |
 | `boost-pkg-compat` | Patched resolve falls back to bare `{base}`; record actual version; no clean→bare fallback | Needed before flipping publishers |
 | `boost-pkg-use-libs` | Pass `patched_test=` from package `use_libs` | Small, can ship with identity or just before |
@@ -241,29 +236,12 @@ Still in this plan if we touch source Boost again:
 
 ## Related observation: type selectors for name clashes
 
-Boost is the sharpest case today (`boost` source / archive extract vs GitLab `boost_package`
-both reading as “boost” in human speech), but the same clash appears whenever two supply chains
-share a short name. **Quince** is the built-in that most clearly forces source Boost today even
-when the project declared `boost_package` — see [§Quince and the selector gap](#boost-quince-selector-gap).
+BuildWith-time type selectors and untyped precedence are specified in
+[`dependency-resolve.md`](dependency-resolve.md). Storage list/remove/purge already uses the same
+selector spelling ([`removal-options.md`](removal-options.md) §4.15).
 
-**Idea (not in the first Boost identity PR):** allow an optional type prefix on dependency
-tokens, consistent with wipe/remove grammar already used for storage types:
-
-| Token | Meaning |
-|-------|---------|
-| `[gitlab]boost` / `[gitlab]boost/1.91-patched` | Registry package identity |
-| `[archive]boost` / `[source]boost` | Source / archive-extract Boost |
-| `[toolchain]clang/profiles-2026-08-07-27` | Fetched toolchain archive (see toolchain-archive plan) |
-
-Unprefixed `boost` keeps today’s resolution rules (project-declared deps, existing heuristics).
-Selectors disambiguate **list / remove / purge / wipe** and any future “pin this flavour”
-CLIs when two types coexist on disk.
-
-Track implementation with removal-options / dependency listing work; Boost identity
-(`-patched` / `-clean` versions) remains the first fix for GitLab vs GitLab collisions.
-Type selectors address **cross-type** collisions. **Session resolve** (which Boost a built-in
-like Quince should use when `boost_package` is declared) may land before or with selectors — Quince
-is the motivating consumer.
+Boost remains the sharpest case (`boost` archive vs GitLab `boost_package`). Quince is the
+motivating built-in consumer — see [§Quince and the selector gap](#boost-quince-selector-gap).
 
 ## Suggested first PR
 

--- a/design/plans/dependency-resolve.md
+++ b/design/plans/dependency-resolve.md
@@ -1,0 +1,140 @@
+# Plan: BuildWith dependency resolve and type selectors
+
+- **Status:** in progress
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Dependencies; [`boost-updates.md`](boost-updates.md) (Boost identity / Quince motivation); [`removal-options.md`](removal-options.md) §4.15 (storage token grammar already shipped); [#250](https://github.com/ja11sop/cuppa/issues/250) (Quince first consumer); [#206](https://github.com/ja11sop/cuppa/issues/206) / [#248](https://github.com/ja11sop/cuppa/issues/248) (package-only must not pull source Boost); scratchpad note graduated from [`ideas/scratchpad.md`](../ideas/scratchpad.md)
+- **Updated:** 2026-09-04
+- **Impact:** minor — new opt-in resolve behaviour for untyped `BuildWith` names when multiple supply chains exist; Quince and runners become consumers
+
+## Why
+
+Cuppa already has two overlapping stories:
+
+1. **Uniform link API** — `env.BuildWith('…').use_libs([...])` so the dependency owns transitive
+   libs, ordering, and version-specific drops (e.g. Boost `system` ≥ 1.89). Documented for source
+   Boost and `boost_package`; some built-ins (Quince) still call `BoostStaticLibs` / manual
+   `STATICLIBS`.
+2. **Type selectors** — `[source]` / `[archive]`, `[gitlab]`, `[repository]`, `[conan]` on the
+   **storage** list/remove/purge surface ([`removal-options.md`](removal-options.md)). The same
+   vocabulary is **not** yet used when resolving `BuildWith('boost')`.
+
+Boost makes the gap concrete: the built-in archive factory is always registered as `boost`, while
+projects register GitLab Boost as `boost_package` to avoid the name clash. Quince and similar
+built-ins only know the short name “boost”; they must not hard-code `boost_package` vs `boost`.
+A Quince-local `session_boost` / `uses_boost_package` fork would fix one symptom and encode the
+wrong abstraction (superseded spike on branch work for [#250](https://github.com/ja11sop/cuppa/issues/250)).
+
+This plan is the home for **BuildWith-time** resolve rules and selectors. Boost package
+`-patched` / `-clean` identity stays in [`boost-updates.md`](boost-updates.md).
+
+## Goals
+
+1. **Untyped short names resolve by precedence** among project-available candidates of different
+   supply-chain types (GitLab package before archive for Boost-shaped cases).
+2. **Explicit type selectors** pin a supply chain: `[gitlab]boost`, `[archive]boost`, etc.
+3. **Legacy registry names** remain usable (`boost_package` as a known GitLab Boost identity).
+4. **`use_libs` is the link path** for dependents that need libraries from a resolved dependency.
+5. **Quince is the first worked example** — only `BuildWith('boost')` + `use_libs`; Cuppa chooses
+   the flavour.
+6. **Same resolver** for Boost.Test runners (replace or thin-wrap today’s `session_boost()`).
+
+## Non-goals
+
+- Requiring type selectors on every `BuildWith` (untyped names stay valid).
+- Selecting `[conan]…` for untyped short names until Conan deps expose the same APIs (`use_libs`,
+  version helpers) — see [`archive/conan-consumer-plan.md`](../archive/conan-consumer-plan.md).
+- Renaming the Python API `location_dependency` or changing storage bucket labels.
+- Auto-registering GitLab packages under the short name `boost` without selectors (name clash with
+  the built-in remains until typed registration exists).
+- Broader “explicit import only” / `cuppa.import_dependencies` (scratchpad longer-term idea;
+  not this slice).
+
+## Settled decisions
+
+| Topic | Decision |
+|-------|----------|
+| Link API | Dependents that need libraries call `BuildWith(<name>).use_libs([...])` (or `use_libs` on the instance `BuildWith` returned). No `BoostStaticLibs` / manual Boost `STATICLIBS` in Quince. |
+| What Quince knows | Only that it needs “boost” and which logical libs it wants. It does not branch on archive vs GitLab vs legacy package name. |
+| Untyped `BuildWith('boost')` precedence | Among **project-available** candidates, try in order: `[gitlab]boost` → legacy registry name `boost_package` → `[archive]boost` / built-in factory `boost`. |
+| Explicit tokens | `[gitlab]boost`, `[archive]boost` / `[source]boost`, or literal `boost_package` bypass precedence and select that candidate only. |
+| Conan | Never chosen for untyped `boost` (or other short names) until Conan deps share the link/version API. Explicit `[conan]boost` may error or no-op with a clear message until supported. |
+| Project-available | A candidate counts if it is **declared** for the project (`dependencies=` / `default_dependencies` / equivalent registration the project opted into) **or** already applied earlier in this env via `BuildWith` in the same sconscript session (`BUILD_WITH` / resolve record). Intent: an earlier `BuildWith('boost_package')` makes that package available for a later untyped `BuildWith('boost')`. |
+| Always-registered built-ins | Built-in `boost` stays in the factory registry for opt-in use. Presence in the registry alone does **not** beat a project-available GitLab package. Untyped resolve prefers package when package is project-available; otherwise falls through to archive `boost`. |
+| Selector spelling | Align with storage grammar ([`removal-options.md`](removal-options.md) §4.15): `[gitlab]`, `[archive]` / `[source]`, … Primary form `[selector]name`. |
+| Test runners | Use the same resolve helper as `BuildWith` (package-before-archive). Do not keep a Boost-only parallel policy long term. |
+| First consumer | Quince (`quince`, `quince-postgresql`, `quince-sqlite`) on [#250](https://github.com/ja11sop/cuppa/issues/250). |
+| Docs | Antora: precedence table + Quince example; methods/`BuildWith` note; quince stub points here. |
+
+## Vocabulary
+
+| Term | Meaning |
+|------|---------|
+| **Factory registry** | `env['dependencies']` — factories Cuppa knows about (includes always-on built-ins). |
+| **Project-available** | Declared by the project and/or already `BuildWith`’d on this env in the session (see table). |
+| **Untyped name** | `boost` — no `[selector]` prefix. |
+| **Typed token** | `[gitlab]boost`, `[archive]boost`, … |
+| **Legacy alias** | Registry key `boost_package` treated as GitLab Boost for precedence and explicit `BuildWith('boost_package')`. |
+
+Storage list/remove tokens and BuildWith tokens should **mean the same selectors**; implementation
+may share the parser already used for wipe/remove.
+
+## Quince shape after this lands
+
+```python
+def update_env( env ):
+    env.BuildWith( 'boost' )
+
+# when linking
+env.BuildWith( 'boost' ).use_libs( [ 'filesystem', 'thread', 'system' ] )
+# backends: use_libs( [ 'date_time', ... ] ) as today logically requires
+```
+
+Boost’s `use_libs` owns dependents, ordering, and dropping `system` when version ≥ 1.89.
+Quince does not call `ensure_session_boost` / `append_session_boost_static_libs` / package-vs-source
+branches.
+
+## Work slices
+
+| ID | Slice | Notes |
+|----|--------|-------|
+| `dep-resolve-rules` | This document’s settled table + ROADMAP / boost-updates cross-links | **This change** |
+| `dep-resolve-helper` | Shared resolve(name) used by `BuildWith` and runners; unit tests for precedence, `BUILD_WITH` availability, explicit selectors, Conan refusal | Implementation |
+| `dep-resolve-buildwith` | `BuildWith` accepts typed tokens; untyped uses helper | |
+| `dep-resolve-runners` | Point `session_boost` at helper or replace call sites | Closes parallel Boost-only policy |
+| `dep-resolve-quince` | Quince → `BuildWith('boost').use_libs(...)` only | [#250](https://github.com/ja11sop/cuppa/issues/250) |
+| `dep-resolve-docs` | Antora BuildWith / dependencies + quince stub | Same PR as Quince or immediately after |
+
+Optional later: register GitLab Boost as `[gitlab]boost` without requiring the `boost_package`
+legacy key; explicit-import-only built-ins (scratchpad).
+
+## Refusal rules
+
+- Do not teach Quince (or new built-ins) to branch on `boost_package` vs `boost`.
+- Do not leave source path on `BoostStaticLibs` while package path uses `use_libs`.
+- Do not treat “factory key present in the registry” as project-available for always-on built-ins
+  when a GitLab candidate is also project-available.
+- Do not select Conan for untyped short names in the first implementation.
+- Do not invent a third Boost session helper; extend resolve once and reuse.
+
+## Progress snapshot
+
+| Slice | Status |
+|-------|--------|
+| `dep-resolve-rules` | Done (this plan) |
+| `dep-resolve-helper` | Done — `cuppa/core/dependency_resolve.py` |
+| `dep-resolve-buildwith` | Done — `BuildWith` uses resolve |
+| `dep-resolve-runners` | Done — `session_boost` uses resolve |
+| `dep-resolve-quince` | Done — `use_libs` only ([#250](https://github.com/ja11sop/cuppa/issues/250)) |
+| `dep-resolve-docs` | Done — quince stub + methods page |
+
+**Superseded:** Quince-local `uses_boost_package` / `ensure_session_boost` /
+`append_session_boost_static_libs` approach drafted against [#250](https://github.com/ja11sop/cuppa/issues/250)
+before this plan — do not merge that shape.
+
+## Open questions (non-blocking for first PR)
+
+- Exact error text when untyped `boost` has **no** project-available candidate (should not happen
+  if built-in archive remains the final fallback whenever the factory exists — confirm product
+  intent: is “no Boost at all” possible?).
+- Whether `[source]` and `[archive]` are strict aliases for BuildWith (storage already aliases them).
+- When to allow registering a GitLab package under the short display name `boost` keyed only as
+  typed `[gitlab]boost` in the registry.

--- a/design/plans/dependency-resolve.md
+++ b/design/plans/dependency-resolve.md
@@ -54,15 +54,16 @@ This plan is the home for **BuildWith-time** resolve rules and selectors. Boost 
 |-------|----------|
 | Link API | Dependents that need libraries call `BuildWith(<name>).use_libs([...])` (or `use_libs` on the instance `BuildWith` returned). No `BoostStaticLibs` / manual Boost `STATICLIBS` in Quince. |
 | What Quince knows | Only that it needs “boost” and which logical libs it wants. It does not branch on archive vs GitLab vs legacy package name. |
-| Untyped `BuildWith('boost')` precedence | Among **project-available** candidates, try in order: `[gitlab]boost` → legacy registry name `boost_package` → `[archive]boost` / built-in factory `boost`. |
-| Explicit tokens | `[gitlab]boost`, `[archive]boost` / `[source]boost`, or literal `boost_package` bypass precedence and select that candidate only. |
-| Conan | Never chosen for untyped `boost` (or other short names) until Conan deps share the link/version API. Explicit `[conan]boost` may error or no-op with a clear message until supported. |
-| Project-available | A candidate counts if it is **declared** for the project (`dependencies=` / `default_dependencies` / equivalent registration the project opted into) **or** already applied earlier in this env via `BuildWith` in the same sconscript session (`BUILD_WITH` / resolve record). Intent: an earlier `BuildWith('boost_package')` makes that package available for a later untyped `BuildWith('boost')`. |
-| Always-registered built-ins | Built-in `boost` stays in the factory registry for opt-in use. Presence in the registry alone does **not** beat a project-available GitLab package. Untyped resolve prefers package when package is project-available; otherwise falls through to archive `boost`. |
-| Selector spelling | Align with storage grammar ([`removal-options.md`](removal-options.md) §4.15): `[gitlab]`, `[archive]` / `[source]`, … Primary form `[selector]name`. |
-| Test runners | Use the same resolve helper as `BuildWith` (package-before-archive). Do not keep a Boost-only parallel policy long term. |
-| First consumer | Quince (`quince`, `quince-postgresql`, `quince-sqlite`) on [#250](https://github.com/ja11sop/cuppa/issues/250). |
-| Docs | Antora: precedence table + Quince example; methods/`BuildWith` note; quince stub points here. |
+| Untyped precedence (general) | For any short name `N`, among **project-available** candidates try in order: `[gitlab]N` (typed registry key, when used) → legacy `{N}_package` → short name / `[archive]N` / `[source]N`. Final fallback: short name `N` if present in the factory registry (covers always-on built-ins such as `boost`). |
+| Legacy `{N}_package` | **General** GitLab naming convention when the short name is already taken (Boost’s `boost_package` is the motivating case, not a Boost-only rule). Prefer retiring it once packages register under `[gitlab]N`. |
+| Explicit tokens | `[gitlab]N`, `[archive]N` / `[source]N`, or literal `{N}_package` bypass untyped precedence. `[gitlab]N` maps to `[gitlab]N` or `{N}_package`, not to an always-on built-in short name. |
+| Conan | Never chosen for untyped short names until Conan deps share the link/version API. Explicit `[conan]…` errors for now. |
+| Project-available | Declared (`dependencies=` / `default_dependencies`) **or** already `BuildWith`’d earlier in this sconscript session (`BUILD_WITH`). |
+| Always-registered built-ins | e.g. built-in `boost`: registry presence alone is not project-available and does not beat a project-available GitLab candidate. |
+| Selector spelling | Align with storage grammar ([`removal-options.md`](removal-options.md) §4.15). |
+| Test runners | Same resolve helper as `BuildWith`. |
+| First consumer | Quince on [#250](https://github.com/ja11sop/cuppa/issues/250); unit tests cover a generic `widget_lib` / `widget_lib_package` pair as well as Boost. |
+| Docs | Antora precedence table is name-general; Quince is the worked example. |
 
 ## Vocabulary
 
@@ -70,9 +71,9 @@ This plan is the home for **BuildWith-time** resolve rules and selectors. Boost 
 |------|---------|
 | **Factory registry** | `env['dependencies']` — factories Cuppa knows about (includes always-on built-ins). |
 | **Project-available** | Declared by the project and/or already `BuildWith`’d on this env in the session (see table). |
-| **Untyped name** | `boost` — no `[selector]` prefix. |
-| **Typed token** | `[gitlab]boost`, `[archive]boost`, … |
-| **Legacy alias** | Registry key `boost_package` treated as GitLab Boost for precedence and explicit `BuildWith('boost_package')`. |
+| **Untyped name** | `boost`, `widget_lib` — no `[selector]` prefix. |
+| **Typed token** | `[gitlab]boost`, `[archive]widget_lib`, … |
+| **Legacy alias** | Registry key `{name}_package` treated as GitLab for that short name (e.g. `boost_package`). |
 
 Storage list/remove tokens and BuildWith tokens should **mean the same selectors**; implementation
 may share the parser already used for wipe/remove.
@@ -120,7 +121,7 @@ legacy key; explicit-import-only built-ins (scratchpad).
 | Slice | Status |
 |-------|--------|
 | `dep-resolve-rules` | Done (this plan) |
-| `dep-resolve-helper` | Done — `cuppa/core/dependency_resolve.py` |
+| `dep-resolve-helper` | Done — general name precedence in `cuppa/core/dependency_resolve.py` (not Boost-only) |
 | `dep-resolve-buildwith` | Done — `BuildWith` uses resolve |
 | `dep-resolve-runners` | Done — `session_boost` uses resolve |
 | `dep-resolve-quince` | Done — `use_libs` only ([#250](https://github.com/ja11sop/cuppa/issues/250)) |
@@ -130,11 +131,9 @@ legacy key; explicit-import-only built-ins (scratchpad).
 `append_session_boost_static_libs` approach drafted against [#250](https://github.com/ja11sop/cuppa/issues/250)
 before this plan — do not merge that shape.
 
-## Open questions (non-blocking for first PR)
+## Open questions (non-blocking)
 
-- Exact error text when untyped `boost` has **no** project-available candidate (should not happen
-  if built-in archive remains the final fallback whenever the factory exists — confirm product
-  intent: is “no Boost at all” possible?).
-- Whether `[source]` and `[archive]` are strict aliases for BuildWith (storage already aliases them).
-- When to allow registering a GitLab package under the short display name `boost` keyed only as
-  typed `[gitlab]boost` in the registry.
+- Exact error text when untyped `N` has **no** factory candidate.
+- When packages routinely register under `[gitlab]N`, deprecate accepting new `{N}_package`
+  registrations (keep resolve for compatibility).
+- Whether more built-ins than `boost` need the always-on availability exception list.

--- a/docs/modules/ROOT/pages/dependencies/builtins/quince.adoc
+++ b/docs/modules/ROOT/pages/dependencies/builtins/quince.adoc
@@ -11,11 +11,13 @@ on the backends). It asks only for the short name `boost` and links with `use_li
 env.BuildWith('boost').use_libs(['filesystem', 'thread', 'system'])
 ```
 
-Cuppa resolves untyped `boost` by precedence among project-available candidates: GitLab
-`boost_package` (including when already `BuildWith`'d earlier in the sconscript) before the
-built-in archive `boost`. Explicit pins such as `[archive]boost` or `[gitlab]boost` bypass
-precedence. See xref:methods/dependencies-and-profiles.adoc[Dependencies and profiles] and the
-repository plan `design/plans/dependency-resolve.md`.
+Cuppa resolves untyped `boost` by **general** short-name precedence among project-available
+candidates: GitLab (`[gitlab]boost` or legacy `boost_package`) before the built-in archive
+`boost`, including when the package was already `BuildWith`'d earlier in the sconscript.
+Explicit pins such as `[archive]boost` or `[gitlab]boost` bypass precedence. The same rules apply
+to any short name (for example `widget_lib` / `widget_lib_package`). See
+xref:methods/dependencies-and-profiles.adoc[Dependencies and profiles] and
+`design/plans/dependency-resolve.md`.
 
 This page is otherwise a stub. The modules live under `cuppa/dependencies/`. See
 xref:dependencies/builtins.adoc[Built-in dependencies] and

--- a/docs/modules/ROOT/pages/dependencies/builtins/quince.adoc
+++ b/docs/modules/ROOT/pages/dependencies/builtins/quince.adoc
@@ -1,9 +1,22 @@
 = Quince
-:description: Built-in quince ORM dependencies — honest stub
+:description: Built-in quince ORM dependencies — session Boost via BuildWith resolve
 
 The `quince` dependency (and related Quince backends such as PostgreSQL/SQLite helpers) pulls
 Quince as location dependencies for ORM-style {cpp} projects.
 
-This page is a stub. The modules live under `cuppa/dependencies/`. Expand it when real usage
-is documented. See xref:dependencies/builtins.adoc[Built-in dependencies] and
+Quince needs Boost libraries (`filesystem`, `thread`, `system` when applicable, plus `date_time`
+on the backends). It asks only for the short name `boost` and links with `use_libs`:
+
+```python
+env.BuildWith('boost').use_libs(['filesystem', 'thread', 'system'])
+```
+
+Cuppa resolves untyped `boost` by precedence among project-available candidates: GitLab
+`boost_package` (including when already `BuildWith`'d earlier in the sconscript) before the
+built-in archive `boost`. Explicit pins such as `[archive]boost` or `[gitlab]boost` bypass
+precedence. See xref:methods/dependencies-and-profiles.adoc[Dependencies and profiles] and the
+repository plan `design/plans/dependency-resolve.md`.
+
+This page is otherwise a stub. The modules live under `cuppa/dependencies/`. See
+xref:dependencies/builtins.adoc[Built-in dependencies] and
 xref:dependencies/location.adoc[Location dependencies].

--- a/docs/modules/ROOT/pages/methods/dependencies-and-profiles.adoc
+++ b/docs/modules/ROOT/pages/methods/dependencies-and-profiles.adoc
@@ -61,17 +61,24 @@ xref:dependencies/builtins/boost.adoc[Boost] and xref:dependencies.adoc[Dependen
 
 === Untyped names and type selectors
 
-When more than one supply chain can mean the same short name (Boost is the main case: built-in
-archive `boost` vs GitLab `boost_package`), an **untyped** `BuildWith('boost')` resolves by
-precedence among **project-available** candidates:
+When more than one supply chain can mean the same short name (for example a GitLab package
+registered as `widget_lib_package` alongside an archive or built-in `widget_lib`), an
+**untyped** `BuildWith('widget_lib')` resolves by precedence among **project-available**
+candidates:
 
-1. GitLab package registered as `boost_package` (or selected as `[gitlab]boost`) when declared in
-   `default_dependencies` / `dependencies=`, or already applied earlier in this sconscript via
-   `BuildWith`
-2. Built-in archive `boost` (final fallback so `BuildWith('boost')` still opts into the built-in)
+1. GitLab — registry key `[gitlab]widget_lib` when used, else the legacy `{name}_package`
+   form (`widget_lib_package`, and Boost’s familiar `boost_package`)
+2. Short name / archive — `widget_lib`, or `[archive]widget_lib` / `[source]widget_lib` when
+   registered that way
 
-Explicit tokens bypass precedence: `[archive]boost` / `[source]boost`, `[gitlab]boost`, or the
-literal registry name `boost_package`. `[conan]…` is not selected for untyped names yet.
+A candidate is project-available when it appears in `default_dependencies` / `dependencies=`, or
+was already applied earlier in this sconscript via `BuildWith`. Always-on built-ins such as
+archive `boost` stay in the factory registry for opt-in use; registry presence alone does not
+beat a project-available GitLab package.
+
+Explicit tokens bypass precedence: `[archive]widget_lib` / `[source]widget_lib`,
+`[gitlab]widget_lib`, or the literal legacy key `widget_lib_package`. `[conan]…` is not selected
+for untyped names yet.
 
 `use_libs([...])` is the uniform way to link libraries from whichever flavour was resolved.
 Built-ins such as xref:dependencies/builtins/quince.adoc[Quince] only ask for `boost` and call

--- a/docs/modules/ROOT/pages/methods/dependencies-and-profiles.adoc
+++ b/docs/modules/ROOT/pages/methods/dependencies-and-profiles.adoc
@@ -59,6 +59,24 @@ Where the dependency provides libraries, chain `.use_libs([...])` on the returne
 source builds, `boost_package`, and other `package_dependency` flavours). See
 xref:dependencies/builtins/boost.adoc[Boost] and xref:dependencies.adoc[Dependencies].
 
+=== Untyped names and type selectors
+
+When more than one supply chain can mean the same short name (Boost is the main case: built-in
+archive `boost` vs GitLab `boost_package`), an **untyped** `BuildWith('boost')` resolves by
+precedence among **project-available** candidates:
+
+1. GitLab package registered as `boost_package` (or selected as `[gitlab]boost`) when declared in
+   `default_dependencies` / `dependencies=`, or already applied earlier in this sconscript via
+   `BuildWith`
+2. Built-in archive `boost` (final fallback so `BuildWith('boost')` still opts into the built-in)
+
+Explicit tokens bypass precedence: `[archive]boost` / `[source]boost`, `[gitlab]boost`, or the
+literal registry name `boost_package`. `[conan]…` is not selected for untyped names yet.
+
+`use_libs([...])` is the uniform way to link libraries from whichever flavour was resolved.
+Built-ins such as xref:dependencies/builtins/quince.adoc[Quince] only ask for `boost` and call
+`use_libs` — they do not branch on package vs archive.
+
 Passing several names returns a list (order matches the call):
 
 [source,python]

--- a/tests/unit/test_dependency_resolve.py
+++ b/tests/unit/test_dependency_resolve.py
@@ -1,0 +1,105 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+"""Unit tests for BuildWith dependency resolve (#250 / dependency-resolve plan)."""
+
+import pytest
+
+from cuppa.core.dependency_resolve import (
+    DependencyResolveException,
+    is_project_available,
+    resolve_registry_name,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_is_project_available_builtin_needs_build_with_or_default():
+    env = {
+        'dependencies': { 'boost': object() },
+        'BUILD_WITH': [],
+        'default_dependencies': [],
+    }
+    assert is_project_available( env, 'boost' ) is False
+
+    env['BUILD_WITH'] = [ 'boost' ]
+    assert is_project_available( env, 'boost' ) is True
+
+
+def test_is_project_available_package_when_registered():
+    env = {
+        'dependencies': { 'boost_package': object() },
+        'BUILD_WITH': [],
+        'default_dependencies': [],
+    }
+    assert is_project_available( env, 'boost_package' ) is True
+
+
+def test_untyped_boost_prefers_project_available_package():
+    env = {
+        'dependencies': {
+            'boost': object(),
+            'boost_package': object(),
+        },
+        'BUILD_WITH': [],
+        'default_dependencies': [ 'boost_package' ],
+    }
+    assert resolve_registry_name( env, 'boost' ) == 'boost_package'
+
+
+def test_untyped_boost_prefers_package_already_buildwith():
+    env = {
+        'dependencies': {
+            'boost': object(),
+            'boost_package': object(),
+        },
+        'BUILD_WITH': [ 'boost_package' ],
+        'default_dependencies': [],
+    }
+    assert resolve_registry_name( env, 'boost' ) == 'boost_package'
+
+
+def test_untyped_boost_falls_back_to_archive_builtin():
+    env = {
+        'dependencies': { 'boost': object() },
+        'BUILD_WITH': [],
+        'default_dependencies': [],
+    }
+    assert resolve_registry_name( env, 'boost' ) == 'boost'
+
+
+def test_explicit_archive_boost_skips_package():
+    env = {
+        'dependencies': {
+            'boost': object(),
+            'boost_package': object(),
+        },
+        'default_dependencies': [ 'boost_package' ],
+    }
+    assert resolve_registry_name( env, '[archive]boost' ) == 'boost'
+    assert resolve_registry_name( env, '[source]boost' ) == 'boost'
+
+
+def test_explicit_gitlab_boost_maps_to_boost_package():
+    env = {
+        'dependencies': {
+            'boost': object(),
+            'boost_package': object(),
+        },
+    }
+    assert resolve_registry_name( env, '[gitlab]boost' ) == 'boost_package'
+    assert resolve_registry_name( env, 'boost_package' ) == 'boost_package'
+
+
+def test_explicit_conan_refused():
+    env = { 'dependencies': { 'boost': object() } }
+    with pytest.raises( DependencyResolveException ) as caught:
+        resolve_registry_name( env, '[conan]boost' )
+    assert 'conan' in caught.value.parameter.lower()
+
+
+def test_resolve_required_false_returns_none():
+    assert resolve_registry_name( {}, 'boost', required=False ) is None

--- a/tests/unit/test_dependency_resolve.py
+++ b/tests/unit/test_dependency_resolve.py
@@ -29,35 +29,67 @@ def test_is_project_available_builtin_needs_build_with_or_default():
     assert is_project_available( env, 'boost' ) is True
 
 
-def test_is_project_available_package_when_registered():
+def test_is_project_available_non_builtin_when_registered():
     env = {
-        'dependencies': { 'boost_package': object() },
+        'dependencies': { 'widget_lib_package': object() },
         'BUILD_WITH': [],
         'default_dependencies': [],
     }
-    assert is_project_available( env, 'boost_package' ) is True
+    assert is_project_available( env, 'widget_lib_package' ) is True
 
 
-def test_untyped_boost_prefers_project_available_package():
+def test_untyped_prefers_legacy_package_over_short_name():
+    """General case: widget_lib_package beats archive/short widget_lib."""
+    env = {
+        'dependencies': {
+            'widget_lib': object(),
+            'widget_lib_package': object(),
+        },
+        'BUILD_WITH': [],
+        'default_dependencies': [ 'widget_lib_package' ],
+    }
+    assert resolve_registry_name( env, 'widget_lib' ) == 'widget_lib_package'
+
+
+def test_untyped_prefers_package_already_buildwith():
+    env = {
+        'dependencies': {
+            'widget_lib': object(),
+            'widget_lib_package': object(),
+        },
+        'BUILD_WITH': [ 'widget_lib_package' ],
+        'default_dependencies': [],
+    }
+    assert resolve_registry_name( env, 'widget_lib' ) == 'widget_lib_package'
+
+
+def test_untyped_prefers_typed_gitlab_registry_key():
+    env = {
+        'dependencies': {
+            'widget_lib': object(),
+            '[gitlab]widget_lib': object(),
+        },
+        'default_dependencies': [ '[gitlab]widget_lib' ],
+    }
+    assert resolve_registry_name( env, 'widget_lib' ) == '[gitlab]widget_lib'
+
+
+def test_untyped_falls_back_to_short_name():
+    env = {
+        'dependencies': { 'widget_lib': object() },
+        'BUILD_WITH': [],
+        'default_dependencies': [],
+    }
+    assert resolve_registry_name( env, 'widget_lib' ) == 'widget_lib'
+
+
+def test_untyped_boost_prefers_boost_package():
     env = {
         'dependencies': {
             'boost': object(),
             'boost_package': object(),
         },
-        'BUILD_WITH': [],
         'default_dependencies': [ 'boost_package' ],
-    }
-    assert resolve_registry_name( env, 'boost' ) == 'boost_package'
-
-
-def test_untyped_boost_prefers_package_already_buildwith():
-    env = {
-        'dependencies': {
-            'boost': object(),
-            'boost_package': object(),
-        },
-        'BUILD_WITH': [ 'boost_package' ],
-        'default_dependencies': [],
     }
     assert resolve_registry_name( env, 'boost' ) == 'boost_package'
 
@@ -71,16 +103,26 @@ def test_untyped_boost_falls_back_to_archive_builtin():
     assert resolve_registry_name( env, 'boost' ) == 'boost'
 
 
-def test_explicit_archive_boost_skips_package():
+def test_explicit_archive_skips_legacy_package():
     env = {
         'dependencies': {
-            'boost': object(),
-            'boost_package': object(),
+            'widget_lib': object(),
+            'widget_lib_package': object(),
         },
-        'default_dependencies': [ 'boost_package' ],
+        'default_dependencies': [ 'widget_lib_package' ],
     }
-    assert resolve_registry_name( env, '[archive]boost' ) == 'boost'
-    assert resolve_registry_name( env, '[source]boost' ) == 'boost'
+    assert resolve_registry_name( env, '[archive]widget_lib' ) == 'widget_lib'
+    assert resolve_registry_name( env, '[source]widget_lib' ) == 'widget_lib'
+
+
+def test_explicit_gitlab_maps_to_legacy_package():
+    env = {
+        'dependencies': {
+            'widget_lib': object(),
+            'widget_lib_package': object(),
+        },
+    }
+    assert resolve_registry_name( env, '[gitlab]widget_lib' ) == 'widget_lib_package'
 
 
 def test_explicit_gitlab_boost_maps_to_boost_package():
@@ -94,12 +136,18 @@ def test_explicit_gitlab_boost_maps_to_boost_package():
     assert resolve_registry_name( env, 'boost_package' ) == 'boost_package'
 
 
-def test_explicit_conan_refused():
+def test_explicit_gitlab_does_not_select_always_on_builtin_short_name():
     env = { 'dependencies': { 'boost': object() } }
+    with pytest.raises( DependencyResolveException ):
+        resolve_registry_name( env, '[gitlab]boost' )
+
+
+def test_explicit_conan_refused():
+    env = { 'dependencies': { 'widget_lib': object() } }
     with pytest.raises( DependencyResolveException ) as caught:
-        resolve_registry_name( env, '[conan]boost' )
+        resolve_registry_name( env, '[conan]widget_lib' )
     assert 'conan' in caught.value.parameter.lower()
 
 
 def test_resolve_required_false_returns_none():
-    assert resolve_registry_name( {}, 'boost', required=False ) is None
+    assert resolve_registry_name( {}, 'widget_lib', required=False ) is None


### PR DESCRIPTION
## Summary

- Shared `BuildWith` dependency resolve: **general** untyped short-name precedence — project-available `[gitlab]N` / legacy `{N}_package` before archive/short `N` (not Boost-only).
- Quince links via `BuildWith('boost').use_libs(...)` (#250); `session_boost` uses the same resolver.
- Plan + Antora docs describe name-general rules; unit tests cover `widget_lib` as well as Boost.

## Test plan

- [x] `flake8 cuppa` / `pylint -E cuppa`
- [x] `pytest -m unit` (includes general `widget_lib` resolve cases)
- [x] `pytest -m integration`
- [x] CI green on the matrix

