### PR TITLE
Housekeeping for the 1.10.0 cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ``boost_package`` unpinned ``version`` uses registry latest (same as generic GitLab
   packages), no longer ``determine_latest_boost_version`` / boost.org
   ([#271](https://github.com/ja11sop/cuppa/issues/271)).
-- Document GitLab registry-``latest`` offline contract: remembered version string scoped
-  like ``boost_latest_version`` (shared downloads → ``~/.cuppaconfig``, project downloads
-  → ``configure.conf``); offline replays the pin or fails — no older-archive fallback
-  ([#271](https://github.com/ja11sop/cuppa/issues/271)).
-- Unit coverage for registry-latest conf-path scoping and offline pin + missing archive
-  (no older on-disk fallback) ([#271](https://github.com/ja11sop/cuppa/issues/271)).
 - GCC ``--rel`` LTO matches Clang's archive story: emit ``-ffat-lto-objects`` and
   prefer version-matched ``gcc-ar`` / ``gcc-ranlib`` when available
   ([#262](https://github.com/ja11sop/cuppa/issues/262)).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,25 +11,40 @@ Use this document to see what is shipped today, what is planned next, and what i
 
 When code and this roadmap disagree on *current* behaviour, **code and the Antora docs are authoritative**; update this file in the same change.
 
-**As of:** 2026-09-04
+**As of:** 2026-09-05
 
 ---
 
-## 1.10.0 cycle focus (open)
+## 1.11.0 cycle focus (open)
 
-Minor cycle after **1.9.1**. Prefer work that changes opt-in toolchain or package behaviour (`impact:minor`) over parking it in another patch.
+Minor cycle after **1.10.0**. Prefer work that changes opt-in toolchain or package behaviour
+(`impact:minor`) over parking it in another patch.
 
-| Area | Intent in 1.10.0 |
+| Area | Intent in 1.11.0 |
 |------|------------------|
-| GCC `--rel` LTO archiver / fat objects + spurious re-links | [#262](https://github.com/ja11sop/cuppa/issues/262) parity shipped in [#266](https://github.com/ja11sop/cuppa/pull/266); re-links fixed in [#269](https://github.com/ja11sop/cuppa/pull/269) / [#267](https://github.com/ja11sop/cuppa/issues/267) (Boost `STATICLIBS` order) |
-| GitLab CMake staging | [#209](https://github.com/ja11sop/cuppa/issues/209) |
-| GitLab package `latest` + consume docs | [`gitlab-package-latest.md`](design/plans/gitlab-package-latest.md) — registry latest; Boost package default retarget; Antora general-then-extension |
 | `cuppa.run` default_dependencies objects | [`run-default-dependency-objects.md`](design/plans/run-default-dependency-objects.md) — pass factories into both lists without `.name()` |
-| BuildWith dependency resolve + Quince | [`dependency-resolve.md`](design/plans/dependency-resolve.md); [#250](https://github.com/ja11sop/cuppa/issues/250) shipped; Boost identity remains [`boost-updates.md`](design/plans/boost-updates.md) |
+| GitLab CMake staging | [#209](https://github.com/ja11sop/cuppa/issues/209) |
 | Artefact removal design | [#135](https://github.com/ja11sop/cuppa/issues/135) |
 | Console bundle | `--terse-output`, log hygiene, `cuppa --info` |
+| Boost package identity | [`boost-updates.md`](design/plans/boost-updates.md) (`-patched` / `-clean`) |
 
-Parallel coverage collection (`GCOV_PREFIX`) remains a later coverage follow-on ([`coverage-parallel.md`](design/plans/coverage-parallel.md)); it is not a 1.10.0 gate.
+Parallel coverage collection (`GCOV_PREFIX`) remains a later coverage follow-on ([`coverage-parallel.md`](design/plans/coverage-parallel.md)); it is not a 1.11.0 gate.
+
+---
+
+## 1.10.0 cycle focus (ready to cut)
+
+Minor cycle after **1.9.1**. Open section is still `## [1.10.0] - unreleased` until Actions
+**prepare** / `finish_release`. Shipped on master:
+
+| Area | Status in 1.10.0 |
+|------|------------------|
+| GCC `--rel` LTO archiver / fat objects | [#262](https://github.com/ja11sop/cuppa/issues/262) / [#266](https://github.com/ja11sop/cuppa/pull/266) |
+| `--cxx-disable-lto` + Boost `STATICLIBS` order (spurious re-links) | [#268](https://github.com/ja11sop/cuppa/pull/268); [#267](https://github.com/ja11sop/cuppa/issues/267) / [#269](https://github.com/ja11sop/cuppa/pull/269) |
+| BuildWith dependency resolve + Quince | [`dependency-resolve.md`](design/archive/dependency-resolve.md); [#250](https://github.com/ja11sop/cuppa/issues/250) / [#270](https://github.com/ja11sop/cuppa/pull/270) |
+| GitLab package `latest` + consume docs | [`gitlab-package-latest.md`](design/archive/gitlab-package-latest.md); [#271](https://github.com/ja11sop/cuppa/issues/271) / [#272](https://github.com/ja11sop/cuppa/pull/272) |
+
+**Deferred to 1.11.0:** `default_dependencies` objects; [#209](https://github.com/ja11sop/cuppa/issues/209); [#135](https://github.com/ja11sop/cuppa/issues/135); console bundle; Boost package identity.
 
 ---
 
@@ -61,7 +76,7 @@ Cycle opened with docs/site and Profiles follow-ons; identity slices A–C close
 | Boost.Test runners skip source Boost extract | Shipped [#249](https://github.com/ja11sop/cuppa/pull/249) / [#248](https://github.com/ja11sop/cuppa/issues/248) |
 | Package staging for generated VariantDir lib dirs | Shipped [#256](https://github.com/ja11sop/cuppa/pull/256) / [#255](https://github.com/ja11sop/cuppa/issues/255) |
 
-**Larger follow-ons are listed under the 1.10.0 cycle.**
+**Larger follow-ons are listed under the 1.11.0 cycle.**
 
 ---
 
@@ -531,10 +546,10 @@ Design: [`native-toolchain-output.md`](design/plans/native-toolchain-output.md),
 
 | ID | Work | Priority | Notes |
 |----|------|----------|-------|
-| `console-terse-output` | `--terse-output`: coloured one-line success; commands on failure/warning | High | [`terse-build-output.md`](design/plans/terse-build-output.md); **1.10.0** |
-| `console-log-hygiene` | Configure-time log demotion; fix variant/action default messages | High | [`build-log-hygiene.md`](design/plans/build-log-hygiene.md); **1.10.0** |
-| `cli-info` | `cuppa --info`: package version without sconstruct / build | Medium | [`cuppa-info.md`](design/plans/cuppa-info.md); **1.10.0** |
-| `console-native-output` | `--native-output`: enable toolchain native colour; passthrough spawn | Medium | [`native-toolchain-output.md`](design/plans/native-toolchain-output.md); optional 1.10.0 |
+| `console-terse-output` | `--terse-output`: coloured one-line success; commands on failure/warning | High | [`terse-build-output.md`](design/plans/terse-build-output.md); **1.11.0** |
+| `console-log-hygiene` | Configure-time log demotion; fix variant/action default messages | High | [`build-log-hygiene.md`](design/plans/build-log-hygiene.md); **1.11.0** |
+| `cli-info` | `cuppa --info`: package version without sconstruct / build | Medium | [`cuppa-info.md`](design/plans/cuppa-info.md); **1.11.0** |
+| `console-native-output` | `--native-output`: enable toolchain native colour; passthrough spawn | Medium | [`native-toolchain-output.md`](design/plans/native-toolchain-output.md); optional 1.11.0 |
 | `console-stream-split` | Logging → stderr vs tool primary → stdout | Low | Validate current behaviour first (scratchpad note) |
 
 ### Out of scope (console output)

--- a/design/README.md
+++ b/design/README.md
@@ -21,9 +21,9 @@ maintainer workflow evolved.
 
 | Document | Status | Subject |
 |----------|--------|---------|
-| [`plans/gitlab-package-latest.md`](plans/gitlab-package-latest.md) | in progress | GitLab `version="latest"` = registry latest; Boost package retarget; consume docs split |
 | [`plans/run-default-dependency-objects.md`](plans/run-default-dependency-objects.md) | proposal | `cuppa.run` `default_dependencies` accepts dependency objects (back-compat with strings) |
-| [`plans/dependency-resolve.md`](plans/dependency-resolve.md) | in progress | BuildWith untyped resolve + type selectors; `use_libs`; Quince (#250) shipped |
+| [`archive/gitlab-package-latest.md`](archive/gitlab-package-latest.md) | shipped | GitLab `version="latest"` = registry latest; Boost package retarget; consume docs — [#271](https://github.com/ja11sop/cuppa/issues/271) / [#272](https://github.com/ja11sop/cuppa/pull/272) |
+| [`archive/dependency-resolve.md`](archive/dependency-resolve.md) | shipped | BuildWith untyped resolve + type selectors; Quince `use_libs` — [#250](https://github.com/ja11sop/cuppa/issues/250) / [#270](https://github.com/ja11sop/cuppa/pull/270) |
 | [`plans/boost-updates.md`](plans/boost-updates.md) | proposal | Boost source vs GitLab `boost_package` identity; #206 `use_libs`; #248/#249 runners; Quince gap → dependency-resolve |
 | [`plans/shiki-syntax-highlighting.md`](plans/shiki-syntax-highlighting.md) | proposal | Build-time Shiki for Antora listings; ANSI preview only — ROADMAP `doc-shiki` |
 | [`plans/coverage-performance.md`](plans/coverage-performance.md) | proposal | Where `--cov --test` time actually goes, what the A/B measurement ruled out, and the remaining suspects |

--- a/design/archive/dependency-resolve.md
+++ b/design/archive/dependency-resolve.md
@@ -1,8 +1,8 @@
 # Plan: BuildWith dependency resolve and type selectors
 
-- **Status:** in progress
-- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Dependencies; [`boost-updates.md`](boost-updates.md) (Boost identity / Quince motivation); [`removal-options.md`](removal-options.md) §4.15 (storage token grammar already shipped); [#250](https://github.com/ja11sop/cuppa/issues/250) (Quince first consumer); [#206](https://github.com/ja11sop/cuppa/issues/206) / [#248](https://github.com/ja11sop/cuppa/issues/248) (package-only must not pull source Boost); scratchpad note graduated from [`ideas/scratchpad.md`](../ideas/scratchpad.md)
-- **Updated:** 2026-09-04
+- **Status:** shipped
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Dependencies; [`../plans/boost-updates.md`](../plans/boost-updates.md) (Boost identity / Quince motivation); [`../plans/removal-options.md`](../plans/removal-options.md) §4.15 (storage token grammar already shipped); [#250](https://github.com/ja11sop/cuppa/issues/250) / [#270](https://github.com/ja11sop/cuppa/pull/270) (Quince first consumer); [#206](https://github.com/ja11sop/cuppa/issues/206) / [#248](https://github.com/ja11sop/cuppa/issues/248) (package-only must not pull source Boost); scratchpad note graduated from [`../ideas/scratchpad.md`](../ideas/scratchpad.md)
+- **Updated:** 2026-09-05
 - **Impact:** minor — new opt-in resolve behaviour for untyped `BuildWith` names when multiple supply chains exist; Quince and runners become consumers
 
 ## Why
@@ -14,7 +14,7 @@ Cuppa already has two overlapping stories:
    Boost and `boost_package`; some built-ins (Quince) still call `BoostStaticLibs` / manual
    `STATICLIBS`.
 2. **Type selectors** — `[source]` / `[archive]`, `[gitlab]`, `[repository]`, `[conan]` on the
-   **storage** list/remove/purge surface ([`removal-options.md`](removal-options.md)). The same
+   **storage** list/remove/purge surface ([`removal-options.md`](../plans/removal-options.md)). The same
    vocabulary is **not** yet used when resolving `BuildWith('boost')`.
 
 Boost makes the gap concrete: the built-in archive factory is always registered as `boost`, while
@@ -24,7 +24,7 @@ A Quince-local `session_boost` / `uses_boost_package` fork would fix one symptom
 wrong abstraction (superseded spike on branch work for [#250](https://github.com/ja11sop/cuppa/issues/250)).
 
 This plan is the home for **BuildWith-time** resolve rules and selectors. Boost package
-`-patched` / `-clean` identity stays in [`boost-updates.md`](boost-updates.md).
+`-patched` / `-clean` identity stays in [`boost-updates.md`](../plans/boost-updates.md).
 
 ## Goals
 
@@ -41,7 +41,7 @@ This plan is the home for **BuildWith-time** resolve rules and selectors. Boost 
 
 - Requiring type selectors on every `BuildWith` (untyped names stay valid).
 - Selecting `[conan]…` for untyped short names until Conan deps expose the same APIs (`use_libs`,
-  version helpers) — see [`archive/conan-consumer-plan.md`](../archive/conan-consumer-plan.md).
+  version helpers) — see [`conan-consumer-plan.md`](conan-consumer-plan.md).
 - Renaming the Python API `location_dependency` or changing storage bucket labels.
 - Auto-registering GitLab packages under the short name `boost` without selectors (name clash with
   the built-in remains until typed registration exists).
@@ -60,7 +60,7 @@ This plan is the home for **BuildWith-time** resolve rules and selectors. Boost 
 | Conan | Never chosen for untyped short names until Conan deps share the link/version API. Explicit `[conan]…` errors for now. |
 | Project-available | Declared (`dependencies=` / `default_dependencies`) **or** already `BuildWith`’d earlier in this sconscript session (`BUILD_WITH`). |
 | Always-registered built-ins | e.g. built-in `boost`: registry presence alone is not project-available and does not beat a project-available GitLab candidate. |
-| Selector spelling | Align with storage grammar ([`removal-options.md`](removal-options.md) §4.15). |
+| Selector spelling | Align with storage grammar ([`removal-options.md`](../plans/removal-options.md) §4.15). |
 | Test runners | Same resolve helper as `BuildWith`. |
 | First consumer | Quince on [#250](https://github.com/ja11sop/cuppa/issues/250); unit tests cover a generic `widget_lib` / `widget_lib_package` pair as well as Boost. |
 | Docs | Antora precedence table is name-general; Quince is the worked example. |

--- a/design/archive/gitlab-package-latest.md
+++ b/design/archive/gitlab-package-latest.md
@@ -1,8 +1,8 @@
 # Plan: GitLab package `latest` and consume docs
 
-- **Status:** in progress
-- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — 1.10.0 packages; [#271](https://github.com/ja11sop/cuppa/issues/271); [`boost-updates.md`](boost-updates.md) (Boost package identity / patched-clean; source Boost latest is separate); [`archive/boost-latest-persistence.md`](../archive/boost-latest-persistence.md) (source Boost scrape persistence — not registry latest); [`archive/build-and-package-identity.md`](../archive/build-and-package-identity.md) (lookup overrides); [`run-default-dependency-objects.md`](run-default-dependency-objects.md) (`default_dependencies` accepts objects); [#209](https://github.com/ja11sop/cuppa/issues/209) (CMake publish staging — parallel)
-- **Updated:** 2026-09-04
+- **Status:** shipped
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — 1.10.0; [#271](https://github.com/ja11sop/cuppa/issues/271) / [#272](https://github.com/ja11sop/cuppa/pull/272); [`../plans/boost-updates.md`](../plans/boost-updates.md) (Boost package identity / patched-clean; source Boost latest is separate); [`boost-latest-persistence.md`](boost-latest-persistence.md) (source Boost scrape persistence — not registry latest); [`build-and-package-identity.md`](build-and-package-identity.md) (lookup overrides); [`../plans/run-default-dependency-objects.md`](../plans/run-default-dependency-objects.md) (`default_dependencies` accepts objects — deferred); [#209](https://github.com/ja11sop/cuppa/issues/209) (CMake publish staging — deferred)
+- **Updated:** 2026-09-05
 - **Impact:** minor — new `version="latest"` consume behaviour; Boost package default changes; Antora consume docs
 
 ## Why
@@ -37,14 +37,14 @@ Antora is skewed: `gitlab.adoc` leads with Boost; the ordinary
 5. **Docs:** general GitLab depend-on first; then overrides; then `latest`; then extension
    interface with `boost_package` as the worked example; thin note on pip-installable custom
    packages. Prefer examples that pass the dependency **object** into both `dependencies` and
-   `default_dependencies` once [`run-default-dependency-objects.md`](run-default-dependency-objects.md)
+   `default_dependencies` once [`run-default-dependency-objects.md`](../plans/run-default-dependency-objects.md)
    lands; until then show `.name()` as the safe form.
 
 ## Non-goals
 
 - Changing source Boost (`BuildWith('boost')`) unpinned / `--boost-latest` scrape behaviour —
-  that stays under builtins Boost docs and [`boost-latest-persistence.md`](../archive/boost-latest-persistence.md).
-- Implementing full `-patched` / `-clean` package identity ([`boost-updates.md`](boost-updates.md))
+  that stays under builtins Boost docs and [`boost-latest-persistence.md`](boost-latest-persistence.md).
+- Implementing full `-patched` / `-clean` package identity ([`boost-updates.md`](../plans/boost-updates.md))
   in the same PR — but define how `latest` interacts (see settled decisions).
 - Magic string `"latest_release"` as a generic GitLab feature (packages that need upstream
   latest expose a callable; optional later string that dispatches to that hook with uniform
@@ -68,7 +68,7 @@ Antora is skewed: `gitlab.adoc` leads with Boost; the ordinary
 | Interaction with lookup overrides | Resolve latest **among versions that have (or could have) an archive for the preferred stem**; if listing is version-only, attempt download with current stem rules and fail uniformly on 404 after fallback — document honesty if the API cannot filter by stem. |
 | Interaction with `-patched` / `-clean` | Until identity lands: latest among version strings as published today. After identity: latest among versions matching the session’s package flavour (patched default for Boost). Do not block registry `latest` on identity shipping. |
 | Failure shape | Configure-time StopError / clear logger error: not available, not supported, offline with no remembered version — same family of messages as missing pinned package. |
-| Docs order | (1) Ordinary `package_dependency` + BuildWith; (2) lookup overrides; (3) `version="latest"`; (4) extension interface (`define`, `default_version`, `use_libs`, …) with Boost as example; (5) optional pip plugin stub. Ideal `cuppa.run` examples use the dependency object in `default_dependencies` — see [`run-default-dependency-objects.md`](run-default-dependency-objects.md). |
+| Docs order | (1) Ordinary `package_dependency` + BuildWith; (2) lookup overrides; (3) `version="latest"`; (4) extension interface (`define`, `default_version`, `use_libs`, …) with Boost as example; (5) optional pip plugin stub. Ideal `cuppa.run` examples use the dependency object in `default_dependencies` — see [`run-default-dependency-objects.md`](../plans/run-default-dependency-objects.md). |
 
 ## Example shapes
 
@@ -94,7 +94,7 @@ cuppa.run(
 
 Meaning: newest **registry** version of `google-cloud-cpp` for the current lookup stem.
 
-Until [`run-default-dependency-objects.md`](run-default-dependency-objects.md) ships, sconstructs
+Until [`run-default-dependency-objects.md`](../plans/run-default-dependency-objects.md) ships, sconstructs
 must keep using `.name()` or a string name in `default_dependencies`. Docs for registry `latest`
 should call that out and prefer `.name()` over duplicating the magic string.
 
@@ -128,7 +128,7 @@ boost_package = cuppa.packages.boost_package.define(
 | `pkg-latest-docs` | Restructure `packages.adoc` / `gitlab.adoc`; extension section; Boost as example | Same release; can be same PR as wire if small. Note object vs `.name()` for `default_dependencies` until run-default-dependency-objects lands |
 | `pkg-latest-issue` | File GitHub issue with `impact:minor` from this plan | When starting implementation |
 
-Related (separate plan): [`run-default-dependency-objects.md`](run-default-dependency-objects.md) —
+Related (separate plan): [`run-default-dependency-objects.md`](../plans/run-default-dependency-objects.md) —
 `default_dependencies = [ google_cloud_cpp ]` without `.name()`.
 
 ## Refusal rules

--- a/design/ideas/scratchpad.md
+++ b/design/ideas/scratchpad.md
@@ -26,7 +26,7 @@ Do not put private project names here; use anonymised labels and
 - Split methods into own pages → [`plans/methods-pages-split.md`](../plans/methods-pages-split.md)
 - Better Antora UI bundle → [`plans/antora-ui-bundle.md`](../plans/antora-ui-bundle.md)
 - Shiki syntax highlighting → [`plans/shiki-syntax-highlighting.md`](../plans/shiki-syntax-highlighting.md)
-- Boost name clashes / BuildWith type resolve → [`plans/dependency-resolve.md`](../plans/dependency-resolve.md) (Quince #250; boost-updates cross-link)
+- Boost name clashes / BuildWith type resolve → [`plans/dependency-resolve.md`](../archive/dependency-resolve.md) (Quince #250; boost-updates cross-link)
 
 ## Output processing (follow-on)
 

--- a/design/plans/boost-updates.md
+++ b/design/plans/boost-updates.md
@@ -1,7 +1,7 @@
 # Plan: Boost source and package updates
 
 - **Status:** proposal
-- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Boost source and packages; [#206](https://github.com/ja11sop/cuppa/issues/206) (package-only builds must not pull source Boost); [#248](https://github.com/ja11sop/cuppa/issues/248) (test runners must not pull source Boost); [#250](https://github.com/ja11sop/cuppa/issues/250) / [`dependency-resolve.md`](dependency-resolve.md) (Quince + BuildWith resolve); registry package `latest` is [`gitlab-package-latest.md`](gitlab-package-latest.md) (not boost.org scrape); storage listing/removal stays in [`removal-options.md`](removal-options.md); offline source-Boost “latest” persistence is [`boost-latest-persistence.md`](../archive/boost-latest-persistence.md) (separate)
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Boost source and packages; [#206](https://github.com/ja11sop/cuppa/issues/206) (package-only builds must not pull source Boost); [#248](https://github.com/ja11sop/cuppa/issues/248) (test runners must not pull source Boost); [#250](https://github.com/ja11sop/cuppa/issues/250) / [`dependency-resolve.md`](../archive/dependency-resolve.md) (Quince + BuildWith resolve); registry package `latest` is [`gitlab-package-latest.md`](../archive/gitlab-package-latest.md) (not boost.org scrape); storage listing/removal stays in [`removal-options.md`](removal-options.md); offline source-Boost “latest” persistence is [`boost-latest-persistence.md`](../archive/boost-latest-persistence.md) (separate)
 - **Updated:** 2026-09-04
 
 Source `boost` (b2 / extract homes) and GitLab `boost_package` share Boost.Test patch semantics
@@ -37,7 +37,7 @@ re-extracted the full `archives.boost.io` source tree (~224 MB) even though link
 and `env.BoostStaticLibs(…)` (see [§Quince and the selector gap](#boost-quince-selector-gap)).
 Any project using `boost_package` for its own tests **and** Quince for DB access pays **both**
 supply chains until untyped `BuildWith('boost')` resolves by precedence — see
-[`dependency-resolve.md`](dependency-resolve.md).
+[`dependency-resolve.md`](../archive/dependency-resolve.md).
 
 That is why “name clash” is not only a **list/remove** UX issue — it is a **resolve** bug when
 two registered names (`boost` built-in vs `boost_package`) both mean “Boost” but only one was
@@ -48,7 +48,7 @@ intended.
 ## Quince and the selector gap
 
 **Concrete example** for cross-type BuildWith resolve
-([`dependency-resolve.md`](dependency-resolve.md) — canonical plan).
+([`dependency-resolve.md`](../archive/dependency-resolve.md) — canonical plan).
 
 Quince is a built-in location dependency (`cuppa/dependencies/build_with_quince.py`). Today it has
 **no** awareness of which Boost supply chain the project chose:
@@ -72,7 +72,7 @@ but also `BuildWith('quince')` (or quince in `default_dependencies`):
 
 - Untyped `BuildWith('boost')` resolves by precedence among project-available candidates
   (GitLab / legacy `boost_package` before archive). See
-  [`dependency-resolve.md`](dependency-resolve.md) settled decisions.
+  [`dependency-resolve.md`](../archive/dependency-resolve.md) settled decisions.
 - Quince links only via `BuildWith('boost').use_libs([...])` — same API as sconscripts.
 - Test runners already prefer package via `session_boost()` ([#249](https://github.com/ja11sop/cuppa/pull/249));
   that helper should share the same resolver.
@@ -225,7 +225,7 @@ Still in this plan if we touch source Boost again:
 |----|--------|-------|
 | `boost-use-libs-no-source` | `boost_package.use_libs` must not invoke source `boost` factory | **Shipped** — [#206](https://github.com/ja11sop/cuppa/issues/206) / [#207](https://github.com/ja11sop/cuppa/pull/207): pass package version to `remove_system_static_lib` |
 | `boost-test-runner-no-source` | Test runners must not instantiate source `boost` when `boost_package` is declared | **Shipped** — [#249](https://github.com/ja11sop/cuppa/pull/249) / [#248](https://github.com/ja11sop/cuppa/issues/248): `session_boost()`; serialise source location cache |
-| `boost-quince-package` | Quince uses session Boost via shared BuildWith resolve + `use_libs` | **Done** in [`dependency-resolve.md`](dependency-resolve.md) / [#250](https://github.com/ja11sop/cuppa/issues/250) |
+| `boost-quince-package` | Quince uses session Boost via shared BuildWith resolve + `use_libs` | **Done** in [`dependency-resolve.md`](../archive/dependency-resolve.md) / [#250](https://github.com/ja11sop/cuppa/issues/250) |
 | `boost-pkg-version` | Canonical `{base}-patched` / `{base}-clean`; strip suffix for numeric version; publisher + resolve + `package_id` | Core identity |
 | `boost-pkg-compat` | Patched resolve falls back to bare `{base}`; record actual version; no clean→bare fallback | Needed before flipping publishers |
 | `boost-pkg-use-libs` | Pass `patched_test=` from package `use_libs` | Small, can ship with identity or just before |
@@ -237,7 +237,7 @@ Still in this plan if we touch source Boost again:
 ## Related observation: type selectors for name clashes
 
 BuildWith-time type selectors and untyped precedence are specified in
-[`dependency-resolve.md`](dependency-resolve.md). Storage list/remove/purge already uses the same
+[`dependency-resolve.md`](../archive/dependency-resolve.md). Storage list/remove/purge already uses the same
 selector spelling ([`removal-options.md`](removal-options.md) §4.15).
 
 Boost remains the sharpest case (`boost` archive vs GitLab `boost_package`). Quince is the

--- a/design/plans/run-default-dependency-objects.md
+++ b/design/plans/run-default-dependency-objects.md
@@ -1,7 +1,7 @@
 # Plan: `cuppa.run` accepts dependency objects in `default_dependencies`
 
 - **Status:** proposal
-- **Related:** [`ROADMAP.md`](../../ROADMAP.md); [`gitlab-package-latest.md`](gitlab-package-latest.md) (motivating consume ergonomics); [`dependency-resolve.md`](dependency-resolve.md) (BuildWith tokens remain strings); `cuppa/construct.py` `_normalise_with_defaults`
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md); [`gitlab-package-latest.md`](../archive/gitlab-package-latest.md) (motivating consume ergonomics); [`dependency-resolve.md`](../archive/dependency-resolve.md) (BuildWith tokens remain strings); `cuppa/construct.py` `_normalise_with_defaults`
 - **Updated:** 2026-09-04
 - **Impact:** minor — accept dependency factories/classes where names are required today; strings stay valid
 
@@ -42,7 +42,7 @@ strings into `default_profiles`.
 
 ## Non-goals
 
-- Changing BuildWith resolve / type selectors ([`dependency-resolve.md`](dependency-resolve.md)).
+- Changing BuildWith resolve / type selectors ([`dependency-resolve.md`](../archive/dependency-resolve.md)).
 - Requiring objects everywhere (strings remain first-class).
 - Auto-adding every `dependencies=` entry to `default_dependencies` (explicit default list stays).
 


### PR DESCRIPTION
## Summary

- Archive shipped plans (`gitlab-package-latest`, `dependency-resolve`) and refresh the design index.
- Mark the **1.10.0** cycle ready to cut; open **1.11.0** for deferred work (`default_dependencies` objects, [#209](https://github.com/ja11sop/cuppa/issues/209), [#135](https://github.com/ja11sop/cuppa/issues/135), console bundle, Boost package identity).
- Trim changelog noise (docs/test-only bullets folded into the feature entries).

No product behaviour change. After merge: Actions → **release** → **prepare**.

## Test plan

- [x] `pytest -m unit tests/unit/test_design_index.py tests/unit/test_version_and_changelog.py`
- [x] CI green