### PR TITLE
Fix docs /latest/ navbar links and add URL integrity checks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'docs/**'
       - 'scripts/docs_*.py'
+      - 'scripts/check_docs_urls.py'
       - 'requirements.txt'
       - '.github/workflows/docs.yml'
   release:
@@ -64,11 +65,17 @@ jobs:
         working-directory: docs
         run: npm ci
 
+      - name: Check docs URL integrity (sources)
+        run: python -m scripts.check_docs_urls
+
       - name: Generate Antora site and agent Markdown
         working-directory: docs
         run: npm run build:site:all
         env:
           SITE_SEARCH_PROVIDER: lunr
+
+      - name: Check docs URL integrity (built site)
+        run: python -m scripts.check_docs_urls --built-site _docs_build/site
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,6 +337,7 @@ flake8 cuppa
 pylint -E cuppa
 pytest -m unit
 pytest -m integration
+python -m scripts.check_docs_urls   # versionless /cuppa/… links (also in check_release)
 ```
 
 If you cannot activate the venv in the current shell, call the venv binaries by path
@@ -509,7 +510,7 @@ help only — that includes running outside a project tree, or from a nested dir
 `-D`. Inspect a project's options with `cuppa -D -h` (from anywhere under the tree). `scons -D -h`
 lists the same registered flags once the project has loaded; `scons -H` is SCons' own option list
 for the installed version. Task pages live under `docs/modules/ROOT/pages/cli/` /
-[CLI reference](https://ja11sop.github.io/cuppa/cuppa/cli-reference.html).
+[CLI reference](https://ja11sop.github.io/cuppa/cuppa/latest/cli-reference.html).
 
 ## Defaults (do not invent older paths)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``auto_enable_dependencies``. Examples prefer ``BuildWith(...).use_libs(...)``
   ([#276](https://github.com/ja11sop/cuppa/issues/276)).
   Integration fixtures exercise both preferred and legacy ``cuppa.run`` kwargs.
+- ``scripts.check_docs_urls`` — refuse versionless ``/cuppa/….html`` links in the top navbar
+  partial, README/AGENTS absolute URLs, and (with ``--built-site``) generated Antora HTML.
+  Included from ``scripts.check_release`` and the documentation workflow.
 
 ### Changed
 
@@ -26,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+- Top navbar and README absolute docs links used versionless ``/cuppa/….html`` paths after
+  ``latest_version_segment``; they now target ``/cuppa/latest/…``. ``scripts.check_docs_urls``
+  guards sources and the built site (also wired into ``check_release`` and the documentation
+  workflow).
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ cuppa -D
 
 and cuppa builds the relevant `sconscript` files (the `-D` SCons flag finds the `sconstruct` and runs scripts relative to your starting directory).
 
-Full reference documentation: **[https://ja11sop.github.io/cuppa/](https://ja11sop.github.io/cuppa/)** (Antora site in [`docs/`](docs/)). Contributing to cuppa itself (versioning, releases): [Contributing](https://ja11sop.github.io/cuppa/cuppa/contributing.html). Agent-oriented guidance: [`AGENTS.md`](AGENTS.md). Feature roadmap: [`ROADMAP.md`](ROADMAP.md). Release notes: [`CHANGELOG.md`](CHANGELOG.md). Design notes and plans: [`design/`](design/).
+Full reference documentation: **[https://ja11sop.github.io/cuppa/](https://ja11sop.github.io/cuppa/)** (Antora site in [`docs/`](docs/)). Contributing to cuppa itself (versioning, releases): [Contributing](https://ja11sop.github.io/cuppa/cuppa/latest/contributing.html). Agent-oriented guidance: [`AGENTS.md`](AGENTS.md). Feature roadmap: [`ROADMAP.md`](ROADMAP.md). Release notes: [`CHANGELOG.md`](CHANGELOG.md). Design notes and plans: [`design/`](design/).
 
 ## Features
 
@@ -31,7 +31,7 @@ pip install cuppa
 
 The `cuppa` console script wraps `scons`: it appends `--cuppa-mode`, intercepts stdout/stderr to mask environment values whose names contain `TOKEN`, and may adjust CPU affinity when `--parallel` is used. Prefer `cuppa` over bare `scons` in CI.
 
-Other install options (local `pip install cuppa -t .`, `site_scons`, bootstrap from `sconstruct`) are covered in the [install guide](https://ja11sop.github.io/cuppa/cuppa/install.html).
+Other install options (local `pip install cuppa -t .`, `site_scons`, bootstrap from `sconstruct`) are covered in the [install guide](https://ja11sop.github.io/cuppa/cuppa/latest/install.html).
 
 ## Quickstart
 
@@ -126,7 +126,7 @@ cuppa -D --cov --test
 
 Benchmarks and generic runners: `--benchmark`, `--run` (and `--force-*` variants).
 
-See the [CLI reference](https://ja11sop.github.io/cuppa/cuppa/cli-reference.html) for the full option list (storage, location matching, Boost, GitLab packages, Code::Blocks export, and more).
+See the [CLI reference](https://ja11sop.github.io/cuppa/cuppa/latest/cli-reference.html) for the full option list (storage, location matching, Boost, GitLab packages, Code::Blocks export, and more).
 
 ## Build layout
 
@@ -158,7 +158,7 @@ If the script file is named `sconscript`, that filename segment is omitted.
 | **Variants / actions** | How to compile (`dbg`/`rel`/`cov`) vs extra work (`test`/`benchmark`/`run`) |
 | **Toolchains** | Concrete compilers discovered at configure time (`gcc`, `gcc15`, `clang`, `clang21`, …) |
 
-Toolchains are discovered from the machine; supported aliases currently extend through **gcc16** (including `gcc162`) and **clang22**, plus MSVC `vc` / `vc*` on Windows (coverage is GCC/Clang only). Details: [toolchains](https://ja11sop.github.io/cuppa/cuppa/toolchains.html).
+Toolchains are discovered from the machine; supported aliases currently extend through **gcc16** (including `gcc162`) and **clang22**, plus MSVC `vc` / `vc*` on Windows (coverage is GCC/Clang only). Details: [toolchains](https://ja11sop.github.io/cuppa/cuppa/latest/toolchains.html).
 
 ## Configuration
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,6 +23,7 @@ Minor cycle after **1.10.0**. Prefer work that changes opt-in toolchain or packa
 | Area | Intent in 1.11.0 |
 |------|------------------|
 | `cuppa.run` default_dependencies objects | [`run-default-dependency-objects.md`](design/plans/run-default-dependency-objects.md) — objects in both lists; teach register vs auto-apply; optional clearer names later |
+| Transitive GitLab packages | [`gitlab-package-transitive.md`](design/plans/gitlab-package-transitive.md) — package A carries B (proposal; not committed for 1.11.0 yet) |
 | GitLab CMake staging | [#209](https://github.com/ja11sop/cuppa/issues/209) |
 | Artefact removal design | [#135](https://github.com/ja11sop/cuppa/issues/135) |
 | Console bundle | `--terse-output`, log hygiene, `cuppa --info` |

--- a/design/README.md
+++ b/design/README.md
@@ -21,6 +21,7 @@ maintainer workflow evolved.
 
 | Document | Status | Subject |
 |----------|--------|---------|
+| [`plans/gitlab-package-transitive.md`](plans/gitlab-package-transitive.md) | proposal | GitLab package A can carry deps on package B (manifest + BuildWith); consumer declares A only |
 | [`plans/run-default-dependency-objects.md`](plans/run-default-dependency-objects.md) | in progress | `cuppa.run` `default_dependencies` accepts objects; register vs auto-apply semantics / naming |
 | [`archive/gitlab-package-latest.md`](archive/gitlab-package-latest.md) | shipped | GitLab `version="latest"` = registry latest; Boost package retarget; consume docs — [#271](https://github.com/ja11sop/cuppa/issues/271) / [#272](https://github.com/ja11sop/cuppa/pull/272) |
 | [`archive/dependency-resolve.md`](archive/dependency-resolve.md) | shipped | BuildWith untyped resolve + type selectors; Quince `use_libs` — [#250](https://github.com/ja11sop/cuppa/issues/250) / [#270](https://github.com/ja11sop/cuppa/pull/270) |

--- a/design/ideas/scratchpad.md
+++ b/design/ideas/scratchpad.md
@@ -16,6 +16,7 @@ Do not put private project names here; use anonymised labels and
 
 ### Graduated (removed from this file)
 
+- Dependent GitLab packages → [`plans/gitlab-package-transitive.md`](../plans/gitlab-package-transitive.md)
 - Boost `latest` persistence → [`archive/boost-latest-persistence.md`](../archive/boost-latest-persistence.md)
 - `--list-toolchains` → [`archive/list-toolchains.md`](../archive/list-toolchains.md)
 - Native coloured toolchain output → [`plans/native-toolchain-output.md`](../plans/native-toolchain-output.md)
@@ -44,13 +45,6 @@ Assess what is involved and write a plan. Should integrate with the existing GCC
 reporting path. Deferred while Boost latest persistence and `--list-toolchains` are in flight.
 
 ## New plan(s): Dependencies
-
-### Support dependent gitlab packages for gitlab packages
-
-Currently gitlab packages are largely standalone so if package A depends on package B then
-you need to explicitly add A and B to your sconstruct. It would be nice if we could allow
-packages themselves to depend on other packages so in the example case the user just needs
-to know about A and it already carries the information needed to also get package B.
 
 ### Built-in dependencies in their own repositories
 

--- a/design/plans/docs-site-release-default.md
+++ b/design/plans/docs-site-release-default.md
@@ -90,6 +90,8 @@ latest routing moves `latest` to that line.
 | `doc-site-ci` | Adjust `docs.yml` and/or `release.yml` so stable site updates on publish | `workflow_call` from **publish** after the tag exists (`GITHUB_TOKEN` `release: published` does not start other workflows); also `workflow_dispatch` | **Done** |
 | `doc-site-local` | Contributor notes: preview current branch vs build release set | Contributing / AGENTS | **Done** |
 | `doc-site-verify` | After first release with the model: homepage / `/latest/` shows released text | Manual check after merge/deploy | Open |
+| `doc-site-navbar-latest` | Top navbar + README absolute links use `/cuppa/latest/…` (not versionless `/cuppa/…`) | Broken Contributing/menu after `latest_version_segment` | **Done** (2026-09-05) |
+| `doc-site-url-gate` | `scripts.check_docs_urls` in unit tests, `check_release`, and `docs.yml` (sources + built site) | Catch versionless `/cuppa/…` before publish | **Done** (2026-09-05) |
 
 ## Acceptance criteria
 

--- a/design/plans/gitlab-package-transitive.md
+++ b/design/plans/gitlab-package-transitive.md
@@ -1,0 +1,182 @@
+# Plan: Transitive GitLab package dependencies
+
+- **Status:** proposal
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Dependencies / packages; [`archive/gitlab-package-latest.md`](../archive/gitlab-package-latest.md); [`archive/dependency-resolve.md`](../archive/dependency-resolve.md); [`archive/conan-consumer-plan.md`](../archive/conan-consumer-plan.md) (transitive `requires` as contrast); [`run-default-dependency-objects.md`](run-default-dependency-objects.md) (import vs auto-enable); scratchpad graduate
+- **Updated:** 2026-09-05
+- **Impact:** minor — new publish/consume behaviour for GitLab packages; existing flat declarations stay valid
+
+## Problem
+
+GitLab `package_dependency` archives are **standalone**. If package **A** needs package **B**
+at build or link time, the consumer must declare both in the sconstruct:
+
+```python
+A = cuppa.package_dependency( 'a', registry=…, package='a', version='1.2' )
+B = cuppa.package_dependency( 'b', registry=…, package='b', version='3.0' )
+
+cuppa.run(
+    import_dependencies = [ A, B ],
+    auto_enable_dependencies = [ A, B ],  # or BuildWith both in sconscripts
+)
+```
+
+That duplicates publisher knowledge in every consumer and is easy to get wrong (forgotten B,
+mismatched versions). The desired ergonomics: the consumer knows about **A**, and A already
+carries enough information to fetch and apply **B**.
+
+Today there is **no** package-to-package graph for GitLab:
+
+| Mechanism | What it does | Transitive packages? |
+|-----------|--------------|----------------------|
+| `use_libs(..., depends_on=[])` | SCons `env.Depends` on include/lib nodes | No — build-order only |
+| Boost `add_dependent_libraries` | Intra-Boost static link closure | No — same archive |
+| `dependency_resolve` | Pick GitLab vs archive for one *name* | No — supply-chain choice |
+| Conan `requires` | Conan install graph | Yes — Conan only |
+| Published archive | `include/`, `lib/`, optional `modules/` | No dependency manifest |
+
+Key code: `cuppa/build_with_package.py`, `cuppa/package_managers/gitlab.py`
+(`GitlabPackageDependency`, `GitlabPackagePublisher`), consume docs under
+`docs/modules/ROOT/pages/dependencies/gitlab.adoc` and publish under `packages.adoc`.
+
+## Goals
+
+1. Let a GitLab package **declare** dependencies on other GitLab packages so a consumer that
+   `BuildWith`s / auto-enables **A** also gets **B** without listing B in the sconstruct.
+2. Keep the existing flat model working (explicit A+B remains valid and is the escape hatch).
+3. Fail clearly for cycles, missing factories, and offline cache misses.
+4. Document publish and consume shapes; cover with an integration round-trip.
+
+## Non-goals (MVP)
+
+- A full constraint solver (version ranges, backtracking) — Conan already covers that niche.
+- Implicit `auto_enable` of transitive deps as session defaults (surprise global includes).
+- Cross-registry deps in the first cut (same registry / `registry: "same"` only).
+- Replacing Conan for multi-package graphs from ConanCenter.
+- Changing BuildWith type-selector / `dependency_resolve` precedence
+  ([`dependency-resolve.md`](../archive/dependency-resolve.md)).
+
+## Semantics (settled for exploration)
+
+Align with import vs auto-enable ([`run-default-dependency-objects.md`](run-default-dependency-objects.md)):
+
+| Layer | Role for transitive B |
+|-------|------------------------|
+| Consumer still **imports / auto-enables A** | A remains the only name the project must know |
+| When A is `BuildWith`'d (or auto-enabled) | Cuppa reads A's dependency metadata and `BuildWith`s B |
+| B is **not** added to `auto_enable_dependencies` by default | Avoid pulling B into every sconscript that never uses A |
+| Consumer may still import B explicitly | Pins, develop paths, or overrides win over transitive discovery |
+
+So “declare A only” means: **register A**; applying A pulls B. It does **not** mean B becomes a
+session-wide default unless the consumer listed B in `auto_enable_dependencies`.
+
+## Where the edge is declared
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A. Manifest inside the published archive** (recommended MVP) | Travels with the artefact; offline-friendly; versioned with A | Needs publish + consume changes; schema evolution |
+| **B. Only `define()` / publisher kwargs in Python** | Familiar to Cuppa authors | Consumer never runs publisher code unless metadata is written into the archive anyway |
+| **C. Separate registry index / API** | No archive format change | Extra infra; weaker offline story |
+| **D. Consumer-only `requires=[B]` on A's factory** | Easy to prototype | Defeats “A carries B”; duplicates publisher knowledge |
+
+**Recommendation:** **A**, fed by publisher kwargs (**B** at authoring time). Publisher writes
+something like `cuppa-package.json` (name TBD) next to `include/` / `lib/` when staging the
+tarball. Consumer reads it after extract.
+
+Illustrative schema (not final):
+
+```json
+{
+  "cuppa_package_format": 1,
+  "dependencies": [
+    {
+      "name": "fmt",
+      "package": "fmt",
+      "version": "12.1.0",
+      "registry": "same"
+    }
+  ]
+}
+```
+
+- **Concrete versions in MVP** — no ranges; publish-time resolve of `latest` into a pin is
+  allowed so offline consumers do not re-resolve B.
+- `registry: "same"` means A's registry URL (or an explicit URL later).
+- Optional later fields: `link` (auto `use_libs` pull), supply-chain type, develop hints.
+
+## How consume applies B
+
+1. After A is extracted (or develop path selected), read the manifest if present.
+2. For each dependency entry, obtain a factory:
+   - Prefer a factory already registered under `name` (consumer or plugin).
+   - Else **synthesize** `package_dependency(name, registry=…, package=…, version=…)` when the
+     manifest has enough identity (MVP: same registry + package + version).
+3. Call `env.BuildWith(B)` during A's initialise / first apply path (not global auto-enable).
+4. **Cycle detection** on the apply stack (A→B→A → `StopError`).
+5. **Diamond:** same `(registry, package, version, tool_variant)` reuses the existing
+   package instance / cache (today's identity caching already helps).
+6. **Conflict:** two concrete versions of the same package name → fail clearly in MVP
+   (first-wins is too silent for prebuilt ABI).
+
+### Develop / offline
+
+- **`--offline`:** every transitive archive must already be under downloads; no network
+  `latest` for B unless a remembered pin exists and the archive is cached.
+- **`--develop`:** if the consumer configured a develop path for B, use it; otherwise use the
+  packaged extract. Do not invent develop paths for transitive deps.
+- **`--list-dependencies`:** show A with B as a child edge when the manifest was applied
+  (presentation; inventory already has a tree shape).
+
+## Contrast with Conan
+
+Conan already models transitive `requires`. This plan is **GitLab registry packages only** —
+prebuilt Cuppa-shaped archives (`include/` / `lib/` / `modules/`), not a second Conan.
+Keep Conan for ConanCenter graphs; keep GitLab transitive for org-published Cuppa packages.
+A later bridge (manifest → Conan `requires` on publish) is out of scope for MVP.
+
+## Phases
+
+| ID | Slice | Notes |
+|----|--------|-------|
+| `gl-dep-rules` | This plan: semantics, schema sketch, refusal rules | **This document** |
+| `gl-dep-publish` | Publisher writes manifest from kwargs / `dependencies=` | Opt-in at first if safer |
+| `gl-dep-consume` | Read manifest; synthesize or reuse factory; `BuildWith` transitive; cycles / conflicts | |
+| `gl-dep-tests` | Integration: publish A+B fixture → consume A only → link/run | |
+| `gl-dep-docs` | `gitlab.adoc` + `packages.adoc`; teach vs flat declare | |
+| `gl-dep-list` | `--list-dependencies` / inventory edges from manifest | After consume |
+| `gl-dep-ranges` | Version ranges / softer diamond policy | Deferred |
+| `gl-dep-issue` | File `impact:minor` issue when implementing | |
+
+## Open questions
+
+1. **Manifest filename** — `cuppa-package.json` vs `cuppa.json` vs beside `module-map.json`?
+2. **Opt-in publish** — always write when deps declared, or `--package-write-deps` until soak?
+3. **Does `use_libs` on A imply transitive `use_libs` on B?** MVP: only `BuildWith` (headers /
+   SYSINCPATH); linking B stays explicit unless a later `link: true` field exists.
+4. **Naming of Cuppa registry names** — must manifest `name` match `package_dependency`'s
+   registry name (`fmt` vs `fmt_package`)? Prefer the **BuildWith name** the consumer would use.
+5. **Interaction with `boost_package`** — Boost's internal lib graph stays separate; Boost as a
+   transitive *package* dep of A is an ordinary manifest entry.
+6. **Pip plugins** — can a plugin's factory default-declare transitive deps without a published
+   archive (develop / location hybrid)? Defer unless a concrete plugin needs it.
+
+## Refusal rules
+
+- Do not require every existing package to sprout a manifest (absent file = today's behaviour).
+- Do not auto-add transitive names to `auto_enable_dependencies`.
+- Do not invent a solver in MVP — concrete versions only.
+- Do not silently pick one version when two concrete pins conflict.
+- Do not put private project / registry host names in this plan's examples (use
+  `gitlab.example` / `widget` / `fmt`).
+
+## Progress snapshot
+
+| Slice | Status |
+|-------|--------|
+| `gl-dep-rules` | Done — this proposal |
+| `gl-dep-publish` | Not started |
+| `gl-dep-consume` | Not started |
+| `gl-dep-tests` | Not started |
+| `gl-dep-docs` | Not started |
+| `gl-dep-list` | Not started |
+| `gl-dep-ranges` | Deferred |
+| `gl-dep-issue` | Not filed |

--- a/design/process/agent-workflow-journey.md
+++ b/design/process/agent-workflow-journey.md
@@ -422,7 +422,8 @@ This is a process rule, not a product plan. Day-to-day wording lives in `AGENTS.
 | [`CHANGELOG.md`](../../CHANGELOG.md) | Release-facing history |
 | [`release.txt`](../../release.txt) | One-page release checklist |
 | [`.github/workflows/release.yml`](../../.github/workflows/release.yml) | prepare / publish / tag-push |
-| [`scripts/check_release.py`](../../scripts/check_release.py) | Gate: no `.dev`, dated notes, tag match |
+| [`scripts/check_release.py`](../../scripts/check_release.py) | Gate: no `.dev`, dated notes, tag match; also docs URL integrity |
+| [`scripts/check_docs_urls.py`](../../scripts/check_docs_urls.py) | Refuse versionless `/cuppa/….html` in navbar / README / built site |
 | [`scripts/finish_release.py`](../../scripts/finish_release.py) / [`start_release.py`](../../scripts/start_release.py) | Close / open cycles |
 | [`docs/.../contributing.adoc`](../../docs/modules/ROOT/pages/contributing.adoc) | Human Contributing hub (diagrams on children) |
 | [`design/README.md`](../README.md) | Index of plans / process / archive |

--- a/docs/modules/ROOT/pages/contributing/release.adoc
+++ b/docs/modules/ROOT/pages/contributing/release.adoc
@@ -103,6 +103,17 @@ sequenceDiagram
 Tagging (or publishing against a tag that points at) a commit that is still `.dev` fails the
 release gate — the same mistake as tagging the wrong merge before `finish_release` landed.
 
+Before **prepare** / **publish**, and in CI, also run:
+
+[source,sh]
+----
+python -m scripts.check_docs_urls
+----
+
+After a local multi-version docs build, add `--built-site _docs_build/site` so generated navbar
+hrefs cannot regress to versionless `/cuppa/….html` (404 once `latest_version_segment` is on).
+`scripts.check_release` includes the source-side check automatically.
+
 [mermaid]
 ....
 flowchart TD

--- a/docs/supplemental-ui/partials/header-content.hbs
+++ b/docs/supplemental-ui/partials/header-content.hbs
@@ -24,35 +24,35 @@
     <div id="topbar-nav" class="navbar-menu">
       <div class="navbar-end">
         <div class="navbar-item has-dropdown is-hoverable">
-          <a class="navbar-link" href="{{{siteRootPath}}}/cuppa/install.html">Get started</a>
+          <a class="navbar-link" href="{{{siteRootPath}}}/cuppa/latest/install.html">Get started</a>
           <div class="navbar-dropdown">
-            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/install.html">Install</a>
-            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/quickstart.html">Quickstart</a>
-            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/concepts.html">Concepts</a>
-            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/build-layout.html">Build layout</a>
-            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/configuration.html">Configuration</a>
+            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/latest/install.html">Install</a>
+            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/latest/quickstart.html">Quickstart</a>
+            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/latest/concepts.html">Concepts</a>
+            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/latest/build-layout.html">Build layout</a>
+            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/latest/configuration.html">Configuration</a>
           </div>
         </div>
         <div class="navbar-item has-dropdown is-hoverable">
-          <a class="navbar-link" href="{{{siteRootPath}}}/cuppa/cli-reference.html">Reference</a>
+          <a class="navbar-link" href="{{{siteRootPath}}}/cuppa/latest/cli-reference.html">Reference</a>
           <div class="navbar-dropdown">
-            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/cli-reference.html">CLI reference</a>
-            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/methods.html">Methods</a>
-            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/dependencies.html">Dependencies</a>
-            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/toolchains.html">Toolchains</a>
-            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/testing-coverage.html">Testing and coverage</a>
-            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/packages.html">Publishing packages</a>
-            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/extending.html">Extending cuppa</a>
+            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/latest/cli-reference.html">CLI reference</a>
+            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/latest/methods.html">Methods</a>
+            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/latest/dependencies.html">Dependencies</a>
+            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/latest/toolchains.html">Toolchains</a>
+            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/latest/testing-coverage.html">Testing and coverage</a>
+            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/latest/packages.html">Publishing packages</a>
+            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/latest/extending.html">Extending cuppa</a>
           </div>
         </div>
         <div class="navbar-item has-dropdown is-hoverable">
-          <a class="navbar-link" href="{{{siteRootPath}}}/cuppa/cxx-modules.html">C++</a>
+          <a class="navbar-link" href="{{{siteRootPath}}}/cuppa/latest/cxx-modules.html">C++</a>
           <div class="navbar-dropdown">
-            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/cxx-modules.html">C++ Modules</a>
-            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/cxx-profiles.html">C++ Profiles</a>
+            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/latest/cxx-modules.html">C++ Modules</a>
+            <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/latest/cxx-profiles.html">C++ Profiles</a>
           </div>
         </div>
-        <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/contributing.html">Contributing</a>
+        <a class="navbar-item" href="{{{siteRootPath}}}/cuppa/latest/contributing.html">Contributing</a>
         {{!-- Brand marks are inlined so they inherit the navbar colour; paths from Simple Icons (CC0). --}}
         <a class="navbar-item is-icon" href="https://github.com/ja11sop/cuppa" title="Cuppa on GitHub">
           <span class="icon">

--- a/scripts/check_docs_urls.py
+++ b/scripts/check_docs_urls.py
@@ -1,0 +1,147 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+"""Docs URL integrity: versioned site paths must not rot to versionless /cuppa/….
+
+    python -m scripts.check_docs_urls
+    python -m scripts.check_docs_urls --built-site _docs_build/site
+
+After ``latest_version_segment: latest``, absolute and supplemental-UI links of the form
+``…/cuppa/contributing.html`` 404; they must be ``…/cuppa/latest/…`` (or ``…/cuppa/next/…``
+for intentional prerelease pointers). This check runs from unit tests, ``check_release``,
+and the documentation workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Absolute product-docs URLs in tracked Markdown (README, AGENTS, …).
+ABSOLUTE_VERSIONLESS = re.compile(
+    r"https://ja11sop\.github\.io/cuppa/cuppa/(?!latest/|next/)([^\s\)\"']+)"
+)
+
+# Supplemental UI header: {{{siteRootPath}}}/cuppa/<page> without latest/.
+HEADER_VERSIONLESS = re.compile(
+    r"\{\{\{siteRootPath\}\}\}/cuppa/(?!latest/)([^\"'\s]+)"
+)
+
+# Built multi-version site: from …/cuppa/latest/…, ../../cuppa/foo.html is versionless.
+BUILT_NAVBAR_VERSIONLESS = re.compile(
+    r"""href=["']\.\./\.\./cuppa/(?!latest/|next/)([^"']+)["']"""
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def check_header_partial(text: str, *, label: str) -> list[str]:
+    found = []
+    for match in HEADER_VERSIONLESS.finditer(text):
+        found.append(
+            "{}: versionless docs href …/cuppa/{} "
+            "(use …/cuppa/latest/… after latest_version_segment)".format(
+                label, match.group(1)
+            )
+        )
+    return found
+
+
+def check_markdown_absolute_urls(text: str, *, label: str) -> list[str]:
+    found = []
+    for match in ABSOLUTE_VERSIONLESS.finditer(text):
+        found.append(
+            "{}: versionless absolute URL …/cuppa/{} "
+            "(use …/cuppa/latest/… or …/cuppa/next/…)".format(label, match.group(1))
+        )
+    return found
+
+
+def check_built_site(site_root: Path) -> list[str]:
+    if not site_root.is_dir():
+        return ["built site [{}] does not exist".format(site_root)]
+    found = []
+    # Sample pages under the latest (or sole) component tree.
+    html_files = sorted(site_root.rglob("*.html"))
+    if not html_files:
+        return ["built site [{}] has no HTML files".format(site_root)]
+    for path in html_files:
+        try:
+            relative = path.relative_to(site_root).as_posix()
+        except ValueError:
+            relative = str(path)
+        text = _read(path)
+        for match in BUILT_NAVBAR_VERSIONLESS.finditer(text):
+            found.append(
+                "{}: navbar/versionless href ../../cuppa/{} "
+                "(supplemental-ui must use /cuppa/latest/…)".format(
+                    relative, match.group(1)
+                )
+            )
+            # One hit per file is enough to fail loudly without flooding.
+            break
+    return found
+
+
+def check_sources(repo_root: Path | None = None) -> list[str]:
+    root = repo_root or REPO_ROOT
+    found = []
+    header = root / "docs" / "supplemental-ui" / "partials" / "header-content.hbs"
+    if header.is_file():
+        found.extend(
+            check_header_partial(_read(header), label=str(header.relative_to(root)))
+        )
+    else:
+        found.append("missing {}".format(header.relative_to(root)))
+
+    for relative in ("README.md", "AGENTS.md"):
+        path = root / relative
+        if path.is_file():
+            found.extend(
+                check_markdown_absolute_urls(
+                    _read(path), label=relative
+                )
+            )
+    return found
+
+
+def check(
+    *,
+    repo_root: Path | None = None,
+    built_site: Path | None = None,
+) -> list[str]:
+    found = check_sources(repo_root)
+    if built_site is not None:
+        found.extend(check_built_site(built_site))
+    return found
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--built-site",
+        type=Path,
+        help="Also scan Antora HTML under this directory (e.g. _docs_build/site)",
+    )
+    args = parser.parse_args(argv)
+    found = check(built_site=args.built_site)
+    if found:
+        print("Docs URL integrity check failed:")
+        for problem in found:
+            print("  - {}".format(problem))
+        return 1
+    print("Docs URL integrity check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -9,10 +9,12 @@ import argparse
 import sys
 
 from scripts import changelog
+from scripts.check_docs_urls import check as check_docs_urls
 
 
 def check( tag, version, text ):
     found = list( changelog.problems( version, text ) )
+    found.extend( check_docs_urls() )
 
     if changelog.is_development( version ):
         found.append( "cuppa/VERSION [{}] is a development version. Run: python -m "

--- a/tests/unit/test_check_docs_urls.py
+++ b/tests/unit/test_check_docs_urls.py
@@ -1,0 +1,95 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+"""Unit tests for docs URL integrity (versionless /cuppa/… must not ship)."""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.check_docs_urls import (
+    check,
+    check_built_site,
+    check_header_partial,
+    check_markdown_absolute_urls,
+    check_sources,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+GOOD_HEADER = """
+<a href="{{{siteRootPath}}}/cuppa/latest/contributing.html">Contributing</a>
+<a href="{{{siteRootPath}}}/cuppa/latest/install.html">Install</a>
+"""
+
+BAD_HEADER = """
+<a href="{{{siteRootPath}}}/cuppa/contributing.html">Contributing</a>
+"""
+
+
+def test_good_header_passes():
+    assert check_header_partial(GOOD_HEADER, label="header") == []
+
+
+def test_versionless_header_fails():
+    found = check_header_partial(BAD_HEADER, label="header")
+    assert len(found) == 1
+    assert "contributing.html" in found[0]
+    assert "latest" in found[0]
+
+
+def test_markdown_allows_latest_and_next():
+    text = (
+        "[a](https://ja11sop.github.io/cuppa/cuppa/latest/install.html) "
+        "[b](https://ja11sop.github.io/cuppa/cuppa/next/contributing.html)"
+    )
+    assert check_markdown_absolute_urls(text, label="README.md") == []
+
+
+def test_markdown_rejects_versionless_component_url():
+    text = "[x](https://ja11sop.github.io/cuppa/cuppa/contributing.html)"
+    found = check_markdown_absolute_urls(text, label="README.md")
+    assert len(found) == 1
+    assert "contributing.html" in found[0]
+
+
+def test_built_site_rejects_versionless_navbar(tmp_path: Path):
+    page = tmp_path / "cuppa" / "latest" / "index.html"
+    page.parent.mkdir(parents=True)
+    page.write_text(
+        '<a class="navbar-item" href="../../cuppa/contributing.html">Contributing</a>\n',
+        encoding="utf-8",
+    )
+    found = check_built_site(tmp_path)
+    assert found
+    assert "contributing.html" in found[0]
+
+
+def test_built_site_accepts_latest_navbar(tmp_path: Path):
+    page = tmp_path / "cuppa" / "latest" / "index.html"
+    page.parent.mkdir(parents=True)
+    page.write_text(
+        '<a class="navbar-item" href="../../cuppa/latest/contributing.html">Contributing</a>\n',
+        encoding="utf-8",
+    )
+    assert check_built_site(tmp_path) == []
+
+
+def test_repository_sources_are_clean():
+    found = check_sources()
+    assert not found, "\n".join(found)
+
+
+def test_check_combines_sources_and_built_site(tmp_path: Path):
+    # Sources from the real repo should be clean; inject a bad built page.
+    page = tmp_path / "index.html"
+    page.write_text(
+        'href="../../cuppa/install.html"',
+        encoding="utf-8",
+    )
+    found = check(built_site=tmp_path)
+    assert any("install.html" in item for item in found)


### PR DESCRIPTION
## Summary

- Fix top navbar (`header-content.hbs`) and README/AGENTS absolute docs URLs to use `/cuppa/latest/…` (versionless `/cuppa/….html` 404s after `latest_version_segment`).
- Add `scripts.check_docs_urls` (sources + optional `--built-site`); wire into unit tests, `check_release`, and `docs.yml`.
- Graduate scratchpad note to [`design/plans/gitlab-package-transitive.md`](design/plans/gitlab-package-transitive.md) (proposal only).

**Shipping note:** Antora `supplemental-ui` comes from the checkout that builds the site, so merging this to `master` and letting the documentation workflow deploy fixes **both** `/latest/` and `/next/` navbars. A Cuppa **1.10.1** tag is **not** required for the live Contributing link.

## Test plan

- [x] `python -m scripts.check_docs_urls`
- [x] `pytest -m unit` (includes `test_check_docs_urls`)
- [x] CI green (Windows re-run after unrelated parallel timeout flake)
- [x] After merge: confirm https://ja11sop.github.io/cuppa/cuppa/latest/contributing.html via top-nav Contributing