### PR TITLE
Import/auto-enable dependency kwargs and factory defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- ``cuppa.run`` ``default_dependencies`` / ``default_profiles`` accept dependency or
-  profile factories (same objects as ``dependencies`` / ``profiles``), coercing via
-  ``name()``; strings remain valid. Clear ``StopError`` when a non-string entry has no
-  usable name. Docs teach register vs auto-apply
+- ``cuppa.run`` preferred kwargs ``import_dependencies`` /
+  ``auto_enable_dependencies`` (and ``import_profiles`` /
+  ``auto_enable_profiles``), with legacy ``dependencies`` /
+  ``default_dependencies`` (and profile twins) as aliases. Lists accept factories or
+  strings via ``name()``; clear ``StopError`` when a non-string entry has no usable
+  name. Docs teach import vs auto-enable
   ([#276](https://github.com/ja11sop/cuppa/issues/276)).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``auto_enable_profiles``), with legacy ``dependencies`` /
   ``default_dependencies`` (and profile twins) as aliases. Lists accept factories or
   strings via ``name()``; clear ``StopError`` when a non-string entry has no usable
-  name. Docs teach import vs auto-enable
+  name. Docs teach import vs auto-enable; built-ins and pip plugins need only
+  ``auto_enable_dependencies``. Examples prefer ``BuildWith(...).use_libs(...)``
   ([#276](https://github.com/ja11sop/cuppa/issues/276)).
+  Integration fixtures exercise both preferred and legacy ``cuppa.run`` kwargs.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- ``cuppa.run`` ``default_dependencies`` / ``default_profiles`` accept dependency or
+  profile factories (same objects as ``dependencies`` / ``profiles``), coercing via
+  ``name()``; strings remain valid. Clear ``StopError`` when a non-string entry has no
+  usable name. Docs teach register vs auto-apply
+  ([#276](https://github.com/ja11sop/cuppa/issues/276)).
+
 ### Changed
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -75,17 +75,19 @@ cuppa -D --dbg --test --show-test-output
 
 A self-contained smoke project lives in [`examples/minimal/`](examples/minimal/).
 
-### Default dependencies
+### Auto-enable a built-in dependency
+
+Built-ins such as source Boost are already registered. Pass them to
+`auto_enable_dependencies` (not `import_dependencies`). Unpinned Boost resolves to the
+latest release on the download path; optionally pin a local tree with `boost-location` /
+`boost-home` in `default_options`.
 
 ```python
 import cuppa
 
 cuppa.run(
-    default_options = {
-        'boost-location': '/path/to/boost',
-    },
-    default_dependencies = [
-        'boost',
+    auto_enable_dependencies = [
+        'boost',  # unpinned → latest on the download path
     ],
 )
 ```
@@ -93,7 +95,10 @@ cuppa.run(
 ```python
 Import('env')
 
-env.AppendUnique(STATICLIBS=env.BoostStaticLibs(['system', 'filesystem']))
+env.BuildWith('boost').use_libs([
+    'system',
+    'filesystem',
+])
 env.BuildTest('my_test', 'my_test.cpp')
 ```
 

--- a/cuppa/construct.py
+++ b/cuppa/construct.py
@@ -44,7 +44,6 @@ from cuppa.cpp.coverage_workflow import maybe_warn_parallel_coverage_collection
 
 from cuppa.colourise import as_emphasised, as_info, as_error, as_notice, colour_items, as_info_label
 from cuppa.log import set_logging_level, reset_logging_format, logger, enable_thirdparty_logging
-from cuppa.utility.types import is_string
 from cuppa.utility.entry_points import iter_entry_points
 
 from cuppa.toolchains             import *
@@ -301,33 +300,8 @@ class Construct(object):
 
     @classmethod
     def _normalise_with_defaults( cls, values, default_values, name ):
-
-        warning = None
-        if isinstance( values, dict ):
-            warning = "Dictionary passed for {}, this approach has been deprecated, please use a list instead".format( name )
-            values = [ v for v in six.itervalues(values) ]
-
-        default_value_objects = []
-        default_value_names = []
-
-        for value in default_values:
-            if not is_string( value ):
-                default_value_objects.append( value )
-                try:
-                    name = getattr( value, 'name' )
-                    if callable( name ):
-                        default_value_names.append( name() )
-                    else:
-                        default_value_names.append( value.__name__ )
-                except:
-                    default_value_names.append( value.__name__ )
-            else:
-                default_value_names.append( value )
-
-        default_values = default_value_names
-        values = values + default_value_objects
-
-        return values, default_values, warning
+        from cuppa.core.run_list_names import normalise_with_defaults
+        return normalise_with_defaults( values, default_values, name )
 
 
     def __init__( self,

--- a/cuppa/construct.py
+++ b/cuppa/construct.py
@@ -306,26 +306,62 @@ class Construct(object):
 
     def __init__( self,
                   sconstruct_path,
-                  base_path            = os.path.abspath( '.' ),
-                  branch_root          = None,
-                  default_options      = {},
-                  default_projects     = [],
-                  default_variants     = [],
-                  default_dependencies = [],
-                  default_profiles     = [],
-                  dependencies         = [],
-                  profiles             = [],
-                  default_runner       = None,
-                  configure_callback   = None,
-                  tools                = [] ):
+                  base_path                 = os.path.abspath( '.' ),
+                  branch_root               = None,
+                  default_options           = {},
+                  default_projects          = [],
+                  default_variants          = [],
+                  import_dependencies       = None,
+                  auto_enable_dependencies  = None,
+                  import_profiles           = None,
+                  auto_enable_profiles      = None,
+                  # Legacy aliases (same lists as import_* / auto_enable_*):
+                  dependencies              = None,
+                  default_dependencies      = None,
+                  profiles                  = None,
+                  default_profiles          = None,
+                  default_runner            = None,
+                  configure_callback        = None,
+                  tools                     = [] ):
+
+        from cuppa.core.run_list_names import coalesce_aliased_run_list
 
         cuppa.core.base_options.set_base_options()
 
         cuppa_env = cuppa.core.environment.CuppaEnvironment()
         cuppa_env.add_tools( tools )
 
-        dependencies, default_dependencies, dependencies_warning = self._normalise_with_defaults( dependencies, default_dependencies, "dependencies" )
-        profiles, default_profiles, profiles_warning = self._normalise_with_defaults( profiles, default_profiles, "profiles" )
+        dependencies = coalesce_aliased_run_list(
+                import_dependencies,
+                dependencies,
+                'import_dependencies',
+                'dependencies',
+        )
+        default_dependencies = coalesce_aliased_run_list(
+                auto_enable_dependencies,
+                default_dependencies,
+                'auto_enable_dependencies',
+                'default_dependencies',
+        )
+        profiles = coalesce_aliased_run_list(
+                import_profiles,
+                profiles,
+                'import_profiles',
+                'profiles',
+        )
+        default_profiles = coalesce_aliased_run_list(
+                auto_enable_profiles,
+                default_profiles,
+                'auto_enable_profiles',
+                'default_profiles',
+        )
+
+        dependencies, default_dependencies, dependencies_warning = self._normalise_with_defaults(
+                dependencies, default_dependencies, "import_dependencies"
+        )
+        profiles, default_profiles, profiles_warning = self._normalise_with_defaults(
+                profiles, default_profiles, "import_profiles"
+        )
 
         cuppa_env['default_options'] = default_options or {}
         cuppa_env['configured_options'] = {}

--- a/cuppa/core/run_list_names.py
+++ b/cuppa/core/run_list_names.py
@@ -1,0 +1,93 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   Coerce cuppa.run() list entries to registry names
+#-------------------------------------------------------------------------------
+
+"""Turn ``dependencies`` / ``default_dependencies`` (and profile) entries into names.
+
+Strings pass through. Dependency / profile factories must expose a callable ``name()``
+(classmethod or instance method) that returns a non-empty string registry key.
+"""
+
+import SCons.Errors
+
+from cuppa.utility.types import is_string
+
+
+def registry_name_from_run_entry( value, list_label='dependencies' ):
+    """Return the registry name for one ``cuppa.run`` list entry.
+
+    Raises ``SCons.Errors.StopError`` when a non-string value has no usable ``name()``.
+    """
+    if is_string( value ):
+        return value
+
+    name_attr = getattr( value, 'name', None )
+    if name_attr is None:
+        raise SCons.Errors.StopError(
+                "cuppa.run {} entry {!r} has no name(); pass a string registry "
+                "name or a dependency/profile factory that implements name()".format(
+                        list_label, value
+                )
+        )
+
+    try:
+        if callable( name_attr ):
+            resolved = name_attr()
+        else:
+            resolved = name_attr
+    except Exception as error:
+        raise SCons.Errors.StopError(
+                "cuppa.run {} entry {!r} name() failed: {}".format(
+                        list_label, value, error
+                )
+        )
+
+    if not is_string( resolved ) or not resolved:
+        raise SCons.Errors.StopError(
+                "cuppa.run {} entry {!r} name() must return a non-empty string "
+                "(got {!r})".format( list_label, value, resolved )
+        )
+    return resolved
+
+
+def normalise_with_defaults( values, default_values, list_label ):
+    """Normalise registration + default-name lists for ``cuppa.run``.
+
+    * ``default_values`` may mix strings and factories; factories become names for
+      auto-apply and are also merged into the registration list when not already present.
+    * ``values`` (registration list) may be a deprecated dict of name→factory.
+
+    Returns ``(registration_values, default_names, warning_or_None)``.
+    """
+    import six
+
+    warning = None
+    if isinstance( values, dict ):
+        warning = (
+                "Dictionary passed for {}, this approach has been deprecated, "
+                "please use a list instead".format( list_label )
+        )
+        values = [ v for v in six.itervalues( values ) ]
+
+    registration = list( values ) if values else []
+    default_names = []
+    seen_registration_ids = {
+            id( entry ) for entry in registration if not is_string( entry )
+    }
+
+    for entry in ( default_values or [] ):
+        if is_string( entry ):
+            default_names.append( entry )
+            continue
+        default_names.append( registry_name_from_run_entry( entry, list_label ) )
+        entry_id = id( entry )
+        if entry_id not in seen_registration_ids:
+            registration.append( entry )
+            seen_registration_ids.add( entry_id )
+
+    return registration, default_names, warning

--- a/cuppa/core/run_list_names.py
+++ b/cuppa/core/run_list_names.py
@@ -7,10 +7,13 @@
 #   Coerce cuppa.run() list entries to registry names
 #-------------------------------------------------------------------------------
 
-"""Turn ``dependencies`` / ``default_dependencies`` (and profile) entries into names.
+"""Turn ``cuppa.run`` dependency/profile list entries into registry names.
 
-Strings pass through. Dependency / profile factories must expose a callable ``name()``
-(classmethod or instance method) that returns a non-empty string registry key.
+Preferred kwargs: ``import_dependencies`` / ``auto_enable_dependencies`` (and the
+profile twins). Legacy ``dependencies`` / ``default_dependencies`` remain aliases.
+
+Strings pass through. Factories must expose callable ``name()`` returning a
+non-empty string registry key.
 """
 
 import SCons.Errors
@@ -18,7 +21,28 @@ import SCons.Errors
 from cuppa.utility.types import is_string
 
 
-def registry_name_from_run_entry( value, list_label='dependencies' ):
+def coalesce_aliased_run_list( preferred, legacy, preferred_name, legacy_name ):
+    """Pick one list from preferred and legacy kwargs (``None`` means omitted).
+
+    Passing both with unequal values is a StopError. Empty lists are valid.
+    """
+    preferred_set = preferred is not None
+    legacy_set = legacy is not None
+    if preferred_set and legacy_set:
+        if preferred != legacy:
+            raise SCons.Errors.StopError(
+                    "cuppa.run: pass only one of {}= or {}= (legacy alias); "
+                    "got unequal lists".format( preferred_name, legacy_name )
+            )
+        return preferred
+    if preferred_set:
+        return preferred
+    if legacy_set:
+        return legacy
+    return []
+
+
+def registry_name_from_run_entry( value, list_label='import_dependencies' ):
     """Return the registry name for one ``cuppa.run`` list entry.
 
     Raises ``SCons.Errors.StopError`` when a non-string value has no usable ``name()``.
@@ -56,11 +80,11 @@ def registry_name_from_run_entry( value, list_label='dependencies' ):
 
 
 def normalise_with_defaults( values, default_values, list_label ):
-    """Normalise registration + default-name lists for ``cuppa.run``.
+    """Normalise import/registration + auto-enable name lists for ``cuppa.run``.
 
     * ``default_values`` may mix strings and factories; factories become names for
-      auto-apply and are also merged into the registration list when not already present.
-    * ``values`` (registration list) may be a deprecated dict of name→factory.
+      auto-enable and are also merged into the registration list when not already present.
+    * ``values`` (import list) may be a deprecated dict of name→factory.
 
     Returns ``(registration_values, default_names, warning_or_None)``.
     """

--- a/design/README.md
+++ b/design/README.md
@@ -21,7 +21,7 @@ maintainer workflow evolved.
 
 | Document | Status | Subject |
 |----------|--------|---------|
-| [`plans/run-default-dependency-objects.md`](plans/run-default-dependency-objects.md) | proposal | `cuppa.run` `default_dependencies` accepts objects; register vs auto-apply semantics / naming |
+| [`plans/run-default-dependency-objects.md`](plans/run-default-dependency-objects.md) | in progress | `cuppa.run` `default_dependencies` accepts objects; register vs auto-apply semantics / naming |
 | [`archive/gitlab-package-latest.md`](archive/gitlab-package-latest.md) | shipped | GitLab `version="latest"` = registry latest; Boost package retarget; consume docs — [#271](https://github.com/ja11sop/cuppa/issues/271) / [#272](https://github.com/ja11sop/cuppa/pull/272) |
 | [`archive/dependency-resolve.md`](archive/dependency-resolve.md) | shipped | BuildWith untyped resolve + type selectors; Quince `use_libs` — [#250](https://github.com/ja11sop/cuppa/issues/250) / [#270](https://github.com/ja11sop/cuppa/pull/270) |
 | [`plans/boost-updates.md`](plans/boost-updates.md) | proposal | Boost source vs GitLab `boost_package` identity; #206 `use_libs`; #248/#249 runners; Quince gap → dependency-resolve |

--- a/design/ideas/scratchpad.md
+++ b/design/ideas/scratchpad.md
@@ -52,13 +52,6 @@ you need to explicitly add A and B to your sconstruct. It would be nice if we co
 packages themselves to depend on other packages so in the example case the user just needs
 to know about A and it already carries the information needed to also get package B.
 
-### Clarify `dependencies` vs `default_dependencies` naming
-
-`dependencies` means register/import factories for the session; `default_dependencies` means
-auto-`BuildWith` that subset in every sconscript. Semantics and possible clearer names are
-captured under [`plans/run-default-dependency-objects.md`](../plans/run-default-dependency-objects.md)
-(§ Semantics). Remove this note when that plan’s docs/naming slices land.
-
 ### Built-in dependencies in their own repositories
 
 Shipping every built-in inside Cuppa does not scale and is a weak blueprint for third-party

--- a/design/plans/run-default-dependency-objects.md
+++ b/design/plans/run-default-dependency-objects.md
@@ -1,7 +1,7 @@
 # Plan: `cuppa.run` accepts dependency objects in `default_dependencies`
 
-- **Status:** proposal
-- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — 1.11.0; [`gitlab-package-latest.md`](../archive/gitlab-package-latest.md) (motivating consume ergonomics); [`dependency-resolve.md`](../archive/dependency-resolve.md) (BuildWith tokens remain strings); `cuppa/construct.py` `_normalise_with_defaults`
+- **Status:** in progress
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — 1.11.0; [#276](https://github.com/ja11sop/cuppa/issues/276); [`gitlab-package-latest.md`](../archive/gitlab-package-latest.md) (motivating consume ergonomics); [`dependency-resolve.md`](../archive/dependency-resolve.md) (BuildWith tokens remain strings); `cuppa/core/run_list_names.py`
 - **Updated:** 2026-09-05
 - **Impact:** minor — accept dependency factories/classes where names are required today; strings stay valid
 
@@ -137,13 +137,15 @@ cuppa.run(
 
 | Slice | Status |
 |-------|--------|
-| `run-dep-obj-rules` | Done (this document; semantics note added) |
-| Remaining | Not started |
+| `run-dep-obj-rules` | Done |
+| `run-dep-obj-normalise` | Done — `cuppa/core/run_list_names.py`; dedupe registration; strict `name()` |
+| `run-dep-obj-docs` | Done — concepts / packages / gitlab register vs auto-apply |
+| `run-dep-obj-naming` | Deferred — keep current keys; explore aliases later |
+| `run-dep-obj-issue` | Done — [#276](https://github.com/ja11sop/cuppa/issues/276) |
 
 ## Open questions
 
-- Exact type check: `callable` + `.name`, class with `name()`, or duck-typing only?
 - Whether `default_dependencies = dependencies` (aliasing the same list) should be documented as
-  supported once objects work.
+  supported (works when the list holds factories).
 - Whether clearer `cuppa.run` parameter names (or aliases) are worth a compatibility cycle, and
   which pair best matches register vs auto-apply without colliding with BuildWith vocabulary.

--- a/design/plans/run-default-dependency-objects.md
+++ b/design/plans/run-default-dependency-objects.md
@@ -139,12 +139,12 @@ cuppa.run(
 |-------|--------|
 | `run-dep-obj-rules` | Done |
 | `run-dep-obj-normalise` | Done — `cuppa/core/run_list_names.py`; dedupe registration; strict `name()` |
-| `run-dep-obj-docs` | Done — concepts / packages / gitlab register vs auto-apply |
+| `run-dep-obj-docs` | Done — teach path prefers preferred names; built-ins → `auto_enable` only; `use_libs` over `BoostStaticLibs`; integration fixtures mix preferred + legacy kwargs |
 | `run-dep-obj-naming` | Done — preferred import_/auto_enable_ names; legacy aliases |
 | `run-dep-obj-issue` | Done — [#276](https://github.com/ja11sop/cuppa/issues/276) |
 
 ## Open questions
 
-- Whether `default_dependencies = dependencies` (aliasing the same list) should be documented as
-  supported (works when the list holds factories).
+- Whether `auto_enable_dependencies = import_dependencies` (aliasing the same list) should be
+  documented as supported (works when the list holds factories).
 - Whether to emit a soft warn when only legacy ``dependencies`` / ``default_dependencies`` are used.

--- a/design/plans/run-default-dependency-objects.md
+++ b/design/plans/run-default-dependency-objects.md
@@ -130,7 +130,8 @@ cuppa.run(
 - Do not break existing string `default_dependencies`.
 - Do not invent a second registration API; only widen what `cuppa.run` accepts.
 - Do not silently ignore objects that lack a resolvable name.
-- Do not rename run() keys in the first cut without a deprecation / alias story.
+- Do not remove legacy `dependencies` / `default_dependencies` aliases without a
+  deprecation story (keep indefinitely for now).
 
 ## Progress snapshot
 

--- a/design/plans/run-default-dependency-objects.md
+++ b/design/plans/run-default-dependency-objects.md
@@ -16,8 +16,8 @@ google_cloud_cpp = cuppa.package_dependency(
 )
 
 cuppa.run(
-    dependencies = [ google_cloud_cpp ],
-    default_dependencies = [ google_cloud_cpp ],
+    import_dependencies = [ google_cloud_cpp ],
+    auto_enable_dependencies = [ google_cloud_cpp ],
 )
 ```
 
@@ -82,8 +82,7 @@ and keep rename options in open questions — do not block object normalisation 
 - Changing BuildWith resolve / type selectors ([`dependency-resolve.md`](../archive/dependency-resolve.md)).
 - Requiring objects everywhere (strings remain first-class).
 - Auto-adding every `dependencies=` entry to `default_dependencies` (explicit default list stays).
-- Renaming `dependencies` / `default_dependencies` in the first implementation cut (see open
-  questions).
+- Removing legacy `dependencies` / `default_dependencies` aliases (keep indefinitely for now).
 
 ## Settled decisions (proposed)
 
@@ -94,7 +93,7 @@ and keep rename options in open questions — do not block object normalisation 
 | Mix of objects and strings | Allowed in one list. |
 | `dependencies=` | Continue to accept factories/classes as today; ensure normalisation is shared so object→name is one code path. |
 | Semantics in docs | Teach register (`dependencies`) vs auto-`BuildWith` (`default_dependencies`) explicitly; examples show one object in both lists when both apply. |
-| Rename of run() keys | **Not** in the first cut. Explore aliases / clearer names as a follow-on once semantics are documented; preserve string and object forms under current names. |
+| Rename of run() keys | Preferred: ``import_dependencies`` / ``auto_enable_dependencies`` (and profile twins). Legacy ``dependencies`` / ``default_dependencies`` remain aliases. Docs lead with the new names. |
 | `default_profiles` | Same object-or-string normalisation if profiles already expose `.name()` — confirm in implementation. |
 | Docs | Update package consume examples to pass the object into both lists; keep `.name()` as an explicit alternative. |
 
@@ -109,10 +108,10 @@ google_cloud_cpp = cuppa.package_dependency(
 )
 
 cuppa.run(
-    # Register: sconstruct / sconscripts may BuildWith this package.
-    dependencies = [ google_cloud_cpp ],
-    # Auto-apply: every sconscript gets BuildWith('google_cloud_cpp') by default.
-    default_dependencies = [ google_cloud_cpp ],
+    # Import into this sconstruct session.
+    import_dependencies = [ google_cloud_cpp ],
+    # Auto-enable: every sconscript gets BuildWith('google_cloud_cpp') by default.
+    auto_enable_dependencies = [ google_cloud_cpp ],
 )
 ```
 
@@ -140,12 +139,11 @@ cuppa.run(
 | `run-dep-obj-rules` | Done |
 | `run-dep-obj-normalise` | Done — `cuppa/core/run_list_names.py`; dedupe registration; strict `name()` |
 | `run-dep-obj-docs` | Done — concepts / packages / gitlab register vs auto-apply |
-| `run-dep-obj-naming` | Deferred — keep current keys; explore aliases later |
+| `run-dep-obj-naming` | Done — preferred import_/auto_enable_ names; legacy aliases |
 | `run-dep-obj-issue` | Done — [#276](https://github.com/ja11sop/cuppa/issues/276) |
 
 ## Open questions
 
 - Whether `default_dependencies = dependencies` (aliasing the same list) should be documented as
   supported (works when the list holds factories).
-- Whether clearer `cuppa.run` parameter names (or aliases) are worth a compatibility cycle, and
-  which pair best matches register vs auto-apply without colliding with BuildWith vocabulary.
+- Whether to emit a soft warn when only legacy ``dependencies`` / ``default_dependencies`` are used.

--- a/docs/modules/ROOT/pages/concepts.adoc
+++ b/docs/modules/ROOT/pages/concepts.adoc
@@ -112,26 +112,27 @@ Common keyword arguments to `cuppa.run()`:
 | `default_options` | Dict of option keys *without* `--` (for example `{'offline': True}`)
 | `default_projects` | Default list of `sconscript` paths
 | `default_variants` | Restrict default variants (for example `['rel']`)
-| `dependencies` | **Register / import** dependency factories so the sconstruct and its sconscripts can look them up and call `BuildWith` when they choose
-| `default_dependencies` | **Auto-apply** subset: names or the same factories, treated as `BuildWith()` in every sconscript
-| `profiles` | Register profile factories
-| `default_profiles` | Auto-apply profile names or factories (same object-or-string shape as dependencies)
+| `import_dependencies` | **Import** dependency factories into this sconstruct session so sconscripts can look them up and call `BuildWith` when they choose. Legacy alias: `dependencies`
+| `auto_enable_dependencies` | **Auto-enable** subset: names or the same factories, treated as `BuildWith()` in every sconscript. Legacy alias: `default_dependencies`
+| `import_profiles` | Import profile factories (legacy: `profiles`)
+| `auto_enable_profiles` | Auto-enable profile names or factories (legacy: `default_profiles`)
 | `default_runner` | Test runner name (default `process`)
 | `configure_callback` | Optional SCons `Configure()` hook
 | `tools` | Extra SCons tools for all environments
 | `base_path` / `branch_root` | Project root / SCM branch root offsets
 |===
 
-`default_dependencies` is not a second import list. Put a factory in `dependencies` to
-register it; put the same factory (or its `.name()` string) in `default_dependencies` to
-auto-apply it. A factory only in `default_dependencies` both registers and auto-applies.
+`auto_enable_dependencies` is not a second import list. Put a factory in
+`import_dependencies` to bring it into the session; put the same factory (or its
+`.name()` string) in `auto_enable_dependencies` to auto-enable it. A factory only in
+`auto_enable_dependencies` both imports and auto-enables.
 
 [source,python]
 ----
 MyPkg = cuppa.package_dependency( 'mypkg', ... )
 
 cuppa.run(
-    dependencies = [ MyPkg ],
-    default_dependencies = [ MyPkg ],
+    import_dependencies = [ MyPkg ],
+    auto_enable_dependencies = [ MyPkg ],
 )
 ----

--- a/docs/modules/ROOT/pages/concepts.adoc
+++ b/docs/modules/ROOT/pages/concepts.adoc
@@ -112,11 +112,26 @@ Common keyword arguments to `cuppa.run()`:
 | `default_options` | Dict of option keys *without* `--` (for example `{'offline': True}`)
 | `default_projects` | Default list of `sconscript` paths
 | `default_variants` | Restrict default variants (for example `['rel']`)
-| `default_dependencies` | Dependency names or classes applied to every env
-| `default_profiles` | Profile names or classes
-| `dependencies` / `profiles` | Extra classes to register
+| `dependencies` | **Register / import** dependency factories so the sconstruct and its sconscripts can look them up and call `BuildWith` when they choose
+| `default_dependencies` | **Auto-apply** subset: names or the same factories, treated as `BuildWith()` in every sconscript
+| `profiles` | Register profile factories
+| `default_profiles` | Auto-apply profile names or factories (same object-or-string shape as dependencies)
 | `default_runner` | Test runner name (default `process`)
 | `configure_callback` | Optional SCons `Configure()` hook
 | `tools` | Extra SCons tools for all environments
 | `base_path` / `branch_root` | Project root / SCM branch root offsets
 |===
+
+`default_dependencies` is not a second import list. Put a factory in `dependencies` to
+register it; put the same factory (or its `.name()` string) in `default_dependencies` to
+auto-apply it. A factory only in `default_dependencies` both registers and auto-applies.
+
+[source,python]
+----
+MyPkg = cuppa.package_dependency( 'mypkg', ... )
+
+cuppa.run(
+    dependencies = [ MyPkg ],
+    default_dependencies = [ MyPkg ],
+)
+----

--- a/docs/modules/ROOT/pages/concepts.adoc
+++ b/docs/modules/ROOT/pages/concepts.adoc
@@ -49,7 +49,8 @@ For how progress events and variant scoping work, see xref:methods.adoc#progress
 == Dependencies
 
 Named packages of compile/link settings and optional fetch/build logic -- Boost, Qt4/Qt5, Quince, location-based header libraries, GitLab registry packages, or optional xref:dependencies/conan.adoc#conan-2-consumer-optional[Conan 2] graphs (`conan_deps` / `conan_dependency`).
-Apply them with `default_dependencies` in `cuppa.run()` or `env.BuildWith('boost')` in a `sconscript`.
+Apply them with `auto_enable_dependencies` in `cuppa.run()` or `env.BuildWith('boost')` in a
+`sconscript`. Built-ins are already imported; custom factories need `import_dependencies` too.
 Publish Cuppa-built libraries with `env.PublishPackage` to GitLab generic packages or a Conan remote.
 See xref:dependencies.adoc[Dependencies] and xref:packages.adoc[Publishing packages].
 
@@ -58,7 +59,7 @@ See xref:dependencies.adoc[Dependencies] and xref:packages.adoc[Publishing packa
 
 Lightweight collections of environment tweaks (sometimes wrapping dependencies).
 Example built-in: `quad_float` (links `quadmath`).
-Apply with `default_profiles` or `env.BuildProfile(...)`.
+Apply with `auto_enable_profiles` or `env.BuildProfile(...)`.
 
 [#variants-and-actions]
 == Variants and actions
@@ -122,10 +123,12 @@ Common keyword arguments to `cuppa.run()`:
 | `base_path` / `branch_root` | Project root / SCM branch root offsets
 |===
 
-`auto_enable_dependencies` is not a second import list. Put a factory in
+`auto_enable_dependencies` is not a second import list. Put a **custom** factory in
 `import_dependencies` to bring it into the session; put the same factory (or its
-`.name()` string) in `auto_enable_dependencies` to auto-enable it. A factory only in
-`auto_enable_dependencies` both imports and auto-enables.
+`.name()` string) in `auto_enable_dependencies` to auto-enable it. A custom factory only in
+`auto_enable_dependencies` both imports and auto-enables. Built-ins (`boost`, `qt5`, …) and
+pip entry-point plugins are already imported — list them only under `auto_enable_dependencies`
+when you want every sconscript to `BuildWith` them.
 
 [source,python]
 ----

--- a/docs/modules/ROOT/pages/dependencies/builtins/boost.adoc
+++ b/docs/modules/ROOT/pages/dependencies/builtins/boost.adoc
@@ -23,8 +23,9 @@ When Boost is fetched from the network (no ``--boost-home=`` or
 
 === Unpinned Boost (latest implied)
 
-Typical packaging or CI layouts register source Boost without a version pin — for example
-``default_dependencies = ['boost']`` in the ``sconstruct``. You do **not** need
+Typical packaging or CI layouts auto-enable source Boost without a version pin — for example
+``auto_enable_dependencies = ['boost']`` in the ``sconstruct``. Built-in ``boost`` is already
+imported by Cuppa; you do not list it in ``import_dependencies``. You do **not** need
 ``--boost-latest`` in that case; latest is implied.
 
 On each **online** build, resolution on the download path is:
@@ -52,7 +53,7 @@ to **force** a fresh boost.org check when online (skipping any stored
 ``boost_latest_version``). A side effect is updating the remembered key after download when
 the resolved version is higher.
 
-You do not need this flag for the usual unpinned ``default_dependencies = ['boost']`` workflow.
+You do not need this flag for the usual unpinned ``auto_enable_dependencies = ['boost']`` workflow.
 
 The flag does not apply when ``--boost-home=`` or ``--boost-location=`` pins the source tree.
 
@@ -91,18 +92,25 @@ stored key stay aligned (project-local downloads with project conf, or a shared 
 
 == Using libraries
 
+Prefer `use_libs` on the value returned by `BuildWith` (same shape as registry `boost_package`):
+
 [source,python]
 ----
 env.BuildWith('boost').use_libs(['system', 'filesystem'])
-# or the older env-method form:
+----
+
+Older env methods still work when you need the library nodes explicitly (for example
+`Install` during package publish):
+
+[source,python]
+----
 env.AppendUnique(STATICLIBS=env.BoostStaticLibs(['system', 'filesystem']))
 # or
 env.AppendUnique(DYNAMICLIBS=env.BoostSharedLibs(['system']))
 ----
 
-`use_libs([...])` matches registry packages such as `boost_package`, so you can switch supply
-chains by changing only the `BuildWith` name. It builds (or reuses) static libraries via
-`BoostStaticLibs` and appends them to `STATICLIBS`. Aliases such as `BoostStaticLib` /
+`use_libs([...])` builds (or reuses) static libraries via `BoostStaticLibs`, appends them to
+`STATICLIBS`, and returns the library nodes. Aliases such as `BoostStaticLib` /
 `BoostStaticLibrary` also exist for compatibility.
 
 When a dependency offers linkable libraries, prefer exposing `use_libs(libs, depends_on=[])`

--- a/docs/modules/ROOT/pages/dependencies/builtins/qt.adoc
+++ b/docs/modules/ROOT/pages/dependencies/builtins/qt.adoc
@@ -2,7 +2,8 @@
 :description: Built-in qt4 / qt5 dependencies — honest stub
 
 Dependencies `qt4` and `qt5` integrate SCons Qt tools for MOC/UIC/RCC-style workflows.
-Enable via `default_dependencies = ['qt5']` (or `qt4`) when Qt is installed on the builder.
+Enable via `auto_enable_dependencies = ['qt5']` (or `qt4`) when Qt is installed on the builder.
+Built-in Qt factories are already imported; you do not list them in `import_dependencies`.
 
 This page is a stub. The modules live under `cuppa/dependencies/` (`qt4`, `qt5`). Expand it
 when real usage — required packages, typical flags, and failure modes — is documented.

--- a/docs/modules/ROOT/pages/dependencies/conan.adoc
+++ b/docs/modules/ROOT/pages/dependencies/conan.adoc
@@ -38,8 +38,8 @@ import cuppa
 Conan = cuppa.conan_deps( conanfile = 'conanfile.txt' )
 
 cuppa.run(
-    dependencies = [Conan],
-    default_dependencies = ['conan'],
+    import_dependencies = [Conan],
+    auto_enable_dependencies = [Conan],
 )
 ----
 
@@ -90,7 +90,7 @@ ConanCenter.
 
 === Pip plugin packaging
 
-You can ship a Conan-backed dependency as a pip package so consumers only `pip install` it and list the name in `default_dependencies`.
+You can ship a Conan-backed dependency as a pip package so consumers only `pip install` it and list the name in `auto_enable_dependencies` (plugins are already discovered; no `import_dependencies` entry is required).
 Cuppa discovers plugins through the `cuppa.dependency.plugins` entry point.
 
 A Conan example lives at `examples/conan_fmt_plugin/` (registers `fmt` via `cuppa.conan_dependency`).

--- a/docs/modules/ROOT/pages/dependencies/extending.adoc
+++ b/docs/modules/ROOT/pages/dependencies/extending.adoc
@@ -9,8 +9,8 @@ Implement a class with:
 * `name()` identifying the dependency
 
 You can also subclass or wrap `location_dependency` / `package_dependency` / `conan_dependency`
-factories. Register extras via `cuppa.run(dependencies=[MyDep])` or the setuptools entry point
-group `cuppa.dependency.plugins`.
+factories. Register extras via `cuppa.run(import_dependencies=[MyDep])` (legacy:
+`dependencies=`) or the setuptools entry point group `cuppa.dependency.plugins`.
 
 == Storage contract
 

--- a/docs/modules/ROOT/pages/dependencies/gitlab.adoc
+++ b/docs/modules/ROOT/pages/dependencies/gitlab.adoc
@@ -160,7 +160,7 @@ cuppa.run(
         BoostPackage,
     ],
     default_dependencies = [
-        BoostPackage.name(),
+        BoostPackage,
     ],
     default_runner = 'boost',
 )

--- a/docs/modules/ROOT/pages/dependencies/gitlab.adoc
+++ b/docs/modules/ROOT/pages/dependencies/gitlab.adoc
@@ -156,10 +156,10 @@ BoostPackage = cuppa.packages.boost_package.define(
 )
 
 cuppa.run(
-    dependencies = [
+    import_dependencies = [
         BoostPackage,
     ],
-    default_dependencies = [
+    auto_enable_dependencies = [
         BoostPackage,
     ],
     default_runner = 'boost',

--- a/docs/modules/ROOT/pages/dependencies/gitlab.adoc
+++ b/docs/modules/ROOT/pages/dependencies/gitlab.adoc
@@ -138,10 +138,11 @@ explicitly (accept a configure `404` if the registry has not published that rele
 
 === Consuming in a project
 
-Declare the package in the ``sconstruct`` and list it in ``default_dependencies`` so every
-sconscript can ``BuildWith`` it. Boost.Test runners then take version and patched-test flags
-from this package and do not extract source Boost. Set ``GITLAB_REGISTRY_TOKEN`` (or rely on
-``CI_JOB_TOKEN`` in GitLab CI) for registry access.
+Declare the package in the ``sconstruct`` with ``import_dependencies`` and
+``auto_enable_dependencies`` so every sconscript gets ``BuildWith`` automatically.
+Boost.Test runners then take version and patched-test flags from this package and do not
+extract source Boost. Set ``GITLAB_REGISTRY_TOKEN`` (or rely on ``CI_JOB_TOKEN`` in GitLab CI)
+for registry access.
 
 [source,python]
 ----
@@ -197,12 +198,11 @@ required):
 import cuppa
 
 cuppa.run(
-    dependencies = [],
     default_options = {
         'boost-patch-boost-test': True,
     },
-    default_dependencies = [
-        'boost',
+    auto_enable_dependencies = [
+        'boost',  # built-in; already imported — unpinned → latest on the download path
     ],
     default_runner = 'boost',
 )
@@ -216,7 +216,7 @@ Import('env')
 
 Boost = env.BuildWith('boost')
 
-BoostLibraries = env.BoostStaticLibs([
+BoostLibraries = Boost.use_libs([
     'chrono',
     'context',
     'filesystem',
@@ -277,8 +277,8 @@ BoostPkg = cuppa.packages.boost_package.define(
 )
 
 cuppa.run(
-    dependencies = [BoostPkg],
-    default_dependencies = ['boost_package'],
+    import_dependencies = [BoostPkg],
+    auto_enable_dependencies = [BoostPkg],
 )
 ----
 

--- a/docs/modules/ROOT/pages/dependencies/location.adoc
+++ b/docs/modules/ROOT/pages/dependencies/location.adoc
@@ -14,8 +14,8 @@ MyHeaders = cuppa.location_dependency(
 )
 
 cuppa.run(
-    dependencies = [MyHeaders],
-    default_dependencies = ['my_headers'],
+    import_dependencies = [ MyHeaders ],
+    auto_enable_dependencies = [ MyHeaders ],
 )
 ----
 

--- a/docs/modules/ROOT/pages/dependencies/managing.adoc
+++ b/docs/modules/ROOT/pages/dependencies/managing.adoc
@@ -238,10 +238,12 @@ cuppa writes. They exit without building. Downloads, develop working copies, and
 trees that are not named stay put; siblings for other toolchains or branches are reported as
 left behind. SCons `-n` is a dry run.
 
-Names are the keys this project uses: `default_dependencies` plus names registered from the
-sconstruct’s `dependencies=[…]` list. Built-in factories that module scan always registers
-(`boost`, `qt4`, …) are **not** removable unless the project names them that way. On-disk folder
-names and listing short names are rejected. An unknown or unused name prints an error (rejected name error-coloured and emphasised) and a
+Names are the keys this project uses: `auto_enable_dependencies` (legacy:
+`default_dependencies`) plus names imported via `import_dependencies` (legacy:
+`dependencies=[…]`). Built-in factories that module scan always registers
+(`boost`, `qt4`, …) are **not** removable unless the project names them that way (for example
+in `auto_enable_dependencies`). On-disk folder names and listing short names are rejected. An
+unknown or unused name prints an error (rejected name error-coloured and emphasised) and a
 ruled tree of dependencies that *can* be removed for the current selection (the in-use /
 referenced picture from `--list-dependencies`, without unreferenced leftovers), after
 `Collating dependency tree...`. See

--- a/docs/modules/ROOT/pages/dependencies/overview.adoc
+++ b/docs/modules/ROOT/pages/dependencies/overview.adoc
@@ -9,36 +9,46 @@ source code, or consume a package from a registry.
 The xref:dependencies.adoc[Dependencies] landing page maps each dependency kind and workflow
 to its detailed guide. This overview explains the vocabulary shared by those guides.
 
-== Declaring default dependencies
+== Import vs auto-enable
 
-Pass `default_dependencies` to `cuppa.run()` when most targets in the project use the same
-dependency set:
+`cuppa.run()` has two related lists (legacy names `dependencies` / `default_dependencies`
+still work):
+
+* `import_dependencies` — bring **custom** factories (`package_dependency`,
+  `location_dependency`, …) into this sconstruct session. Built-ins such as source `boost` are
+  already registered by Cuppa; you do not list them here.
+* `auto_enable_dependencies` — automatically `BuildWith()` that subset in every sconscript.
+
+== Auto-enable built-ins
+
+Pass `auto_enable_dependencies` when most targets use the same built-in set:
 
 [source,python]
 ----
 import cuppa
 
 cuppa.run(
-    default_dependencies = ['boost'],
-    default_options = {
-        'boost-location': '/opt/boost',
-    },
+    auto_enable_dependencies = ['boost'],  # unpinned → latest on the download path
 )
 ----
 
-Cuppa resolves these dependencies while it configures each build environment. Their usage
-requirements are then available to methods such as `env.Build`, `env.BuildLib`, and
+Optional pins such as a local Boost tree belong in `default_options` (`boost-location` /
+`boost-home`), not in `import_dependencies`.
+
+Cuppa resolves auto-enabled dependencies while it configures each build environment. Their
+usage requirements are then available to methods such as `env.Build`, `env.BuildLib`, and
 `env.BuildTest`.
 
 == Adding a dependency in a sconscript
 
-Use `env.BuildWith()` when a dependency belongs to one sconscript or target group:
+Use `env.BuildWith()` when a dependency belongs to one sconscript or target group, or when you
+need instance APIs such as `use_libs`:
 
 [source,python]
 ----
 Import('env')
 
-env.BuildWith('boost')
+env.BuildWith('boost').use_libs(['system', 'filesystem'])
 ----
 
 `BuildWith` applies the registered dependency to that environment. See

--- a/docs/modules/ROOT/pages/dependencies/packages.adoc
+++ b/docs/modules/ROOT/pages/dependencies/packages.adoc
@@ -23,8 +23,8 @@ MyPkg = cuppa.package_dependency(
 
 cuppa.run(
     dependencies = [ MyPkg ],
-    # Until run() accepts objects here, pass the registered name:
-    default_dependencies = [ MyPkg.name() ],
+    # Register above; auto-BuildWith in every sconscript (same factory or MyPkg.name()):
+    default_dependencies = [ MyPkg ],
 )
 ----
 

--- a/docs/modules/ROOT/pages/dependencies/packages.adoc
+++ b/docs/modules/ROOT/pages/dependencies/packages.adoc
@@ -22,9 +22,9 @@ MyPkg = cuppa.package_dependency(
 )
 
 cuppa.run(
-    dependencies = [ MyPkg ],
-    # Register above; auto-BuildWith in every sconscript (same factory or MyPkg.name()):
-    default_dependencies = [ MyPkg ],
+    import_dependencies = [ MyPkg ],
+    # Import above; auto-BuildWith in every sconscript (same factory or MyPkg.name()):
+    auto_enable_dependencies = [ MyPkg ],
 )
 ----
 

--- a/docs/modules/ROOT/pages/extending.adoc
+++ b/docs/modules/ROOT/pages/extending.adoc
@@ -41,7 +41,8 @@ Third-party packages can register plugins without forking cuppa:
 | `cuppa.profile(name)` | Named profile class factory
 |===
 
-Pass custom classes into `cuppa.run(dependencies=[…], profiles=[…])`.
+Pass custom classes into `cuppa.run(import_dependencies=[…], import_profiles=[…])`
+(legacy: `dependencies` / `profiles`).
 
 When writing custom `env.Command` / `Action` helpers, avoid multi-part shell strings such as `cd … && …`.
 Use a Python action with subprocess `cwd=` (or `cuppa.utility.command.run`) so parallel builds stay correct.
@@ -50,7 +51,8 @@ See xref:methods/custom-commands.adoc[Custom commands and working directories].
 == Pip dependency plugins
 
 Third-party packages can ship a named dependency that Cuppa discovers automatically via `cuppa.dependency.plugins`.
-After `pip install`, consumers list the dependency **by name** in `default_dependencies` — no `cuppa.run(dependencies=[…])` entry is required.
+After `pip install`, consumers list the dependency **by name** in `auto_enable_dependencies` — no
+`cuppa.run(import_dependencies=[…])` entry is required (the plugin already registered the factory).
 
 Two complete examples live under `examples/`. Both register the dependency name `fmt`; install **one** of them in a given environment (they are alternative supply chains for the same name).
 
@@ -112,7 +114,7 @@ import cuppa
 
 cuppa.run(
     default_variants=['dbg'],
-    default_dependencies=['fmt'],
+    auto_enable_dependencies=['fmt'],
 )
 ----
 

--- a/docs/modules/ROOT/pages/integration-tests.adoc
+++ b/docs/modules/ROOT/pages/integration-tests.adoc
@@ -19,6 +19,9 @@ Override the default family with `CUPPA_TEST_TOOLCHAIN=gcc|clang|vc` (used by CI
 For Clang, pin the standard library with `CUPPA_TEST_ARGS=--clang-stdlib=libstdc{plus}{plus}` or
 `CUPPA_TEST_ARGS=--clang-stdlib=libc{plus}{plus}` (explicit flags in a test override the env extras).
 
+Generated `cuppa.run` fixtures use both the preferred kwargs (`import_dependencies` /
+`auto_enable_dependencies`) and the legacy aliases (`dependencies` / `default_dependencies`)
+so both call styles stay covered. Teach-path Antora examples prefer the new names.
 Linux CI matrices three cells: `gcc`, `clang` + `libstdc{plus}{plus}`, and
 `clang` + `libc{plus}{plus}`.
 Each Linux integration job also installs Conan 2 so xref:integration/test-conan.adoc[`test_conan`] runs (not skipped).

--- a/docs/modules/ROOT/pages/integration/test-build-profile.adoc
+++ b/docs/modules/ROOT/pages/integration/test-build-profile.adoc
@@ -4,7 +4,10 @@
 
 == What is tested
 
-A custom profile class registered through `cuppa.run(profiles=[…])` is applied with `BuildProfile` and affects the compile (define appended).
+A custom profile class registered through `cuppa.run(import_profiles=[…])` is applied with `BuildProfile` and affects the compile (define appended).
+
+NOTE: The fixture still uses the legacy ``profiles=[…]`` alias so that call style stays covered.
+Prefer ``import_profiles`` / ``auto_enable_profiles`` in new projects.
 
 == Generated files
 

--- a/docs/modules/ROOT/pages/integration/test-build-with.adoc
+++ b/docs/modules/ROOT/pages/integration/test-build-with.adoc
@@ -20,7 +20,7 @@ Headers = cuppa.location_dependency(
 )
 cuppa.run(
     default_variants=['dbg'],
-    dependencies=[Headers],
+    import_dependencies=[Headers],
 )
 ----
 

--- a/docs/modules/ROOT/pages/integration/test-clone-develop.adoc
+++ b/docs/modules/ROOT/pages/integration/test-clone-develop.adoc
@@ -17,6 +17,21 @@ so bare reset lands on that line, and `--reset-develop-branch=default` still ret
 
 Non-empty develop destinations are refused without cloning.
 
+=== `sconstruct` (excerpt)
+
+[source,python]
+----
+Widget = cuppa.location_dependency(
+    'widget',
+    location='git+file:///…@master',
+    develop='/path/to/develop/widget',
+)
+cuppa.run(
+    import_dependencies=[Widget],
+    auto_enable_dependencies=['widget'],
+)
+----
+
 == See also
 
 xref:dependencies/managing.adoc#checking-your-develop-copies[Checking your develop copies]

--- a/docs/modules/ROOT/pages/integration/test-conan.adoc
+++ b/docs/modules/ROOT/pages/integration/test-conan.adoc
@@ -8,7 +8,7 @@ Optional Conan 2 consumer support via `cuppa.conan_deps` / `cuppa.conan_dependen
 * **generators_folder reuse** — pre-run `conan install`, Cuppa loads `SConscript_conandeps` only
 * **Full install** — Cuppa runs `conan install`, builds and runs a `fmt` hello; second `--offline` pass reuses the fingerprint cache
 * **Shared library runtime** — `fmt` built shared; `BuildTest` succeeds with injected library search paths
-* **Pip plugin** — `examples/conan_fmt_plugin` installed via `pip install --no-user --target`; Cuppa discovers `fmt` through `cuppa.dependency.plugins` with only `default_dependencies=['fmt']`
+* **Pip plugin** — `examples/conan_fmt_plugin` installed via `pip install --no-user --target`; Cuppa discovers `fmt` through `cuppa.dependency.plugins` with only `auto_enable_dependencies=['fmt']`
 * **Offline miss** — empty Conan home + Cuppa `--offline` fails clearly when the package is not cached
 * **Publish round-trip** — `BuildStaticLib` + `ConanPackagePublisher` / `PublishPackage` (`export-pkg` only) into an isolated `CONAN_HOME`, then a second project consumes via `conan_deps` under `--offline`
 * **Publish relative generated lib dir** — `BuildStaticLib(..., final_dir='package_lib')` with `source_lib_dir='package_lib'` under `--rel --parallel`; consumer links the exported static lib under `--offline`
@@ -21,6 +21,10 @@ Optional Conan 2 consumer support via `cuppa.conan_deps` / `cuppa.conan_dependen
 Tests skip when `conan` is missing or is not a working Conan 2 CLI.
 Linux CI installs Conan 2 (`pip install 'conan>=2,<3'`) on each integration matrix cell so these scenarios run rather than skip.
 Windows CI does not install Conan yet (see Out of scope).
+
+Early consumer scenarios (generators_folder, install, pip plugin) use preferred
+`import_dependencies` / `auto_enable_dependencies`. Shared-library and publish consumers keep
+the legacy `dependencies` / `default_dependencies` aliases so both styles stay covered.
 
 == Prerequisites
 
@@ -61,8 +65,8 @@ import cuppa
 Conan = cuppa.conan_deps(conanfile='conanfile.txt')
 cuppa.run(
     default_variants=['dbg'],
-    dependencies=[Conan],
-    default_dependencies=['conan'],
+    import_dependencies=[Conan],
+    auto_enable_dependencies=[Conan],
 )
 ----
 
@@ -74,21 +78,38 @@ import cuppa
 Conan = cuppa.conan_deps(generators_folder='_conan')
 cuppa.run(
     default_variants=['dbg'],
-    dependencies=[Conan],
-    default_dependencies=['conan'],
+    import_dependencies=[Conan],
+    auto_enable_dependencies=[Conan],
 )
 ----
 
 === `sconstruct` (pip plugin)
 
-No `dependencies=[…]` — the plugin registers `fmt`:
+No `import_dependencies=[…]` — the plugin registers `fmt`:
 
 [source,python]
 ----
 import cuppa
 cuppa.run(
     default_variants=['dbg'],
-    default_dependencies=['fmt'],
+    auto_enable_dependencies=['fmt'],
+)
+----
+
+=== `sconstruct` (shared library / publish consumers)
+
+NOTE: These fixtures intentionally use the legacy ``dependencies`` /
+``default_dependencies`` aliases so the suite still exercises them. Prefer
+``import_dependencies`` / ``auto_enable_dependencies`` in new projects.
+
+[source,python]
+----
+import cuppa
+Conan = cuppa.conan_deps(conanfile='conanfile.txt')
+cuppa.run(
+    default_variants=['dbg'],
+    dependencies=[Conan],
+    default_dependencies=['conan'],
 )
 ----
 

--- a/docs/modules/ROOT/pages/integration/test-fmt-location-plugin.adoc
+++ b/docs/modules/ROOT/pages/integration/test-fmt-location-plugin.adoc
@@ -6,7 +6,7 @@
 The example package `examples/cuppa_fmt_plugin` registers `fmt` through `cuppa.dependency.plugins` by subclassing `cuppa.location_dependency`, downloading a pinned fmt archive (12.2.0+, required for Clang + `libc{plus}{plus}`), compiling `src/format.cc` and `src/os.cc`, and linking a static library.
 
 * Plugin install via `pip install --no-user --target --no-deps`
-* Consumer uses only `default_dependencies=['fmt']` (no `dependencies=[…]`)
+* Consumer uses only `auto_enable_dependencies=['fmt']` (no `import_dependencies=[…]`)
 * Builds and runs a hello that `#include <fmt/core.h>`
 * Second `--offline` pass succeeds after the archive is cached
 
@@ -24,7 +24,7 @@ The example package `examples/cuppa_fmt_plugin` registers `fmt` through `cuppa.d
 import cuppa
 cuppa.run(
     default_variants=['dbg'],
-    default_dependencies=['fmt'],
+    auto_enable_dependencies=['fmt'],
 )
 ----
 

--- a/docs/modules/ROOT/pages/integration/test-list-dependencies.adoc
+++ b/docs/modules/ROOT/pages/integration/test-list-dependencies.adoc
@@ -44,6 +44,45 @@ HTTP archive folders). The verbose scenario also plants `<storage>/downloads/` (
 files and `packages/<package>/<version>/*.{tar.gz,zip}`) and a `sconstruct` that declares a GitLab
 `boost_package` so resolve can supply a registry URL.
 
+=== `sconstruct` (missing location — preferred kwargs)
+
+Used by the first listing scenario (absent tree → `missing`):
+
+[source,python]
+----
+Widget = cuppa.location_dependency(
+    'widget',
+    location='git+https://example.com/org/widget.git@master',
+)
+cuppa.run(
+    default_variants=['dbg'],
+    import_dependencies=[Widget],
+    auto_enable_dependencies=['widget'],
+)
+----
+
+=== `sconstruct` (GitLab package / other scenarios)
+
+NOTE: These fixtures intentionally use the legacy ``dependencies`` /
+``default_dependencies`` aliases so the suite still exercises them. Prefer
+``import_dependencies`` / ``auto_enable_dependencies`` in new projects.
+
+[source,python]
+----
+Boost = cuppa.package_dependency(
+    'boost_package',
+    package_manager='gitlab',
+    registry='https://gitlab.example/api/v4/projects/1',
+    package='boost',
+    version='1.91',
+)
+cuppa.run(
+    default_variants=['dbg'],
+    dependencies=[Boost],
+    default_dependencies=['boost_package'],
+)
+----
+
 == Commands
 
 [source,sh]

--- a/docs/modules/ROOT/pages/integration/test-list-develop.adoc
+++ b/docs/modules/ROOT/pages/integration/test-list-develop.adoc
@@ -24,6 +24,17 @@ The dummy project, initialised as a git repository on branch `feature_orders`, p
 * `deps/gizmo` — path configured but not created
 * `boostish` — registered without a develop path (counted as "not using develop")
 
+=== `sconstruct` (excerpt)
+
+[source,python]
+----
+cuppa.run(
+    default_variants=['dbg'],
+    import_dependencies=[Widget, Gadget, Flange, Gizmo, Boostish],
+    auto_enable_dependencies=['widget', 'gadget', 'flange', 'gizmo', 'boostish'],
+)
+----
+
 == Commands
 
 [source,sh]

--- a/docs/modules/ROOT/pages/integration/test-list-downloads.adoc
+++ b/docs/modules/ROOT/pages/integration/test-list-downloads.adoc
@@ -23,6 +23,28 @@ The dummy project with a `sconstruct` declaring GitLab `boost_package`, plus pla
 `<storage>/downloads/` (top-level archives, `packages/<package>/<version>/*`, and an orphan) and
 matching trees under `<storage>/dependencies/`.
 
+NOTE: This fixture intentionally uses the legacy ``dependencies`` /
+``default_dependencies`` aliases so the suite still exercises them. Prefer
+``import_dependencies`` / ``auto_enable_dependencies`` in new projects.
+
+=== `sconstruct` (excerpt)
+
+[source,python]
+----
+Boost = cuppa.package_dependency(
+    'boost_package',
+    package_manager='gitlab',
+    registry='https://gitlab.example/api/v4/projects/1',
+    package='boost',
+    version='1.91',
+)
+cuppa.run(
+    default_variants=['dbg'],
+    dependencies=[Boost],
+    default_dependencies=['boost_package'],
+)
+----
+
 == Commands
 
 [source,sh]

--- a/docs/modules/ROOT/pages/integration/test-purge-dependencies.adoc
+++ b/docs/modules/ROOT/pages/integration/test-purge-dependencies.adoc
@@ -21,6 +21,30 @@ Dummy project `sconstruct` declaring `boost_package` or `boost` / `widget`, plus
 under `<storage>/dependencies/` and archives under `<storage>/downloads/` (including
 `packages/<package>/<version>/`).
 
+NOTE: These fixtures intentionally use the legacy ``dependencies`` /
+``default_dependencies`` aliases so the suite still exercises them. Prefer
+``import_dependencies`` / ``auto_enable_dependencies`` in new projects.
+
+=== `sconstruct` (GitLab package — excerpt)
+
+[source,python]
+----
+Boost = cuppa.package_dependency(
+    'boost_package',
+    package_manager='gitlab',
+    registry='https://gitlab.example/api/v4/projects/1',
+    package='boost',
+    version='1.91',
+)
+cuppa.run(
+    default_variants=['dbg'],
+    dependencies=[Boost],
+    default_dependencies=['boost_package'],
+)
+----
+
+Source Boost purge uses ``default_dependencies=['boost']`` with ``--boost-home``.
+
 == Commands
 
 [source,sh]

--- a/docs/modules/ROOT/pages/integration/test-remove-dependencies.adoc
+++ b/docs/modules/ROOT/pages/integration/test-remove-dependencies.adoc
@@ -28,6 +28,46 @@ planted folders under `<storage>/dependencies/` (and a develop tree outside stor
 develop-skip case). The Boost case plants a `--boost-home` extract with `clean/` stage and
 `bin.<abi>` products.
 
+=== `sconstruct` (unknown-name error — preferred kwargs)
+
+[source,python]
+----
+Widget = cuppa.location_dependency(
+    'widget',
+    location='git+https://example.com/org/widget.git@master',
+)
+cuppa.run(
+    default_variants=['dbg'],
+    import_dependencies=[Widget],
+    auto_enable_dependencies=['widget'],
+)
+----
+
+=== `sconstruct` (package / develop / most removals)
+
+NOTE: These fixtures intentionally use the legacy ``dependencies`` /
+``default_dependencies`` aliases so the suite still exercises them. Prefer
+``import_dependencies`` / ``auto_enable_dependencies`` in new projects.
+
+[source,python]
+----
+Boost = cuppa.package_dependency(
+    'boost_package',
+    package_manager='gitlab',
+    registry='https://gitlab.example/api/v4/projects/1',
+    package='boost',
+    version='1.91',
+)
+cuppa.run(
+    default_variants=['dbg'],
+    dependencies=[Boost],
+    default_dependencies=['boost_package'],
+)
+----
+
+Source Boost removal uses ``default_dependencies=['boost']`` (legacy alias) with
+``--boost-home`` under the storage root.
+
 == Commands
 
 [source,sh]

--- a/docs/modules/ROOT/pages/integration/test-wipe-dependencies.adoc
+++ b/docs/modules/ROOT/pages/integration/test-wipe-dependencies.adoc
@@ -23,6 +23,38 @@ With planted trees and archives under a private `--storage-root`:
 Dummy project `sconstruct` declaring `boost_package` or `boost`, plus planted folders under
 `<storage>/dependencies/` and archives under `<storage>/downloads/`.
 
+=== `sconstruct` (source Boost wipe — preferred kwargs)
+
+[source,python]
+----
+cuppa.run(
+    default_variants=['dbg'],
+    auto_enable_dependencies=['boost'],
+)
+----
+
+=== `sconstruct` (GitLab package wipe)
+
+NOTE: Package wipe scenarios reuse a shared helper that intentionally uses the legacy
+``dependencies`` / ``default_dependencies`` aliases so the suite still exercises them.
+Prefer ``import_dependencies`` / ``auto_enable_dependencies`` in new projects.
+
+[source,python]
+----
+Boost = cuppa.package_dependency(
+    'boost_package',
+    package_manager='gitlab',
+    registry='https://gitlab.example/api/v4/projects/1',
+    package='boost',
+    version='1.91',
+)
+cuppa.run(
+    default_variants=['dbg'],
+    dependencies=[Boost],
+    default_dependencies=['boost_package'],
+)
+----
+
 == Commands
 
 [source,shell]

--- a/docs/modules/ROOT/pages/methods/dependencies-and-profiles.adoc
+++ b/docs/modules/ROOT/pages/methods/dependencies-and-profiles.adoc
@@ -66,12 +66,13 @@ registered as `widget_lib_package` alongside an archive or built-in `widget_lib`
 **untyped** `BuildWith('widget_lib')` resolves by precedence among **project-available**
 candidates:
 
-1. GitLab — registry key `[gitlab]widget_lib` when used, else the legacy `{name}_package`
+1. GitLab — registry key `[gitlab]widget_lib` when used, else the legacy `\{name}_package`
    form (`widget_lib_package`, and Boost’s familiar `boost_package`)
 2. Short name / archive — `widget_lib`, or `[archive]widget_lib` / `[source]widget_lib` when
    registered that way
 
-A candidate is project-available when it appears in `default_dependencies` / `dependencies=`, or
+A candidate is project-available when it appears in `auto_enable_dependencies` /
+`import_dependencies` (legacy: `default_dependencies` / `dependencies`), or
 was already applied earlier in this sconscript via `BuildWith`. Always-on built-ins such as
 archive `boost` stay in the factory registry for opt-in use; registry presence alone does not
 beat a project-available GitLab package.
@@ -130,8 +131,9 @@ env.BuildProfile('quad_float')
 env.BuildProfile(['profile_a', 'profile_b'])
 ----
 
-Default profiles from `cuppa.run(default_profiles=…)` are applied automatically before each
-sconscript runs; call `BuildProfile()` in the sconscript for extras.
+Default profiles from `cuppa.run(auto_enable_profiles=…)` (legacy: `default_profiles`) are
+applied automatically before each sconscript runs; call `BuildProfile()` in the sconscript for
+extras.
 
 == Related methods
 

--- a/docs/modules/ROOT/pages/methods/dependencies-and-profiles.adoc
+++ b/docs/modules/ROOT/pages/methods/dependencies-and-profiles.adoc
@@ -71,8 +71,8 @@ candidates:
 2. Short name / archive — `widget_lib`, or `[archive]widget_lib` / `[source]widget_lib` when
    registered that way
 
-A candidate is project-available when it appears in `auto_enable_dependencies` /
-`import_dependencies` (legacy: `default_dependencies` / `dependencies`), or
+A candidate is project-available when it appears in `import_dependencies` /
+`auto_enable_dependencies` (legacy: `dependencies` / `default_dependencies`), or
 was already applied earlier in this sconscript via `BuildWith`. Always-on built-ins such as
 archive `boost` stay in the factory registry for opt-in use; registry presence alone does not
 beat a project-available GitLab package.

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -69,34 +69,40 @@ cuppa -D --dbg --test
 
 Use `--show-test-output` to print stdout/stderr from test processes.
 
-== Default dependencies
+== Auto-enable a built-in dependency
 
-Wire a dependency (for example Boost) for every `sconscript`:
+Built-ins such as source Boost are **already registered** with Cuppa. You do not list them in
+`import_dependencies`. Pass them to `auto_enable_dependencies` so every `sconscript` gets
+`BuildWith('boost')` automatically. Unpinned Boost resolves to the latest release on the download
+path (see xref:dependencies/builtins/boost.adoc[Boost]); optionally pin a local tree with
+`boost-location` / `boost-home` in `default_options`.
 
 [source,python]
 ----
 import cuppa
 
 cuppa.run(
-    default_options = {
-        'boost-location': '/path/to/boost',
-    },
-    default_dependencies = [
-        'boost',
+    auto_enable_dependencies = [
+        'boost',  # unpinned → latest on the download path
     ],
 )
 ----
 
-In a `sconscript`, link Boost libraries:
+Custom factories from `package_dependency` / `location_dependency` still need
+`import_dependencies` (and usually the same object in `auto_enable_dependencies`). See
+xref:concepts.adoc#sconstruct-api[cuppa.run() parameters].
+
+In a `sconscript`, select libraries with `use_libs` on the `BuildWith` return value (preferred
+over `BoostStaticLibs`):
 
 [source,python]
 ----
 Import('env')
 
-env.AppendUnique(STATICLIBS=env.BoostStaticLibs([
+env.BuildWith('boost').use_libs([
     'system',
     'filesystem',
-]))
+])
 
 env.BuildTest('my_test', 'my_test.cpp')
 ----

--- a/docs/modules/ROOT/pages/toolchains.adoc
+++ b/docs/modules/ROOT/pages/toolchains.adoc
@@ -215,7 +215,7 @@ Which management flags apply:
   `--force-wipe-dependencies=[toolchain]gcc/gcc_snapshot_*`, or the session name
   (`[toolchain]clang24_profiles_…` / `[toolchain]gcc16_…`) — yes.
 * `--force-wipe-unreferenced-dependencies` — yes for installs that are not the active selection.
-* `--remove-dependencies` / `--purge-dependencies` / `--wipe-dependencies` (and the `*-all-*` forms) — no; those only target **project-used** dependency names from the current selection (`default_dependencies` / `BuildWith`), not compiler installs.
+* `--remove-dependencies` / `--purge-dependencies` / `--wipe-dependencies` (and the `*-all-*` forms) — no; those only target **project-used** dependency names from the current selection (`auto_enable_dependencies` / `BuildWith`), not compiler installs.
 
 Design notes: `design/archive/toolchains-as-dependencies.md`.
 

--- a/examples/conan_fmt_plugin/CONSUMER.md
+++ b/examples/conan_fmt_plugin/CONSUMER.md
@@ -6,11 +6,11 @@
 #   import cuppa
 #   cuppa.run(
 #       default_variants=['dbg'],
-#       default_dependencies=['fmt'],  # discovered via cuppa.dependency.plugins
+#       auto_enable_dependencies=['fmt'],  # discovered via cuppa.dependency.plugins
 #   )
 #
 # In the project sconscript:
 #
 #   Import('env')
-#   env.BuildWith('fmt')   # optional if already in default_dependencies
+#   env.BuildWith('fmt')   # optional if already in auto_enable_dependencies
 #   env.Build('hello', 'hello.cpp')

--- a/examples/conan_fmt_plugin/cuppa_conan_fmt/__init__.py
+++ b/examples/conan_fmt_plugin/cuppa_conan_fmt/__init__.py
@@ -9,9 +9,9 @@ Install this package (``pip install -e examples/conan_fmt_plugin``) so Cuppa
 discovers the ``fmt`` dependency through the ``cuppa.dependency.plugins``
 entry point. Consumer projects can then use::
 
-    cuppa.run(default_dependencies=['fmt'])
+    cuppa.run(auto_enable_dependencies=['fmt'])
 
-without listing the dependency class in ``cuppa.run(dependencies=[…])``.
+without listing the dependency class in ``cuppa.run(import_dependencies=[…])``.
 """
 
 import cuppa

--- a/examples/cuppa_fmt_plugin/cuppa_fmt/__init__.py
+++ b/examples/cuppa_fmt_plugin/cuppa_fmt/__init__.py
@@ -9,9 +9,9 @@ Install this package (``pip install -e examples/cuppa_fmt_plugin``) so Cuppa
 discovers ``fmt`` through ``cuppa.dependency.plugins``. Consumer projects can
 then use::
 
-    cuppa.run(default_dependencies=['fmt'])
+    cuppa.run(auto_enable_dependencies=['fmt'])
 
-without listing the dependency class in ``cuppa.run(dependencies=[…])``.
+without listing the dependency class in ``cuppa.run(import_dependencies=[…])``.
 
 This builds {fmt} from a pinned GitHub archive (not Conan). Prefer
 ``examples/conan_fmt_plugin`` when you want ConanCenter binaries instead.

--- a/tests/integration/methods/test_build_with.py
+++ b/tests/integration/methods/test_build_with.py
@@ -20,7 +20,7 @@ def test_build_with_location_dependency(tmp_path):
             ")\n"
             "cuppa.run(\n"
             "    default_variants=['dbg'],\n"
-            "    dependencies=[Headers],\n"
+            "    import_dependencies=[Headers],\n"
             ")\n"
         ),
     )

--- a/tests/integration/methods/test_conan.py
+++ b/tests/integration/methods/test_conan.py
@@ -3,7 +3,13 @@
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)
 
-"""Integration tests for optional Conan 2 consumer support (SConsDeps)."""
+"""Integration tests for optional Conan 2 consumer support (SConsDeps).
+
+Early consumer scenarios use preferred ``import_dependencies`` /
+``auto_enable_dependencies``; later publish / shared-lib fixtures keep the
+legacy ``dependencies`` / ``default_dependencies`` aliases so both styles stay
+covered.
+"""
 
 import logging
 import re
@@ -234,8 +240,8 @@ def test_conan_deps_generators_folder_reuse(tmp_path):
             "Conan = cuppa.conan_deps(generators_folder='_conan')\n"
             "cuppa.run(\n"
             "    default_variants=['dbg'],\n"
-            "    dependencies=[Conan],\n"
-            "    default_dependencies=['conan'],\n"
+            "    import_dependencies=[Conan],\n"
+            "    auto_enable_dependencies=[Conan],\n"
             ")\n"
         ),
     )
@@ -274,8 +280,8 @@ def test_conan_deps_install_build_and_run(tmp_path):
             "Conan = cuppa.conan_deps(conanfile='conanfile.txt')\n"
             "cuppa.run(\n"
             "    default_variants=['dbg'],\n"
-            "    dependencies=[Conan],\n"
-            "    default_dependencies=['conan'],\n"
+            "    import_dependencies=[Conan],\n"
+            "    auto_enable_dependencies=[Conan],\n"
             ")\n"
         ),
     )
@@ -393,7 +399,7 @@ def test_conan_fmt_pip_plugin_entry_point(tmp_path):
             "import cuppa\n"
             "cuppa.run(\n"
             "    default_variants=['dbg'],\n"
-            "    default_dependencies=['fmt'],\n"
+            "    auto_enable_dependencies=['fmt'],\n"
             ")\n"
         ),
     )

--- a/tests/integration/methods/test_fmt_location_plugin.py
+++ b/tests/integration/methods/test_fmt_location_plugin.py
@@ -68,7 +68,7 @@ def test_fmt_location_pip_plugin_builds_static_lib(tmp_path):
             "import cuppa\n"
             "cuppa.run(\n"
             "    default_variants=['dbg'],\n"
-            "    default_dependencies=['fmt'],\n"
+            "    auto_enable_dependencies=['fmt'],\n"
             ")\n"
         ),
     )

--- a/tests/integration/test_clone_develop.py
+++ b/tests/integration/test_clone_develop.py
@@ -64,8 +64,8 @@ Widget = cuppa.location_dependency(
         develop={develop!r},
 )
 cuppa.run(
-        default_dependencies=['widget'],
-        dependencies=[Widget],
+        import_dependencies=[Widget],
+        auto_enable_dependencies=['widget'],
 )
 """.format(
                     location="git+{}@master".format( origin_uri ),

--- a/tests/integration/test_list_dependencies.py
+++ b/tests/integration/test_list_dependencies.py
@@ -232,8 +232,8 @@ Widget = cuppa.location_dependency(
 
 cuppa.run(
     default_variants=['dbg'],
-    dependencies=[Widget],
-    default_dependencies=['widget'],
+    import_dependencies=[Widget],
+    auto_enable_dependencies=['widget'],
 )
 """,
     )

--- a/tests/integration/test_list_develop.py
+++ b/tests/integration/test_list_develop.py
@@ -171,8 +171,8 @@ Boostish = cuppa.location_dependency(
 
 cuppa.run(
     default_variants=['dbg'],
-    dependencies=[Widget, Gadget, Flange, Gizmo, Boostish],
-    default_dependencies=['widget', 'gadget', 'flange', 'gizmo', 'boostish'],
+    import_dependencies=[Widget, Gadget, Flange, Gizmo, Boostish],
+    auto_enable_dependencies=['widget', 'gadget', 'flange', 'gizmo', 'boostish'],
 )
 """.format(
                     widget=str( widget ),

--- a/tests/integration/test_remove_dependencies.py
+++ b/tests/integration/test_remove_dependencies.py
@@ -167,8 +167,8 @@ Widget = cuppa.location_dependency(
 
 cuppa.run(
     default_variants=['dbg'],
-    dependencies=[Widget],
-    default_dependencies=['widget'],
+    import_dependencies=[Widget],
+    auto_enable_dependencies=['widget'],
 )
 """,
     )

--- a/tests/integration/test_wipe_dependencies.py
+++ b/tests/integration/test_wipe_dependencies.py
@@ -1,4 +1,9 @@
-"""Integration tests for --wipe-dependencies and --force-wipe-*."""
+"""Integration tests for --wipe-dependencies and --force-wipe-*.
+
+Source-Boost fixtures use preferred ``auto_enable_dependencies``; package
+helpers imported from purge/remove keep legacy ``dependencies`` /
+``default_dependencies`` aliases.
+"""
 
 from pathlib import Path
 
@@ -83,7 +88,7 @@ import cuppa
 
 cuppa.run(
     default_variants=['dbg'],
-    default_dependencies=['boost'],
+    auto_enable_dependencies=['boost'],
 )
 """,
     )
@@ -227,7 +232,7 @@ import cuppa
 
 cuppa.run(
     default_variants=['dbg'],
-    default_dependencies=['boost'],
+    auto_enable_dependencies=['boost'],
 )
 """,
     )
@@ -288,7 +293,7 @@ import cuppa
 
 cuppa.run(
     default_variants=['dbg'],
-    default_dependencies=['boost'],
+    auto_enable_dependencies=['boost'],
 )
 """,
     )
@@ -359,7 +364,7 @@ import cuppa
 
 cuppa.run(
     default_variants=['dbg'],
-    default_dependencies=['boost'],
+    auto_enable_dependencies=['boost'],
 )
 """,
     )

--- a/tests/unit/test_construct_helpers.py
+++ b/tests/unit/test_construct_helpers.py
@@ -6,6 +6,7 @@
 from types import SimpleNamespace
 
 import pytest
+import SCons.Errors
 
 from cuppa.construct import Construct
 from tests.helpers.fakes import FakeEnv
@@ -21,6 +22,84 @@ def test_normalise_with_defaults_list_merge():
     assert warning is None
     assert defaults == ["dbg", "rel"]
     assert values == ["custom"]
+
+
+def test_normalise_with_defaults_object_in_defaults_only():
+    class Named:
+        @classmethod
+        def name( cls ):
+            return "widget"
+
+    values, defaults, warning = Construct._normalise_with_defaults(
+        [], [Named], "dependencies"
+    )
+    assert warning is None
+    assert defaults == ["widget"]
+    assert values == [Named]
+
+
+def test_normalise_with_defaults_object_in_both_lists_dedupes_registration():
+    class Named:
+        @classmethod
+        def name( cls ):
+            return "widget"
+
+    values, defaults, warning = Construct._normalise_with_defaults(
+        [Named], [Named], "dependencies"
+    )
+    assert warning is None
+    assert defaults == ["widget"]
+    assert values == [Named]
+
+
+def test_normalise_with_defaults_mix_string_and_object():
+    class Named:
+        @classmethod
+        def name( cls ):
+            return "widget"
+
+    values, defaults, warning = Construct._normalise_with_defaults(
+        [Named], [Named, "boost"], "dependencies"
+    )
+    assert defaults == ["widget", "boost"]
+    assert values == [Named]
+
+
+def test_normalise_with_defaults_rejects_nameless_object():
+    class Nameless:
+        pass
+
+    with pytest.raises(SCons.Errors.StopError) as caught:
+        Construct._normalise_with_defaults( [], [Nameless], "dependencies" )
+    assert "no name()" in str( caught.value )
+
+
+def test_normalise_with_defaults_rejects_empty_name():
+    class Bad:
+        @classmethod
+        def name( cls ):
+            return ""
+
+    with pytest.raises(SCons.Errors.StopError):
+        Construct._normalise_with_defaults( [], [Bad], "dependencies" )
+
+
+def test_normalise_with_defaults_package_dependency_factory():
+    from cuppa.build_with_package import package_dependency
+
+    Widget = package_dependency(
+            "widget",
+            package_manager="gitlab",
+            registry="https://gitlab.example/api/v4/projects/1",
+            package="widget",
+            version="1.0",
+    )
+    values, defaults, warning = Construct._normalise_with_defaults(
+        [Widget], [Widget], "dependencies"
+    )
+    assert warning is None
+    assert defaults == ["widget"]
+    assert values == [Widget]
 
 
 def test_normalise_with_defaults_deprecated_dict():

--- a/tests/unit/test_construct_helpers.py
+++ b/tests/unit/test_construct_helpers.py
@@ -9,6 +9,7 @@ import pytest
 import SCons.Errors
 
 from cuppa.construct import Construct
+from cuppa.core.run_list_names import coalesce_aliased_run_list
 from tests.helpers.fakes import FakeEnv
 
 
@@ -22,6 +23,39 @@ def test_normalise_with_defaults_list_merge():
     assert warning is None
     assert defaults == ["dbg", "rel"]
     assert values == ["custom"]
+
+
+def test_coalesce_aliased_run_list_prefers_new_name():
+    assert coalesce_aliased_run_list(
+            ["a"], None, "import_dependencies", "dependencies"
+    ) == ["a"]
+
+
+def test_coalesce_aliased_run_list_legacy_when_preferred_omitted():
+    assert coalesce_aliased_run_list(
+            None, ["b"], "import_dependencies", "dependencies"
+    ) == ["b"]
+
+
+def test_coalesce_aliased_run_list_both_equal_ok():
+    assert coalesce_aliased_run_list(
+            ["x"], ["x"], "import_dependencies", "dependencies"
+    ) == ["x"]
+
+
+def test_coalesce_aliased_run_list_both_unequal_fails():
+    with pytest.raises(SCons.Errors.StopError) as caught:
+        coalesce_aliased_run_list(
+                ["a"], ["b"], "import_dependencies", "dependencies"
+        )
+    assert "import_dependencies" in str( caught.value )
+    assert "dependencies" in str( caught.value )
+
+
+def test_coalesce_aliased_run_list_neither_is_empty():
+    assert coalesce_aliased_run_list(
+            None, None, "import_dependencies", "dependencies"
+    ) == []
 
 
 def test_normalise_with_defaults_object_in_defaults_only():


### PR DESCRIPTION
## Summary

- Preferred `cuppa.run` kwargs: `import_dependencies` / `auto_enable_dependencies` (and `import_profiles` / `auto_enable_profiles`); legacy `dependencies` / `default_dependencies` (and profile twins) remain aliases ([#276](https://github.com/ja11sop/cuppa/issues/276)).
- Lists accept factories or strings via `name()`; dedupe registration when the same factory appears in both lists; clear `StopError` when `name()` is missing or when both preferred and legacy kwargs are passed with unequal lists.
- Teach-path docs (quickstart, README, concepts, dependency hubs) prefer the new names: built-ins and pip plugins use only `auto_enable_dependencies`; custom factories use both lists; examples prefer `BuildWith(...).use_libs(...)`.
- Integration fixtures exercise **both** preferred and legacy kwargs; Antora integration pages match the fixtures and use NOTE admonitions where legacy aliases are intentional.

Plan: [`design/plans/run-default-dependency-objects.md`](https://github.com/ja11sop/cuppa/blob/feature/run-default-dependency-objects/design/plans/run-default-dependency-objects.md).

## Test plan

- [x] `flake8` / `pylint -E` / `pytest -m unit`
- [x] Updated integration modules (build_with, fmt plugin, clone/list develop, wipe, list/remove deps, selected conan consumers)
- [x] CI green on the matrix