### PR TITLE
Add transitive GitLab package deps via cuppa-dependency.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ``scripts.check_docs_urls`` — refuse versionless ``/cuppa/….html`` links in the top navbar
   partial, README/AGENTS absolute URLs, and (with ``--built-site``) generated Antora HTML.
   Included from ``scripts.check_release`` and the documentation workflow.
+- Transitive GitLab package dependencies via ``cuppa-dependency.json``: publishers pass
+  ``GitlabPackagePublisher(..., dependencies=[...])``; consumers that ``BuildWith`` / link
+  package A also apply B (includes on ``BuildWith``, edge ``use_libs`` on ``A.use_libs`` /
+  ``A.use_all_libs()``). Cycles and conflicting concrete versions raise ``StopError``.
+  ``use_all_libs()`` links every static library under the package ``lib/`` directory
+  ([#279](https://github.com/ja11sop/cuppa/issues/279)).
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ Minor cycle after **1.10.0**. Prefer work that changes opt-in toolchain or packa
 | Area | Intent in 1.11.0 |
 |------|------------------|
 | `cuppa.run` default_dependencies objects | [`run-default-dependency-objects.md`](design/plans/run-default-dependency-objects.md) — objects in both lists; teach register vs auto-apply; optional clearer names later |
-| Transitive GitLab packages | [`gitlab-package-transitive.md`](design/plans/gitlab-package-transitive.md) — package A carries B (proposal; not committed for 1.11.0 yet) |
+| Transitive GitLab packages | [`gitlab-package-transitive.md`](design/plans/gitlab-package-transitive.md) — package A carries B via `cuppa-dependency.json` (in progress on `feature/gitlab-package-transitive`) |
 | GitLab CMake staging | [#209](https://github.com/ja11sop/cuppa/issues/209) |
 | Artefact removal design | [#135](https://github.com/ja11sop/cuppa/issues/135) |
 | Console bundle | `--terse-output`, log hygiene, `cuppa --info` |

--- a/cuppa/build_with_package.py
+++ b/cuppa/build_with_package.py
@@ -160,7 +160,9 @@ class base(object):
 
 
     def __call__( self, env, toolchain, variant ):
-        self._package.initialise_build_variant( env, toolchain, variant )
+        self._package.initialise_build_variant(
+                env, toolchain, variant, dependency_name=self._name
+        )
 
 
     def storage_paths( self ):
@@ -200,7 +202,19 @@ class base(object):
 
 
     def use_libs( self, libs, depends_on=[] ):
-        self._package.use_libs( libs, depends_on=depends_on )
+        self._package.use_libs(
+                libs, depends_on=depends_on, dependency_name=self._name
+        )
+
+
+    def use_all_libs( self, depends_on=[] ):
+        use_all = getattr( self._package, 'use_all_libs', None )
+        if not callable( use_all ):
+            import SCons.Errors
+            raise SCons.Errors.StopError(
+                    "Package [{}] does not support use_all_libs().".format( self._name )
+            )
+        use_all( depends_on=depends_on, dependency_name=self._name )
 
 
     def package( self ):

--- a/cuppa/package_managers/cuppa_dependency_apply.py
+++ b/cuppa/package_managers/cuppa_dependency_apply.py
@@ -1,0 +1,187 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+"""Apply ``cuppa-dependency.json`` edges during GitLab package BuildWith / use_libs."""
+
+from __future__ import annotations
+
+import SCons.Errors
+
+from cuppa.colourise import as_info, as_notice
+from cuppa.log import logger
+from cuppa.package_managers.cuppa_dependency_manifest import read_manifest
+
+
+_APPLY_STACK_KEY = "_cuppa_transitive_apply_stack"
+_VERSION_PINS_KEY = "_cuppa_package_version_pins"
+_TRANSITIVE_LIBS_APPLIED_KEY = "_cuppa_transitive_use_libs_applied"
+
+
+def _factory_owner( factory ):
+    return getattr( factory, "__self__", None )
+
+
+def _factory_version( factory ):
+    owner = _factory_owner( factory )
+    if owner is None:
+        return None
+    return getattr( owner, "_version", None )
+
+
+def _resolve_registry( entry_registry, parent_registry ):
+    if entry_registry in ( None, "same", "" ):
+        return parent_registry
+    return entry_registry
+
+
+def _ensure_registered( env, entry, parent_registry ):
+    """Ensure ``entry['name']`` is in ``env['dependencies']``; return the name.
+
+    Synthesizes a ``package_dependency`` factory when the name is not already
+    registered. Concrete version pins must agree when the name is already present.
+    """
+    name = entry["name"]
+    version = entry["version"]
+    pins = env.setdefault( _VERSION_PINS_KEY, {} )
+
+    if name in env.get( "dependencies", {} ):
+        factory = env["dependencies"][name]
+        existing = pins.get( name )
+        if existing is None:
+            existing = _factory_version( factory )
+            if existing is not None:
+                pins[name] = existing
+        if existing is not None and str( existing ) != str( version ):
+            raise SCons.Errors.StopError(
+                "Transitive package [{}] requires version [{}] but [{}] is already "
+                "registered or pinned as [{}].".format( name, version, name, existing )
+            )
+        pins[name] = str( version ) if existing is None else str( existing )
+        return name
+
+    registry = _resolve_registry( entry.get( "registry" ), parent_registry )
+    if not registry:
+        raise SCons.Errors.StopError(
+            "Cannot synthesize transitive package [{}]: parent registry is unknown "
+            "and the manifest entry does not name a registry.".format( name )
+        )
+
+    from cuppa.build_with_package import package_dependency
+
+    Factory = package_dependency(
+            name,
+            registry=registry,
+            package=entry.get( "package" ) or name,
+            version=version,
+    )
+    env.setdefault( "dependencies", {} )[name] = Factory.create
+    pins[name] = str( version )
+    logger.info(
+            "Registered transitive package dependency [{}] (package [{}], version [{}]) "
+            "from cuppa-dependency.json".format(
+                    as_info( name ),
+                    as_notice( entry.get( "package" ) or name ),
+                    as_info( str( version ) ),
+            )
+    )
+    return name
+
+
+def apply_transitive_build_with( env, package_dir, parent_name, parent_registry ):
+    """``BuildWith`` each manifest dependency (includes / modules); detect cycles."""
+    document = read_manifest( package_dir )
+    if not document:
+        return
+
+    stack = env.setdefault( _APPLY_STACK_KEY, [] )
+    if parent_name in stack:
+        cycle = " -> ".join( stack + [ parent_name ] )
+        raise SCons.Errors.StopError(
+            "Cycle in transitive GitLab package dependencies: {}".format( cycle )
+        )
+
+    stack.append( parent_name )
+    try:
+        for entry in document["dependencies"]:
+            name = _ensure_registered( env, entry, parent_registry )
+            if name in stack:
+                cycle = " -> ".join( stack + [ name ] )
+                raise SCons.Errors.StopError(
+                    "Cycle in transitive GitLab package dependencies: {}".format( cycle )
+                )
+            logger.debug(
+                    "Applying transitive BuildWith [{}] for package [{}]".format(
+                            as_info( name ),
+                            as_notice( parent_name ),
+                    )
+            )
+            env.BuildWith( name )
+    finally:
+        stack.pop()
+
+
+def apply_transitive_use_libs( env, package_dir, parent_name, parent_registry ):
+    """Apply each manifest edge's ``use_libs`` against the dependency (once per parent)."""
+    document = read_manifest( package_dir )
+    if not document:
+        return
+
+    applied = env.setdefault( _TRANSITIVE_LIBS_APPLIED_KEY, set() )
+    if parent_name in applied:
+        return
+    applied.add( parent_name )
+
+    for entry in document["dependencies"]:
+        use_libs = entry.get( "use_libs" ) or []
+        if not use_libs:
+            continue
+        name = _ensure_registered( env, entry, parent_registry )
+        dependency = env.BuildWith( name )
+        # BuildWith returns a single object or a list
+        if isinstance( dependency, list ):
+            if not dependency:
+                raise SCons.Errors.StopError(
+                    "Transitive package [{}] for [{}] could not be created.".format(
+                            name, parent_name
+                    )
+                )
+            dependency = dependency[0]
+        use = getattr( dependency, "use_libs", None )
+        if not callable( use ):
+            raise SCons.Errors.StopError(
+                "Transitive package [{}] does not support use_libs "
+                "(required by [{}]'s cuppa-dependency.json).".format( name, parent_name )
+            )
+        logger.debug(
+                "Applying transitive use_libs {} on [{}] for package [{}]".format(
+                        as_info( str( use_libs ) ),
+                        as_info( name ),
+                        as_notice( parent_name ),
+                )
+        )
+        use( use_libs )
+
+
+def list_static_lib_stems( lib_dir, lib_prefix, lib_suffix, library_prefix="" ):
+    """Return sorted leaf library names found under ``lib_dir``."""
+    import os
+
+    if not lib_dir or not os.path.isdir( lib_dir ):
+        return []
+    names = []
+    library_prefix = library_prefix or ""
+    for fname in sorted( os.listdir( lib_dir ) ):
+        if not fname.startswith( lib_prefix ):
+            continue
+        if lib_suffix and not fname.endswith( lib_suffix ):
+            continue
+        stem = fname[len( lib_prefix ):]
+        if lib_suffix:
+            stem = stem[: -len( lib_suffix )]
+        if library_prefix and stem.startswith( library_prefix ):
+            stem = stem[len( library_prefix ):]
+        if stem:
+            names.append( stem )
+    return names

--- a/cuppa/package_managers/cuppa_dependency_manifest.py
+++ b/cuppa/package_managers/cuppa_dependency_manifest.py
@@ -1,0 +1,123 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+"""Read/write ``cuppa-dependency.json`` for transitive Cuppa package edges.
+
+See ``design/plans/gitlab-package-transitive.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+
+MANIFEST_FILENAME = "cuppa-dependency.json"
+MANIFEST_FORMAT = 1
+
+
+def manifest_path( package_dir: str ) -> str:
+    return os.path.join( package_dir, MANIFEST_FILENAME )
+
+
+def normalise_dependency_entry( entry: Any ) -> dict:
+    """Accept a dict or an object with ``name()`` / attributes; return a manifest dict."""
+    if isinstance( entry, dict ):
+        name = entry.get( "name" )
+        if not name:
+            raise ValueError( "dependency entry missing 'name'" )
+        out = {
+            "name": str( name ),
+            "package": str( entry.get( "package" ) or name ),
+            "version": str( entry["version"] ) if entry.get( "version" ) is not None else None,
+            "registry": entry.get( "registry", "same" ),
+        }
+        use_libs = entry.get( "use_libs" )
+        if use_libs:
+            out["use_libs"] = [ str( item ) for item in use_libs ]
+        if out["version"] is None:
+            raise ValueError(
+                "dependency [{}] requires a concrete 'version' (MVP)".format( out["name"] )
+            )
+        return out
+
+    name_fn = getattr( entry, "name", None )
+    name = name_fn() if callable( name_fn ) else getattr( entry, "name", None )
+    if not name:
+        raise ValueError( "dependency entry has no usable name()" )
+    package = getattr( entry, "package", None ) or getattr( entry, "_package", None ) or name
+    version = getattr( entry, "version", None ) or getattr( entry, "_version", None )
+    if callable( version ):
+        version = version()
+    registry = getattr( entry, "registry", None ) or getattr( entry, "_registry", None ) or "same"
+    use_libs = getattr( entry, "use_libs", None )
+    if callable( use_libs ) and not isinstance( use_libs, ( list, tuple ) ):
+        use_libs = None
+    normalised = {
+        "name": str( name ),
+        "package": str( package ),
+        "version": str( version ) if version is not None else None,
+        "registry": registry if registry is not None else "same",
+    }
+    if use_libs:
+        normalised["use_libs"] = [ str( item ) for item in use_libs ]
+    if normalised["version"] is None:
+        raise ValueError(
+            "dependency [{}] requires a concrete 'version' (MVP)".format( normalised["name"] )
+        )
+    return normalised
+
+
+def build_manifest( dependencies: list | None ) -> dict | None:
+    """Return a manifest document, or ``None`` when there are no dependencies."""
+    if not dependencies:
+        return None
+    entries = [ normalise_dependency_entry( item ) for item in dependencies ]
+    if not entries:
+        return None
+    return {
+        "cuppa_dependency_format": MANIFEST_FORMAT,
+        "dependencies": entries,
+    }
+
+
+def write_manifest( package_dir: str, dependencies: list | None ) -> str | None:
+    """Write ``cuppa-dependency.json`` under ``package_dir`` when deps are non-empty.
+
+    Returns the path written, or ``None`` if nothing was written.
+    """
+    document = build_manifest( dependencies )
+    if document is None:
+        return None
+    path = manifest_path( package_dir )
+    os.makedirs( package_dir, exist_ok=True )
+    with open( path, "w", encoding="utf-8" ) as handle:
+        json.dump( document, handle, indent=2, sort_keys=True )
+        handle.write( "\n" )
+    return path
+
+
+def read_manifest( package_dir: str ) -> dict | None:
+    """Load a manifest from ``package_dir``, or ``None`` if absent / empty."""
+    path = manifest_path( package_dir )
+    if not os.path.isfile( path ):
+        return None
+    with open( path, encoding="utf-8" ) as handle:
+        document = json.load( handle )
+    if not isinstance( document, dict ):
+        raise ValueError( "{}: expected a JSON object".format( path ) )
+    format_version = document.get( "cuppa_dependency_format" )
+    if format_version not in ( None, MANIFEST_FORMAT, 1 ):
+        raise ValueError(
+            "{}: unsupported cuppa_dependency_format [{}]".format( path, format_version )
+        )
+    deps = document.get( "dependencies" ) or []
+    if not deps:
+        return None
+    # Re-normalise for validation
+    document["dependencies"] = [ normalise_dependency_entry( item ) for item in deps ]
+    document["cuppa_dependency_format"] = format_version or MANIFEST_FORMAT
+    return document

--- a/cuppa/package_managers/gitlab.py
+++ b/cuppa/package_managers/gitlab.py
@@ -512,7 +512,8 @@ class GitlabPackagePublisher:
         package=None,
         version=None,
         variant=None,
-        custom_token=None
+        custom_token=None,
+        dependencies=None,
     ):
         from SCons.Script import Flatten
 
@@ -521,6 +522,7 @@ class GitlabPackagePublisher:
         self._package_folder     = os.path.join( package, str(version) )
         self._package_base_dir   = env.Dir( os.path.join( env['final_dir'], self._package_folder ) )
         self._target_include_dir = env.Dir( os.path.join( str(self._package_base_dir), "include" ) )
+        self._dependencies = list( dependencies ) if dependencies else []
 
         if not offset_include_dir is None:
             self._target_include_dir = env.Dir( os.path.join( str(self._target_include_dir), offset_include_dir ) )
@@ -600,6 +602,17 @@ class GitlabPackagePublisher:
             ) )
             shutil.copytree( source_modules, target_modules )
 
+        from cuppa.package_managers.cuppa_dependency_manifest import write_manifest
+        manifest_path_written = write_manifest(
+                str( self._package_base_dir ),
+                getattr( self, '_dependencies', None ),
+        )
+        if manifest_path_written:
+            logger.info( "Wrote [{}] for package [{}]".format(
+                    as_info( manifest_path_written ),
+                    as_info( self._package_file_name ),
+            ) )
+
         logger.info( "Creating package [{}]...".format( as_info( str(target[0]) ) ) )
         archive_path = str( self._package_archive )
         staging_roots = [
@@ -609,6 +622,8 @@ class GitlabPackagePublisher:
         modules_dir = os.path.join( str( self._package_base_dir ), 'modules' )
         if os.path.isdir( modules_dir ):
             staging_roots.append( modules_dir )
+        if manifest_path_written:
+            staging_roots.append( manifest_path_written )
 
         if package_archive_is_up_to_date( archive_path, staging_roots ):
             logger.info(
@@ -1259,7 +1274,7 @@ class GitlabPackageDependency:
 
     # Package Interface
 
-    def initialise_build_variant( self, env, toolchain, variant ):
+    def initialise_build_variant( self, env, toolchain, variant, dependency_name=None ):
         logger.debug( "Initialise build variant for [{}:{}] for package [{}] by adding SYSINCPATH of [{}]".format(
                 as_notice( str(toolchain.name()) ),
                 as_notice( str(variant) ),
@@ -1272,6 +1287,15 @@ class GitlabPackageDependency:
         if os.path.isdir( modules_dir ):
             from cuppa.cpp.cxx_modules import load_packaged_modules
             load_packaged_modules( env, modules_dir )
+
+        apply_name = dependency_name or self._package
+        from cuppa.package_managers.cuppa_dependency_apply import apply_transitive_build_with
+        apply_transitive_build_with(
+                env,
+                self._package_dir,
+                apply_name,
+                self._registry,
+        )
 
 
     def parse_pkg_config( self, libs ):
@@ -1307,7 +1331,7 @@ class GitlabPackageDependency:
         env.ParseConfig( command )
 
 
-    def use_libs( self, libs, depends_on=[] ):
+    def use_libs( self, libs, depends_on=[], dependency_name=None ):
 
         from SCons.Script import Flatten
 
@@ -1322,6 +1346,33 @@ class GitlabPackageDependency:
             self.parse_pkg_config( libs )
         else:
             self.use_static_libs( libs )
+
+        apply_name = dependency_name or self._package
+        from cuppa.package_managers.cuppa_dependency_apply import apply_transitive_use_libs
+        apply_transitive_use_libs(
+                env,
+                self._package_dir,
+                apply_name,
+                self._registry,
+        )
+
+
+    def use_all_libs( self, depends_on=[], dependency_name=None ):
+        """Link every static library found under this package's ``lib/`` directory."""
+        from cuppa.package_managers.cuppa_dependency_apply import list_static_lib_stems
+
+        env = self._env
+        names = list_static_lib_stems(
+                self._lib_dir,
+                env['LIBPREFIX'],
+                env['LIBSUFFIX'],
+                library_prefix=self._library_prefix,
+        )
+        logger.info( "use_all_libs for package [{}] selected [{}]".format(
+                as_info( self._package_id ),
+                as_notice( ", ".join( names ) if names else "(none)" ),
+        ) )
+        self.use_libs( names, depends_on=depends_on, dependency_name=dependency_name )
 
 
     def use_static_libs( self, libs ):

--- a/design/README.md
+++ b/design/README.md
@@ -21,7 +21,7 @@ maintainer workflow evolved.
 
 | Document | Status | Subject |
 |----------|--------|---------|
-| [`plans/gitlab-package-transitive.md`](plans/gitlab-package-transitive.md) | proposal | GitLab package A can carry deps on package B (manifest + BuildWith); consumer declares A only |
+| [`plans/gitlab-package-transitive.md`](plans/gitlab-package-transitive.md) | in progress | GitLab package A can carry deps on package B (manifest + BuildWith); consumer declares A only |
 | [`plans/run-default-dependency-objects.md`](plans/run-default-dependency-objects.md) | in progress | `cuppa.run` `default_dependencies` accepts objects; register vs auto-apply semantics / naming |
 | [`archive/gitlab-package-latest.md`](archive/gitlab-package-latest.md) | shipped | GitLab `version="latest"` = registry latest; Boost package retarget; consume docs — [#271](https://github.com/ja11sop/cuppa/issues/271) / [#272](https://github.com/ja11sop/cuppa/pull/272) |
 | [`archive/dependency-resolve.md`](archive/dependency-resolve.md) | shipped | BuildWith untyped resolve + type selectors; Quince `use_libs` — [#250](https://github.com/ja11sop/cuppa/issues/250) / [#270](https://github.com/ja11sop/cuppa/pull/270) |

--- a/design/plans/gitlab-package-transitive.md
+++ b/design/plans/gitlab-package-transitive.md
@@ -1,10 +1,10 @@
 # Plan: Transitive GitLab package dependencies
 
-- **Status:** proposal
+- **Status:** in progress
 - **Related:** [`ROADMAP.md`](../../ROADMAP.md) — Dependencies / packages; [`archive/gitlab-package-latest.md`](../archive/gitlab-package-latest.md); [`archive/dependency-resolve.md`](../archive/dependency-resolve.md); [`archive/conan-consumer-plan.md`](../archive/conan-consumer-plan.md) (transitive `requires` as contrast); [`run-default-dependency-objects.md`](run-default-dependency-objects.md) (import vs auto-enable); scratchpad graduate
-- **Updated:** 2026-09-05
+- **Updated:** 2026-09-06
 - **Impact:** minor — new publish/consume behaviour for GitLab packages; existing flat declarations stay valid
-
+- **Issue:** [#279](https://github.com/ja11sop/cuppa/issues/279)
 ## Problem
 
 GitLab `package_dependency` archives are **standalone**. If package **A** needs package **B**
@@ -79,29 +79,33 @@ session-wide default unless the consumer listed B in `auto_enable_dependencies`.
 | **D. Consumer-only `requires=[B]` on A's factory** | Easy to prototype | Defeats “A carries B”; duplicates publisher knowledge |
 
 **Recommendation:** **A**, fed by publisher kwargs (**B** at authoring time). Publisher writes
-something like `cuppa-package.json` (name TBD) next to `include/` / `lib/` when staging the
-tarball. Consumer reads it after extract.
+`cuppa-dependency.json` next to `include/` / `lib/` when staging the tarball (see settled
+decisions). Consumer reads it after extract.
 
 Illustrative schema (not final):
 
 ```json
 {
-  "cuppa_package_format": 1,
+  "cuppa_dependency_format": 1,
   "dependencies": [
     {
-      "name": "fmt",
-      "package": "fmt",
-      "version": "12.1.0",
-      "registry": "same"
+      "name": "boost_package",
+      "package": "boost",
+      "version": "1.91.0",
+      "registry": "same",
+      "use_libs": ["system", "filesystem"]
     }
   ]
 }
 ```
 
+- **`name`** — Cuppa **BuildWith / registry name** (what `BuildWith('…')` looks up).
+- **`package`** — GitLab Packages API package slug when it differs from `name`.
 - **Concrete versions in MVP** — no ranges; publish-time resolve of `latest` into a pin is
   allowed so offline consumers do not re-resolve B.
 - `registry: "same"` means A's registry URL (or an explicit URL later).
-- Optional later fields: `link` (auto `use_libs` pull), supply-chain type, develop hints.
+- **`use_libs`** — libraries to request from B when A is applied (see link closure below).
+  Omit or `[]` when B is headers-only.
 
 ## How consume applies B
 
@@ -110,12 +114,39 @@ Illustrative schema (not final):
    - Prefer a factory already registered under `name` (consumer or plugin).
    - Else **synthesize** `package_dependency(name, registry=…, package=…, version=…)` when the
      manifest has enough identity (MVP: same registry + package + version).
-3. Call `env.BuildWith(B)` during A's initialise / first apply path (not global auto-enable).
-4. **Cycle detection** on the apply stack (A→B→A → `StopError`).
-5. **Diamond:** same `(registry, package, version, tool_variant)` reuses the existing
+3. Call `env.BuildWith(B)` during A's initialise / first apply path (not global auto-enable) so
+   B's includes (`SYSINCPATH`) land with A's.
+4. When linking A (A's `use_libs` / package link step), also apply each dep's `use_libs` against B
+   (e.g. `BuildWith('boost_package').use_libs(['system', 'filesystem'])`), including any
+   *intra*-package expansion B already does (Boost `add_dependent_libraries`).
+5. **Cycle detection** on the apply stack (A→B→A → `StopError`).
+6. **Diamond:** same `(registry, package, version, tool_variant)` reuses the existing
    package instance / cache (today's identity caching already helps).
-6. **Conflict:** two concrete versions of the same package name → fail clearly in MVP
+7. **Conflict:** two concrete versions of the same package name → fail clearly in MVP
    (first-wins is too silent for prebuilt ABI).
+
+### Link / include closure (intended behaviour)
+
+The product win is a **chained** include and link picture, not headers alone.
+
+Example: A depends on `boost_package` and asks for `use_libs: ["P", "S"]`. Boost expands that to
+`P, Q, R, S`. A itself also contributes shared libs `D` and `E`. Then a consumer that only
+`BuildWith`s / links A should see on the link line (conceptually):
+
+`A, D, E, P, Q, R, S`
+
+— subject to how each artefact is linked:
+
+| Situation | What the user typically sees |
+|-----------|------------------------------|
+| Shared / dynamic libs for A and B | Separate `.so`/`.dll` (or import libs) for A, D, E and the Boost closure |
+| Static libs, not absorbed | `STATICLIBS` nodes for A plus B's expanded set |
+| Everything statically linked *into* A's archive at publish time | Often only `A` on the consumer link line |
+
+Cuppa's GitLab `use_libs` today appends **static** library files by default
+(`use_static_libs`); Boost package `use_libs` expands dependents then does the same. Shared
+runtime is a separate path (Conan already models this more fully). The transitive feature must
+**compose** those existing behaviours — not invent a third linker.
 
 ### Develop / offline
 
@@ -126,40 +157,115 @@ Illustrative schema (not final):
 - **`--list-dependencies`:** show A with B as a child edge when the manifest was applied
   (presentation; inventory already has a tree shape).
 
-## Contrast with Conan
+## Contrast with Conan and pip
 
-Conan already models transitive `requires`. This plan is **GitLab registry packages only** —
+**Conan** already models transitive `requires`. This plan is **GitLab registry packages only** —
 prebuilt Cuppa-shaped archives (`include/` / `lib/` / `modules/`), not a second Conan.
 Keep Conan for ConanCenter graphs; keep GitLab transitive for org-published Cuppa packages.
 A later bridge (manifest → Conan `requires` on publish) is out of scope for MVP.
+
+**Pip** is a different layer (and should stay so):
+
+| Layer | What it requires | When it resolves |
+|-------|------------------|------------------|
+| Pip `install_requires` / package deps | Other **Python** distributions (e.g. a `cuppa-boost-package` plugin wheel) | `pip install` time |
+| `cuppa-dependency.json` inside a GitLab archive | Other **Cuppa BuildWith** packages (GitLab tarballs) | Cuppa configure / `BuildWith` after the archive is present |
+
+A sensible stack: pip can pull a plugin that *registers* a custom GitLab package factory (today's
+`boost_package`-style story). That factory's published archives still carry
+`cuppa-dependency.json` for C++/link closure. Pip cannot satisfy those GitLab edges; Cuppa reads
+the manifest once the package is imported and the archive is fetched. Develop trees without an
+archive yet may declare the same edges in Python on the factory; the packaged manifest remains
+the consumer-facing source of truth for registry artefacts.
 
 ## Phases
 
 | ID | Slice | Notes |
 |----|--------|-------|
-| `gl-dep-rules` | This plan: semantics, schema sketch, refusal rules | **This document** |
-| `gl-dep-publish` | Publisher writes manifest from kwargs / `dependencies=` | Opt-in at first if safer |
-| `gl-dep-consume` | Read manifest; synthesize or reuse factory; `BuildWith` transitive; cycles / conflicts | |
-| `gl-dep-tests` | Integration: publish A+B fixture → consume A only → link/run | |
+| `gl-dep-rules` | This plan: semantics, schema sketch, refusal rules | **This document** — open questions settled 2026-09-06 |
+| `gl-dep-publish` | Publisher always writes `cuppa-dependency.json` when deps are declared | Omit file when there are no deps |
+| `gl-dep-consume` | Read manifest; synthesize or reuse factory; `BuildWith` + transitive `use_libs`; cycles / conflicts | |
+| `gl-dep-tests` | Integration: publish A+B fixture → consume A only → compile/link/run with closure | |
 | `gl-dep-docs` | `gitlab.adoc` + `packages.adoc`; teach vs flat declare | |
 | `gl-dep-list` | `--list-dependencies` / inventory edges from manifest | After consume |
+| `gl-dep-lib-api` | `use_all_libs()`; named groups + `show_libs_for` / `show_all_libs` on package instances | Can parallel mega-package wrappers; shares token vocab with manifest |
 | `gl-dep-ranges` | Version ranges / softer diamond policy | Deferred |
 | `gl-dep-issue` | File `impact:minor` issue when implementing | |
 
-## Open questions
+## Settled decisions (2026-09-06)
 
-1. **Manifest filename** — `cuppa-package.json` vs `cuppa.json` vs beside `module-map.json`?
-2. **Opt-in publish** — always write when deps declared, or `--package-write-deps` until soak?
-3. **Does `use_libs` on A imply transitive `use_libs` on B?** MVP: only `BuildWith` (headers /
-   SYSINCPATH); linking B stays explicit unless a later `link: true` field exists.
-4. **Naming of Cuppa registry names** — must manifest `name` match `package_dependency`'s
-   registry name (`fmt` vs `fmt_package`)? Prefer the **BuildWith name** the consumer would use.
-5. **Interaction with `boost_package`** — Boost's internal lib graph stays separate; Boost as a
-   transitive *package* dep of A is an ordinary manifest entry.
-6. **Pip plugins** — can a plugin's factory default-declare transitive deps without a published
-   archive (develop / location hybrid)? Defer unless a concrete plugin needs it.
+| Topic | Decision |
+|-------|----------|
+| Manifest filename | **`cuppa-dependency.json`**. Long-term this is Cuppa *package artefact* metadata (BuildWith-name edges + optional `use_libs`), not GitLab transport. MVP only GitLab publish/consume read/write it; Conan keeps its own `requires`. Prefer this over `cuppa-gitlab-package.json` so we do not rename when location/other Cuppa archives grow the same file later. |
+| When to write | **Always write when the publisher was given dependencies.** No opt-in flag. Omit the file when there are no deps (absent file = today's standalone behaviour). A present file with an empty `dependencies` list is unnecessary. |
+| Includes | **`BuildWith(A)` pulls `BuildWith(B)`** so B's `SYSINCPATH` (and modules load) apply. That is required for chained headers. |
+| Libraries | **Transitive `use_libs` as declared on each edge.** Manifest entries carry `use_libs` for B; applying/linking A applies those against B, including B's own expansion (e.g. Boost dependents). Headers-only B omits `use_libs`. |
+| Link-line picture | Consumer should see the **composed** set (A's libs + each dep's expanded `use_libs`), except where static linking has already absorbed objects into A at publish time — then only A may appear. Matches the A→boost(P,S→P,Q,R,S)+D,E example. |
+| Manifest `name` | The **BuildWith / Cuppa registry name** (`package_dependency('boost_package', package='boost', …)` → `"name": "boost_package"`). GitLab slug stays in `"package"` when different. |
+| `boost_package` | Ordinary transitive entry; Boost's *intra*-archive lib graph stays inside `boost_package.use_libs`. |
+| Pip vs manifest | **Separate layers.** Pip requires other wheels/plugins; `cuppa-dependency.json` requires other Cuppa/GitLab packages after the archive exists. A pip plugin may deliver a GitLab-package factory; the archive still carries the manifest for link/include closure. |
+| `BuildWith` vs link | **Match Boost today:** `BuildWith(A)` = includes (and transitive `BuildWith(B)`). **No** link-all on `BuildWith` / auto-enable alone. |
+| When transitive `use_libs` run | When the consumer first **links A** via `A.use_libs(...)`. That call also applies each manifest edge's `use_libs` against B (including Boost expansion). Headers already landed at `BuildWith(A)`. |
+| Empty `use_libs([])` | **Keep current meaning: link nothing** (empty selection). Do **not** redefine empty as “all libraries”. |
+| “Link everything A offers” | **`use_all_libs()`** — explicit method name (not `use_libs([])` or a magic `'*'`). Settled spelling. |
+| Named groups | **`use_libs` tokens may be leaf libs *or* publisher-defined groups** (e.g. `"kms"`, `"cloud storage"`) that expand to several concrete libraries — same idea as Boost’s dependent-lib expansion, but named by the package author. |
+| Discovery | **`show_libs_for(group_or_lib)`** — print/return what a token expands to. **`show_all_libs()`** — full catalogue, ideally a tree grouped by macro / group names. Aids huge packages (e.g. `google_cloud_cpp`) without guessing. |
+| Override | Consumer `A.use_libs(X)` selects **A's** libs/groups (replaces any future A-side default). Manifest edges for **B** are not a consumer choice — they always apply when A is linked. Consumer may still `BuildWith(B).use_libs(...)` explicitly; conflicting concrete sets → fail or union TBD (prefer fail in MVP if versions conflict; union of lib names if same B). |
 
-## Refusal rules
+### Library selection API (consumer-facing)
+
+Aligned with Boost today, extended for large multi-lib packages:
+
+```python
+# Leaf and/or named group tokens — groups expand to several concrete libs
+env.BuildWith( 'google_cloud_cpp' ).use_libs( [
+    'kms',             # may expand to several libraries
+    'cloud storage',   # named group for a feature area
+] )
+
+# Everything this package offers
+env.BuildWith( 'google_cloud_cpp' ).use_all_libs()
+
+# Discovery (configure-time / console helpers — exact return vs print TBD)
+env.BuildWith( 'google_cloud_cpp' ).show_libs_for( 'cloud storage' )
+env.BuildWith( 'google_cloud_cpp' ).show_all_libs()  # tree grouped by macro / group names
+```
+
+| Call | Role |
+|------|------|
+| `use_libs([...])` | Opt in to named **leaves and/or groups**; each token expands (package-defined) then links |
+| `use_all_libs()` | Opt in to the full concrete set this package publishes |
+| `show_libs_for(token)` | Show expansion for one leaf or group (what would be linked) |
+| `show_all_libs()` | Show the whole map — groups / macros → concrete libs (tree) |
+
+**Relation to transitive GitLab deps:** a manifest edge’s `use_libs` list uses the **same token vocabulary** (leaves or groups) so A can declare `use_libs: ["kms"]` against `google_cloud_cpp` and get the group expansion. `use_all_libs()` on A still triggers transitive edge application for B.
+
+**Phasing:** transitive manifest + `use_libs` / `use_all_libs` on the generic package instance are in scope for this workstream. Named-group tables and `show_*` are the natural follow-on for mega-packages (can ship on `boost_package` / `google_cloud_cpp`-style wrappers first); Boost already has silent dependent expansion without named groups.
+
+### `use_libs` timing — options considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A. Boost-like (recommended)** — `BuildWith` = includes only; `A.use_libs([...])` selects A's libs and triggers transitive edge `use_libs` | Matches `boost` / `boost_package` today; no surprise fat link lines; auto-enable stays safe | Consumer must call `use_libs` even for “simple” single-lib A |
+| **B. Default libs on `BuildWith(A)`** from manifest `default_use_libs` | Zero-call apps “just work” | Fights Boost; easy to over-link; harder for optional-feature packages |
+| **C. `use_libs()` / `[]` means all** | One spelling for “give me everything” | Changes today's empty-list behaviour; easy to do by accident; ambiguous with “no libs” |
+| **D. Explicit overrides defaults** — `BuildWith` applies `default_use_libs`; later `use_libs(X)` replaces A's defaults; edges still always apply | Convenience + escape hatch | Two link moments; docs must be very clear; still need a “all” spelling |
+
+**Recommendation: A.** Same split Boost already teaches: includes early, libraries on purpose.
+Transitive B libs are part of *A's* link contract (declared by the publisher in the manifest), so
+they ride along with `A.use_libs(...)`, not with bare `BuildWith(A)`.
+
+### Publisher API
+
+`GitlabPackagePublisher(..., dependencies=[...])` — list of dicts (or objects with
+`name` / `version` / optional `package`, `registry`, `use_libs`). Writes
+`cuppa-dependency.json` when non-empty; omits the file otherwise.
+
+## Open questions (remaining)
+
+1. Same-B lib union vs error when consumer also calls `B.use_libs` with a different set (lean:
+   union of lib names if same package identity; error on version conflict only). MVP applies
+   edge `use_libs` once per parent link; explicit consumer `B.use_libs` still runs separately.
 
 - Do not require every existing package to sprout a manifest (absent file = today's behaviour).
 - Do not auto-add transitive names to `auto_enable_dependencies`.
@@ -172,11 +278,12 @@ A later bridge (manifest → Conan `requires` on publish) is out of scope for MV
 
 | Slice | Status |
 |-------|--------|
-| `gl-dep-rules` | Done — this proposal |
-| `gl-dep-publish` | Not started |
-| `gl-dep-consume` | Not started |
-| `gl-dep-tests` | Not started |
-| `gl-dep-docs` | Not started |
+| `gl-dep-rules` | Done — proposal + settled decisions 2026-09-06 |
+| `gl-dep-publish` | Done — `dependencies=` → `cuppa-dependency.json` |
+| `gl-dep-consume` | Done — `BuildWith` + transitive `use_libs`; cycles / version conflict |
+| `gl-dep-tests` | In progress — unit + publish integration; full A→B consume E2E deferred |
+| `gl-dep-docs` | Done — `gitlab.adoc` / `packages.adoc` / integration page |
 | `gl-dep-list` | Not started |
+| `gl-dep-lib-api` | Partial — `use_all_libs()` shipped; named groups / `show_*` deferred |
 | `gl-dep-ranges` | Deferred |
-| `gl-dep-issue` | Not filed |
+| `gl-dep-issue` | Done — [#279](https://github.com/ja11sop/cuppa/issues/279) |

--- a/design/plans/gitlab-package-transitive.md
+++ b/design/plans/gitlab-package-transitive.md
@@ -267,6 +267,8 @@ they ride along with `A.use_libs(...)`, not with bare `BuildWith(A)`.
    union of lib names if same package identity; error on version conflict only). MVP applies
    edge `use_libs` once per parent link; explicit consumer `B.use_libs` still runs separately.
 
+## Refusal rules
+
 - Do not require every existing package to sprout a manifest (absent file = today's behaviour).
 - Do not auto-add transitive names to `auto_enable_dependencies`.
 - Do not invent a solver in MVP — concrete versions only.
@@ -281,7 +283,7 @@ they ride along with `A.use_libs(...)`, not with bare `BuildWith(A)`.
 | `gl-dep-rules` | Done — proposal + settled decisions 2026-09-06 |
 | `gl-dep-publish` | Done — `dependencies=` → `cuppa-dependency.json` |
 | `gl-dep-consume` | Done — `BuildWith` + transitive `use_libs`; cycles / version conflict |
-| `gl-dep-tests` | In progress — unit + publish integration; full A→B consume E2E deferred |
+| `gl-dep-tests` | Done for MVP unit/publish — A→B→C apply chains; live consume E2E still deferred |
 | `gl-dep-docs` | Done — `gitlab.adoc` / `packages.adoc` / integration page |
 | `gl-dep-list` | Not started |
 | `gl-dep-lib-api` | Partial — `use_all_libs()` shipped; named groups / `show_*` deferred |

--- a/docs/modules/ROOT/pages/dependencies/gitlab.adoc
+++ b/docs/modules/ROOT/pages/dependencies/gitlab.adoc
@@ -290,4 +290,57 @@ for the active toolchain/variant. The built-in source ``boost`` dependency accep
 shape — ``env.BuildWith('boost').use_libs([...])`` — so switching supply chains does not require
 rewriting sconscripts beyond the dependency name.
 
+To link every static library present under a GitLab package's ``lib/`` directory, call
+``use_all_libs()`` (do not pass an empty ``use_libs([])`` — that still means link nothing):
+
+[source,python]
+----
+env.BuildWith('widget').use_all_libs()
+----
+
+[#transitive-package-dependencies]
+=== Transitive package dependencies
+
+A published GitLab archive may include ``cuppa-dependency.json`` next to ``include/`` and
+``lib/``. When you ``BuildWith`` package **A**, Cuppa reads that file (if present) and
+``BuildWith``s each listed dependency **B** so B's headers (and packaged modules) are on the
+include path. When you later link A with ``A.use_libs(...)`` or ``A.use_all_libs()``, Cuppa also
+applies each edge's ``use_libs`` against B.
+
+Publish the edges with ``GitlabPackagePublisher(..., dependencies=[...])``. Omit the list (or
+pass nothing) when the package is standalone — then no manifest file is written.
+
+[source,python]
+----
+publisher = GitlabPackagePublisher(
+    env,
+    source_include_dir = '#/include',
+    source_lib_dir     = env['abs_final_dir'],
+    registry           = 'https://gitlab.example/api/v4/projects/1',
+    package            = 'widget',
+    version            = '1.0.0',
+    dependencies = [
+        {
+            'name': 'fmt',
+            'package': 'fmt',
+            'version': '12.1.0',
+            'registry': 'same',
+            'use_libs': ['fmt'],
+        },
+    ],
+)
+----
+
+* ``name`` — Cuppa ``BuildWith`` / registry name.
+* ``package`` — GitLab Packages slug when it differs from ``name``.
+* ``version`` — concrete pin (MVP; no ranges).
+* ``registry`` — ``"same"`` means A's registry URL.
+* ``use_libs`` — optional; applied against B when A is linked.
+
+Consumers still only need to import / auto-enable **A**. Transitive names are not added to
+``auto_enable_dependencies``. Conflicting concrete versions of the same name raise ``StopError``.
+Cycles in the dependency graph also fail clearly.
+
+See also xref:packages.adoc[Publishing packages] and the design plan for ``cuppa-dependency.json``.
+
 Integration coverage: xref:integration/test-packages.adoc[].

--- a/docs/modules/ROOT/pages/integration/test-packages.adoc
+++ b/docs/modules/ROOT/pages/integration/test-packages.adoc
@@ -10,6 +10,8 @@
 * Relative generated library dirs (`BuildStaticLib(..., final_dir='package_lib')` with
   `source_lib_dir='package_lib'`) stage from the variant tree under `--rel --parallel`.
   The archive contains the static library (not only a `.packaged` stamp).
+* ``GitlabPackagePublisher(..., dependencies=[...])`` writes ``cuppa-dependency.json`` into the
+  archive (transitive package metadata).
 
 Full consume/upload E2E against a live GitLab registry is still deferred.
 

--- a/docs/modules/ROOT/pages/packages.adoc
+++ b/docs/modules/ROOT/pages/packages.adoc
@@ -30,6 +30,38 @@ upload without re-tarring multi-gigabyte trees.
 Add `--publish-package` to upload it to the GitLab generic registry.
 `env.InstallPackage(...)` installs a package into the local cuppa dependencies layout.
 
+=== Declaring transitive dependencies
+
+Pass ``dependencies=[...]`` to ``GitlabPackagePublisher`` when package **A** needs other GitLab
+packages at include or link time. Cuppa writes ``cuppa-dependency.json`` into the staged package
+directory (next to ``include/`` / ``lib/``) before creating the archive. Omit the argument when
+there are no edges — no manifest file is written, matching today's standalone packages.
+
+[source,python]
+----
+publisher = GitlabPackagePublisher(
+    env,
+    source_include_dir = '#/include',
+    source_lib_dir     = env['abs_final_dir'],
+    registry           = 'https://gitlab.example/api/v4/projects/1',
+    package            = 'widget',
+    version            = '1.0.0',
+    dependencies = [
+        {
+            'name': 'fmt',
+            'package': 'fmt',
+            'version': '12.1.0',
+            'registry': 'same',
+            'use_libs': ['fmt'],
+        },
+    ],
+)
+env.PublishPackage(lib, publisher)
+----
+
+Consumers that ``BuildWith`` / link **A** pick up **B** from the manifest — see
+xref:dependencies/gitlab.adoc#transitive-package-dependencies[Transitive package dependencies].
+
 Relative `source_include_dir` / `source_lib_dir` values are SCons nodes under the active variant directory. Cuppa copies from the generated path when it exists, and only falls back to `srcnode()` for a source-tree directory that is present. Always using `srcnode()` would look for a missing project-root copy such as `boost/1.92/lib` and fail the package step, especially under `--parallel`. Use `env['abs_final_dir']` when libraries already land in `final/`. The same resolution is used for Conan publishing (<<conan-package-publishing>>).
 
 Authentication for registry upload uses the same tokens as consume

--- a/tests/integration/methods/test_packages.py
+++ b/tests/integration/methods/test_packages.py
@@ -1,3 +1,4 @@
+import json
 import tarfile
 import zipfile
 
@@ -111,6 +112,63 @@ def test_gitlab_publish_archive_omits_os_when_requested(tmp_path):
     os_id = os_release_id()
     assert not names[0].startswith("widget_{}_".format(os_id)), names[0]
     assert names[0].startswith("widget_"), names[0]
+
+
+def test_gitlab_publisher_writes_cuppa_dependency_json(tmp_path):
+    project = copy_dummy_project(tmp_path)
+    write_sconstruct(project)
+    write_sconscript(
+        project,
+        """\
+Import('env')
+from cuppa.package_managers.gitlab import GitlabPackagePublisher
+env.AppendUnique(CPPPATH=['#/include'])
+lib = env.BuildStaticLib('widget', 'src/hello.cpp')
+publisher = GitlabPackagePublisher(
+    env,
+    source_include_dir='#/include',
+    source_lib_dir=env['abs_final_dir'],
+    registry='https://gitlab.example/api/v4/projects/1',
+    package='widget',
+    version='1.0.0',
+    dependencies=[
+        {
+            'name': 'fmt',
+            'package': 'fmt',
+            'version': '12.1.0',
+            'registry': 'same',
+            'use_libs': ['fmt'],
+        },
+    ],
+)
+env.PublishPackage(lib, publisher)
+""",
+    )
+    result = run_cuppa(project, "--dbg")
+    assert_success(result)
+    archives = _package_archive_paths(project)
+    assert len(archives) == 1, archives
+    members = _archive_member_names(archives[0])
+    normalised = [name.replace("\\", "/") for name in members]
+    assert any(path.endswith("cuppa-dependency.json") for path in normalised), normalised
+    archive = archives[0]
+    if archive.name.endswith(".zip"):
+        with zipfile.ZipFile(archive) as zf:
+            names = [
+                n for n in zf.namelist()
+                if n.replace("\\", "/").endswith("cuppa-dependency.json")
+            ]
+            payload = json.loads(zf.read(names[0]))
+    else:
+        with tarfile.open(archive, "r:*") as tf:
+            names = [
+                n for n in tf.getnames()
+                if n.replace("\\", "/").endswith("cuppa-dependency.json")
+            ]
+            payload = json.loads(tf.extractfile(names[0]).read())
+    assert payload["cuppa_dependency_format"] == 1
+    assert payload["dependencies"][0]["name"] == "fmt"
+    assert payload["dependencies"][0]["use_libs"] == ["fmt"]
 
 
 def test_gitlab_publisher_stages_generated_relative_lib_dir(tmp_path):

--- a/tests/unit/test_cuppa_dependency_apply.py
+++ b/tests/unit/test_cuppa_dependency_apply.py
@@ -17,9 +17,12 @@ from cuppa.package_managers.cuppa_dependency_apply import (
     list_static_lib_stems,
 )
 from cuppa.package_managers.cuppa_dependency_manifest import MANIFEST_FILENAME
+from cuppa.package_managers.gitlab import GitlabPackageDependency
 
 
 pytestmark = pytest.mark.unit
+
+_REGISTRY = "https://gitlab.example/api/v4/projects/1"
 
 
 def _write_manifest( package_dir: Path, dependencies ):
@@ -34,34 +37,94 @@ def _write_manifest( package_dir: Path, dependencies ):
 
 
 class _FakeEnv( dict ):
-    def __init__( self ):
+    """Mimic ``env.BuildWith`` and optional transitive initialise / use_libs."""
+
+    def __init__( self, package_dirs=None, registry=_REGISTRY ):
         super().__init__()
         self["dependencies"] = {}
         self.build_with_calls = []
         self._instances = {}
+        self._package_dirs = package_dirs or {}
+        self._registry = registry
 
     def BuildWith( self, name ):
         self.build_with_calls.append( name )
         factory = self["dependencies"].get( name )
         if factory and name not in self._instances:
-            self._instances[name] = factory( self )
+            created = factory( self )
+            if isinstance( created, list ):
+                self._instances[name] = created
+            else:
+                self._instances[name] = created
         if name not in self._instances:
-            self._instances[name] = _FakeDependency( name )
+            self._instances[name] = _FakeDependency(
+                    name,
+                    package_dir=self._package_dirs.get( name ),
+                    registry=self._registry,
+            )
         instance = self._instances[name]
-        instance( self, None, "dbg" )
+        if isinstance( instance, list ):
+            return instance
+        if callable( instance ):
+            instance( self, None, "dbg" )
         return instance
 
 
 class _FakeDependency:
-    def __init__( self, name ):
+    def __init__( self, name, package_dir=None, registry=_REGISTRY, support_use_libs=True ):
         self._name = name
+        self._package_dir = package_dir
+        self._registry = registry
+        self._support_use_libs = support_use_libs
+        self._env = None
         self.use_libs_calls = []
 
     def __call__( self, env, toolchain, variant ):
+        self._env = env
+        # Mimic GitlabPackageDependency.initialise_build_variant transitive apply
+        if self._package_dir is not None:
+            apply_transitive_build_with(
+                    env, str( self._package_dir ), self._name, self._registry
+            )
         return self
 
     def use_libs( self, libs, depends_on=[] ):
+        if not self._support_use_libs:
+            raise AttributeError( "no use_libs" )
         self.use_libs_calls.append( list( libs ) )
+        if self._package_dir is not None and self._env is not None:
+            apply_transitive_use_libs(
+                    self._env, str( self._package_dir ), self._name, self._registry
+            )
+
+
+def _install_fake_package_dependency( monkeypatch, created=None, package_dirs=None ):
+    created = created if created is not None else {}
+    package_dirs = package_dirs or {}
+
+    def _fake_package_dependency( name, **kwargs ):
+        class Factory:
+            _name = name
+            _version = kwargs.get( "version" )
+            _package = kwargs.get( "package" )
+            _registry = kwargs.get( "registry" )
+
+            @classmethod
+            def create( cls, env ):
+                created[name] = kwargs
+                return _FakeDependency(
+                        name,
+                        package_dir=package_dirs.get( name ),
+                        registry=kwargs.get( "registry" ) or _REGISTRY,
+                )
+
+        return Factory
+
+    monkeypatch.setattr(
+            "cuppa.build_with_package.package_dependency",
+            _fake_package_dependency,
+    )
+    return created
 
 
 def test_list_static_lib_stems( tmp_path: Path ):
@@ -82,6 +145,11 @@ def test_list_static_lib_stems_strips_library_prefix( tmp_path: Path ):
     ) == ["fmt"]
 
 
+def test_list_static_lib_stems_missing_dir_returns_empty( tmp_path: Path ):
+    assert list_static_lib_stems( str( tmp_path / "missing" ), "lib", ".a" ) == []
+    assert list_static_lib_stems( None, "lib", ".a" ) == []
+
+
 def test_apply_transitive_build_with_registers_and_builds( tmp_path: Path, monkeypatch ):
     package_dir = tmp_path / "a" / "1.0.0"
     _write_manifest( package_dir, [
@@ -93,37 +161,78 @@ def test_apply_transitive_build_with_registers_and_builds( tmp_path: Path, monke
             }
     ] )
 
-    created = {}
-
-    def _fake_package_dependency( name, **kwargs ):
-        class Factory:
-            _name = name
-            _version = kwargs.get( "version" )
-            _package = kwargs.get( "package" )
-            _registry = kwargs.get( "registry" )
-
-            @classmethod
-            def create( cls, env ):
-                created[name] = kwargs
-                return _FakeDependency( name )
-
-        return Factory
-
-    monkeypatch.setattr(
-            "cuppa.build_with_package.package_dependency",
-            _fake_package_dependency,
-    )
-
+    created = _install_fake_package_dependency( monkeypatch )
     env = _FakeEnv()
-    apply_transitive_build_with(
-            env,
-            str( package_dir ),
-            "a",
-            "https://gitlab.example/api/v4/projects/1",
-    )
+    apply_transitive_build_with( env, str( package_dir ), "a", _REGISTRY )
     assert "b" in env["dependencies"]
     assert created["b"]["version"] == "2.0.0"
+    assert created["b"]["registry"] == _REGISTRY
     assert env.build_with_calls == ["b"]
+
+
+def test_apply_chain_a_requires_b_requires_c( tmp_path: Path, monkeypatch ):
+    """A's BuildWith pulls B, and B's initialise pulls C (depth-two chain)."""
+    dir_a = tmp_path / "a" / "1.0.0"
+    dir_b = tmp_path / "b" / "2.0.0"
+    dir_c = tmp_path / "c" / "3.0.0"
+    dir_c.mkdir( parents=True )
+    _write_manifest( dir_a, [
+            { "name": "b", "package": "b", "version": "2.0.0", "registry": "same" },
+    ] )
+    _write_manifest( dir_b, [
+            { "name": "c", "package": "c", "version": "3.0.0", "registry": "same" },
+    ] )
+
+    package_dirs = { "b": dir_b, "c": dir_c }
+    created = _install_fake_package_dependency(
+            monkeypatch, package_dirs=package_dirs
+    )
+    env = _FakeEnv( package_dirs=package_dirs )
+    apply_transitive_build_with( env, str( dir_a ), "a", _REGISTRY )
+
+    assert env.build_with_calls == ["b", "c"]
+    assert created["b"]["version"] == "2.0.0"
+    assert created["c"]["version"] == "3.0.0"
+    assert set( env["dependencies"] ) >= { "b", "c" }
+
+
+def test_apply_chain_use_libs_a_to_b_to_c( tmp_path: Path, monkeypatch ):
+    """Linking A applies B's edge libs, and B's use_libs applies C's edge libs."""
+    dir_a = tmp_path / "a" / "1.0.0"
+    dir_b = tmp_path / "b" / "2.0.0"
+    dir_c = tmp_path / "c" / "3.0.0"
+    dir_c.mkdir( parents=True )
+    _write_manifest( dir_a, [
+            {
+                    "name": "b",
+                    "package": "b",
+                    "version": "2.0.0",
+                    "use_libs": ["b_core"],
+            },
+    ] )
+    _write_manifest( dir_b, [
+            {
+                    "name": "c",
+                    "package": "c",
+                    "version": "3.0.0",
+                    "use_libs": ["c_util"],
+            },
+    ] )
+
+    package_dirs = { "b": dir_b, "c": dir_c }
+    _install_fake_package_dependency( monkeypatch, package_dirs=package_dirs )
+    env = _FakeEnv( package_dirs=package_dirs )
+
+    apply_transitive_use_libs( env, str( dir_a ), "a", _REGISTRY )
+
+    assert env._instances["b"].use_libs_calls == [["b_core"]]
+    assert env._instances["c"].use_libs_calls == [["c_util"]]
+
+
+def test_apply_transitive_build_with_noop_without_manifest( tmp_path: Path ):
+    env = _FakeEnv()
+    apply_transitive_build_with( env, str( tmp_path ), "a", _REGISTRY )
+    assert env.build_with_calls == []
 
 
 def test_apply_transitive_build_with_detects_cycle( tmp_path: Path ):
@@ -134,12 +243,7 @@ def test_apply_transitive_build_with_detects_cycle( tmp_path: Path ):
     env = _FakeEnv()
     env["dependencies"]["a"] = lambda e: _FakeDependency( "a" )
     with pytest.raises( SCons.Errors.StopError, match="Cycle" ):
-        apply_transitive_build_with(
-                env,
-                str( package_dir ),
-                "a",
-                "https://gitlab.example/api/v4/projects/1",
-        )
+        apply_transitive_build_with( env, str( package_dir ), "a", _REGISTRY )
 
 
 def test_apply_transitive_use_libs_once( tmp_path: Path ):
@@ -165,19 +269,114 @@ def test_apply_transitive_use_libs_once( tmp_path: Path ):
 
     env["dependencies"]["b"] = Factory.create
 
-    apply_transitive_use_libs(
-            env,
-            str( package_dir ),
-            "a",
-            "https://gitlab.example/api/v4/projects/1",
-    )
-    apply_transitive_use_libs(
-            env,
-            str( package_dir ),
-            "a",
-            "https://gitlab.example/api/v4/projects/1",
-    )
+    apply_transitive_use_libs( env, str( package_dir ), "a", _REGISTRY )
+    apply_transitive_use_libs( env, str( package_dir ), "a", _REGISTRY )
     assert env._instances["b"].use_libs_calls == [["core"]]
+
+
+def test_apply_transitive_use_libs_skips_headers_only_edge( tmp_path: Path ):
+    package_dir = tmp_path / "a" / "1.0.0"
+    _write_manifest( package_dir, [
+            {
+                    "name": "b",
+                    "package": "b",
+                    "version": "2.0.0",
+                    "registry": "same",
+            }
+    ] )
+    env = _FakeEnv()
+
+    class Factory:
+        _name = "b"
+        _version = "2.0.0"
+
+        @classmethod
+        def create( cls, env ):
+            return _FakeDependency( "b" )
+
+    env["dependencies"]["b"] = Factory.create
+    apply_transitive_use_libs( env, str( package_dir ), "a", _REGISTRY )
+    assert env.build_with_calls == []
+    assert "b" not in env._instances
+
+
+def test_apply_transitive_use_libs_rejects_missing_use_libs( tmp_path: Path ):
+    package_dir = tmp_path / "a" / "1.0.0"
+    _write_manifest( package_dir, [
+            {
+                    "name": "b",
+                    "package": "b",
+                    "version": "2.0.0",
+                    "use_libs": ["core"],
+            }
+    ] )
+    env = _FakeEnv()
+
+    class NoLibs:
+        pass
+
+    class Factory:
+        _name = "b"
+        _version = "2.0.0"
+
+        @classmethod
+        def create( cls, env ):
+            return NoLibs()
+
+    env["dependencies"]["b"] = Factory.create
+    with pytest.raises( SCons.Errors.StopError, match="does not support use_libs" ):
+        apply_transitive_use_libs( env, str( package_dir ), "a", _REGISTRY )
+
+
+def test_apply_transitive_use_libs_unwraps_build_with_list( tmp_path: Path ):
+    package_dir = tmp_path / "a" / "1.0.0"
+    _write_manifest( package_dir, [
+            {
+                    "name": "b",
+                    "package": "b",
+                    "version": "2.0.0",
+                    "use_libs": ["core"],
+            }
+    ] )
+    env = _FakeEnv()
+    dep = _FakeDependency( "b" )
+
+    class Factory:
+        _name = "b"
+        _version = "2.0.0"
+
+        @classmethod
+        def create( cls, env ):
+            return [dep]
+
+    env["dependencies"]["b"] = Factory.create
+    apply_transitive_use_libs( env, str( package_dir ), "a", _REGISTRY )
+    assert dep.use_libs_calls == [["core"]]
+
+
+def test_apply_transitive_use_libs_empty_list_raises( tmp_path: Path ):
+    package_dir = tmp_path / "a" / "1.0.0"
+    _write_manifest( package_dir, [
+            {
+                    "name": "b",
+                    "package": "b",
+                    "version": "2.0.0",
+                    "use_libs": ["core"],
+            }
+    ] )
+    env = _FakeEnv()
+
+    class Factory:
+        _name = "b"
+        _version = "2.0.0"
+
+        @classmethod
+        def create( cls, env ):
+            return []
+
+    env["dependencies"]["b"] = Factory.create
+    with pytest.raises( SCons.Errors.StopError, match="could not be created" ):
+        apply_transitive_use_libs( env, str( package_dir ), "a", _REGISTRY )
 
 
 def test_version_conflict_raises( tmp_path: Path ):
@@ -203,9 +402,60 @@ def test_version_conflict_raises( tmp_path: Path ):
     env["dependencies"]["b"] = Factory.create
 
     with pytest.raises( SCons.Errors.StopError, match="version" ):
-        apply_transitive_build_with(
-                env,
-                str( package_dir ),
-                "a",
-                "https://gitlab.example/api/v4/projects/1",
-        )
+        apply_transitive_build_with( env, str( package_dir ), "a", _REGISTRY )
+
+
+def test_synthesize_requires_registry( tmp_path: Path, monkeypatch ):
+    package_dir = tmp_path / "a" / "1.0.0"
+    _write_manifest( package_dir, [
+            { "name": "b", "package": "b", "version": "1.0.0", "registry": "same" },
+    ] )
+    _install_fake_package_dependency( monkeypatch )
+    env = _FakeEnv()
+    with pytest.raises( SCons.Errors.StopError, match="parent registry is unknown" ):
+        apply_transitive_build_with( env, str( package_dir ), "a", None )
+
+
+def test_explicit_registry_url_is_passed_through( tmp_path: Path, monkeypatch ):
+    other = "https://gitlab.example/api/v4/projects/99"
+    package_dir = tmp_path / "a" / "1.0.0"
+    _write_manifest( package_dir, [
+            {
+                    "name": "b",
+                    "package": "b",
+                    "version": "1.0.0",
+                    "registry": other,
+            },
+    ] )
+    created = _install_fake_package_dependency( monkeypatch )
+    env = _FakeEnv()
+    apply_transitive_build_with( env, str( package_dir ), "a", _REGISTRY )
+    assert created["b"]["registry"] == other
+
+
+def test_use_all_libs_selects_stems_and_delegates( tmp_path: Path ):
+    lib_dir = tmp_path / "lib"
+    lib_dir.mkdir()
+    ( lib_dir / "libwidget.a" ).write_text( "x", encoding="utf-8" )
+    ( lib_dir / "libextra.a" ).write_text( "x", encoding="utf-8" )
+
+    package = GitlabPackageDependency.__new__( GitlabPackageDependency )
+    package._lib_dir = str( lib_dir )
+    package._library_prefix = ""
+    package._package_id = "widget/1.0.0/rel"
+    package._package_dir = str( tmp_path )
+    package._registry = _REGISTRY
+    package._pkg_config_dir = None
+    package._include_dir = str( tmp_path / "include" )
+    ( tmp_path / "include" ).mkdir()
+
+    selected = []
+
+    def _capture_use_libs( libs, depends_on=[], dependency_name=None ):
+        selected.extend( list( libs ) )
+
+    package.use_libs = _capture_use_libs
+    package._env = { "LIBPREFIX": "lib", "LIBSUFFIX": ".a" }
+
+    package.use_all_libs()
+    assert selected == ["extra", "widget"]

--- a/tests/unit/test_cuppa_dependency_apply.py
+++ b/tests/unit/test_cuppa_dependency_apply.py
@@ -1,0 +1,211 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+"""Unit tests for transitive cuppa-dependency.json apply helpers."""
+
+import json
+from pathlib import Path
+
+import pytest
+import SCons.Errors
+
+from cuppa.package_managers.cuppa_dependency_apply import (
+    apply_transitive_build_with,
+    apply_transitive_use_libs,
+    list_static_lib_stems,
+)
+from cuppa.package_managers.cuppa_dependency_manifest import MANIFEST_FILENAME
+
+
+pytestmark = pytest.mark.unit
+
+
+def _write_manifest( package_dir: Path, dependencies ):
+    package_dir.mkdir( parents=True, exist_ok=True )
+    ( package_dir / MANIFEST_FILENAME ).write_text(
+            json.dumps( {
+                    "cuppa_dependency_format": 1,
+                    "dependencies": dependencies,
+            } ),
+            encoding="utf-8",
+    )
+
+
+class _FakeEnv( dict ):
+    def __init__( self ):
+        super().__init__()
+        self["dependencies"] = {}
+        self.build_with_calls = []
+        self._instances = {}
+
+    def BuildWith( self, name ):
+        self.build_with_calls.append( name )
+        factory = self["dependencies"].get( name )
+        if factory and name not in self._instances:
+            self._instances[name] = factory( self )
+        if name not in self._instances:
+            self._instances[name] = _FakeDependency( name )
+        instance = self._instances[name]
+        instance( self, None, "dbg" )
+        return instance
+
+
+class _FakeDependency:
+    def __init__( self, name ):
+        self._name = name
+        self.use_libs_calls = []
+
+    def __call__( self, env, toolchain, variant ):
+        return self
+
+    def use_libs( self, libs, depends_on=[] ):
+        self.use_libs_calls.append( list( libs ) )
+
+
+def test_list_static_lib_stems( tmp_path: Path ):
+    lib_dir = tmp_path / "lib"
+    lib_dir.mkdir()
+    ( lib_dir / "libalpha.a" ).write_text( "x", encoding="utf-8" )
+    ( lib_dir / "libbeta.a" ).write_text( "x", encoding="utf-8" )
+    ( lib_dir / "readme.txt" ).write_text( "x", encoding="utf-8" )
+    assert list_static_lib_stems( str( lib_dir ), "lib", ".a" ) == ["alpha", "beta"]
+
+
+def test_list_static_lib_stems_strips_library_prefix( tmp_path: Path ):
+    lib_dir = tmp_path / "lib"
+    lib_dir.mkdir()
+    ( lib_dir / "libcp_fmt.a" ).write_text( "x", encoding="utf-8" )
+    assert list_static_lib_stems(
+            str( lib_dir ), "lib", ".a", library_prefix="cp_"
+    ) == ["fmt"]
+
+
+def test_apply_transitive_build_with_registers_and_builds( tmp_path: Path, monkeypatch ):
+    package_dir = tmp_path / "a" / "1.0.0"
+    _write_manifest( package_dir, [
+            {
+                    "name": "b",
+                    "package": "b",
+                    "version": "2.0.0",
+                    "registry": "same",
+            }
+    ] )
+
+    created = {}
+
+    def _fake_package_dependency( name, **kwargs ):
+        class Factory:
+            _name = name
+            _version = kwargs.get( "version" )
+            _package = kwargs.get( "package" )
+            _registry = kwargs.get( "registry" )
+
+            @classmethod
+            def create( cls, env ):
+                created[name] = kwargs
+                return _FakeDependency( name )
+
+        return Factory
+
+    monkeypatch.setattr(
+            "cuppa.build_with_package.package_dependency",
+            _fake_package_dependency,
+    )
+
+    env = _FakeEnv()
+    apply_transitive_build_with(
+            env,
+            str( package_dir ),
+            "a",
+            "https://gitlab.example/api/v4/projects/1",
+    )
+    assert "b" in env["dependencies"]
+    assert created["b"]["version"] == "2.0.0"
+    assert env.build_with_calls == ["b"]
+
+
+def test_apply_transitive_build_with_detects_cycle( tmp_path: Path ):
+    package_dir = tmp_path / "a" / "1.0.0"
+    _write_manifest( package_dir, [
+            { "name": "a", "package": "a", "version": "1.0.0", "registry": "same" }
+    ] )
+    env = _FakeEnv()
+    env["dependencies"]["a"] = lambda e: _FakeDependency( "a" )
+    with pytest.raises( SCons.Errors.StopError, match="Cycle" ):
+        apply_transitive_build_with(
+                env,
+                str( package_dir ),
+                "a",
+                "https://gitlab.example/api/v4/projects/1",
+        )
+
+
+def test_apply_transitive_use_libs_once( tmp_path: Path ):
+    package_dir = tmp_path / "a" / "1.0.0"
+    _write_manifest( package_dir, [
+            {
+                    "name": "b",
+                    "package": "b",
+                    "version": "2.0.0",
+                    "registry": "same",
+                    "use_libs": ["core"],
+            }
+    ] )
+    env = _FakeEnv()
+
+    class Factory:
+        _name = "b"
+        _version = "2.0.0"
+
+        @classmethod
+        def create( cls, env ):
+            return _FakeDependency( "b" )
+
+    env["dependencies"]["b"] = Factory.create
+
+    apply_transitive_use_libs(
+            env,
+            str( package_dir ),
+            "a",
+            "https://gitlab.example/api/v4/projects/1",
+    )
+    apply_transitive_use_libs(
+            env,
+            str( package_dir ),
+            "a",
+            "https://gitlab.example/api/v4/projects/1",
+    )
+    assert env._instances["b"].use_libs_calls == [["core"]]
+
+
+def test_version_conflict_raises( tmp_path: Path ):
+    package_dir = tmp_path / "a" / "1.0.0"
+    _write_manifest( package_dir, [
+            {
+                    "name": "b",
+                    "package": "b",
+                    "version": "3.0.0",
+                    "registry": "same",
+            }
+    ] )
+    env = _FakeEnv()
+
+    class Factory:
+        _name = "b"
+        _version = "2.0.0"
+
+        @classmethod
+        def create( cls, env ):
+            return _FakeDependency( "b" )
+
+    env["dependencies"]["b"] = Factory.create
+
+    with pytest.raises( SCons.Errors.StopError, match="version" ):
+        apply_transitive_build_with(
+                env,
+                str( package_dir ),
+                "a",
+                "https://gitlab.example/api/v4/projects/1",
+        )

--- a/tests/unit/test_cuppa_dependency_manifest.py
+++ b/tests/unit/test_cuppa_dependency_manifest.py
@@ -1,0 +1,86 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+"""Unit tests for cuppa-dependency.json helpers."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cuppa.package_managers.cuppa_dependency_manifest import (
+    MANIFEST_FILENAME,
+    build_manifest,
+    normalise_dependency_entry,
+    read_manifest,
+    write_manifest,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_build_manifest_none_when_empty():
+    assert build_manifest( None ) is None
+    assert build_manifest( [] ) is None
+
+
+def test_normalise_dict_entry():
+    entry = normalise_dependency_entry( {
+        "name": "boost_package",
+        "package": "boost",
+        "version": "1.91.0",
+        "use_libs": ["system", "filesystem"],
+    } )
+    assert entry["name"] == "boost_package"
+    assert entry["package"] == "boost"
+    assert entry["version"] == "1.91.0"
+    assert entry["registry"] == "same"
+    assert entry["use_libs"] == ["system", "filesystem"]
+
+
+def test_normalise_requires_version():
+    with pytest.raises( ValueError, match="version" ):
+        normalise_dependency_entry( { "name": "fmt", "package": "fmt" } )
+
+
+def test_write_and_read_round_trip( tmp_path: Path ):
+    deps = [
+        {
+            "name": "fmt",
+            "package": "fmt",
+            "version": "12.1.0",
+            "registry": "same",
+        }
+    ]
+    path = write_manifest( str( tmp_path ), deps )
+    assert path is not None
+    assert Path( path ).name == MANIFEST_FILENAME
+    loaded = read_manifest( str( tmp_path ) )
+    assert loaded["cuppa_dependency_format"] == 1
+    assert loaded["dependencies"][0]["name"] == "fmt"
+    assert loaded["dependencies"][0]["version"] == "12.1.0"
+
+
+def test_write_omits_file_when_no_deps( tmp_path: Path ):
+    assert write_manifest( str( tmp_path ), [] ) is None
+    assert not ( tmp_path / MANIFEST_FILENAME ).exists()
+
+
+def test_read_absent_returns_none( tmp_path: Path ):
+    assert read_manifest( str( tmp_path ) ) is None
+
+
+def test_read_rejects_bad_format( tmp_path: Path ):
+    path = tmp_path / MANIFEST_FILENAME
+    path.write_text(
+        json.dumps( {
+            "cuppa_dependency_format": 99,
+            "dependencies": [ { "name": "x", "package": "x", "version": "1" } ],
+        } ),
+        encoding="utf-8",
+    )
+    with pytest.raises( ValueError, match="unsupported" ):
+        read_manifest( str( tmp_path ) )

--- a/tests/unit/test_cuppa_dependency_manifest.py
+++ b/tests/unit/test_cuppa_dependency_manifest.py
@@ -84,3 +84,77 @@ def test_read_rejects_bad_format( tmp_path: Path ):
     )
     with pytest.raises( ValueError, match="unsupported" ):
         read_manifest( str( tmp_path ) )
+
+
+def test_normalise_rejects_missing_name():
+    with pytest.raises( ValueError, match="missing 'name'" ):
+        normalise_dependency_entry( { "package": "fmt", "version": "1" } )
+
+
+def test_normalise_object_entry():
+    class Dep:
+        def name( self ):
+            return "boost_package"
+
+        _package = "boost"
+        _version = "1.91.0"
+        use_libs = ["system"]
+
+    entry = normalise_dependency_entry( Dep() )
+    assert entry["name"] == "boost_package"
+    assert entry["package"] == "boost"
+    assert entry["version"] == "1.91.0"
+    assert entry["registry"] == "same"
+    assert entry["use_libs"] == ["system"]
+
+
+def test_normalise_object_callable_version():
+    class Dep:
+        def name( self ):
+            return "fmt"
+
+        def version( self ):
+            return "12.1.0"
+
+    entry = normalise_dependency_entry( Dep() )
+    assert entry["version"] == "12.1.0"
+    assert entry["package"] == "fmt"
+
+
+def test_normalise_object_requires_version():
+    class Dep:
+        def name( self ):
+            return "fmt"
+
+    with pytest.raises( ValueError, match="version" ):
+        normalise_dependency_entry( Dep() )
+
+
+def test_normalise_object_without_name_raises():
+    with pytest.raises( ValueError, match="no usable name" ):
+        normalise_dependency_entry( object() )
+
+
+def test_read_empty_dependencies_returns_none( tmp_path: Path ):
+    ( tmp_path / MANIFEST_FILENAME ).write_text(
+            json.dumps( { "cuppa_dependency_format": 1, "dependencies": [] } ),
+            encoding="utf-8",
+    )
+    assert read_manifest( str( tmp_path ) ) is None
+
+
+def test_read_rejects_non_object( tmp_path: Path ):
+    ( tmp_path / MANIFEST_FILENAME ).write_text( "[]", encoding="utf-8" )
+    with pytest.raises( ValueError, match="JSON object" ):
+        read_manifest( str( tmp_path ) )
+
+
+def test_build_manifest_from_objects():
+    class Dep:
+        def name( self ):
+            return "fmt"
+
+        version = "1.0.0"
+
+    document = build_manifest( [ Dep() ] )
+    assert document["dependencies"][0]["name"] == "fmt"

--- a/tests/unit/test_gitlab_package_publisher.py
+++ b/tests/unit/test_gitlab_package_publisher.py
@@ -111,6 +111,7 @@ def test_build_package_skips_create_when_archive_current( tmp_path, monkeypatch 
     publisher._package_source_dir = "widget"
     publisher._package_file_name = archive.name
     publisher._source_lib_dir = str( lib_dir )
+    publisher._dependencies = []
 
     touched = []
     env = _publisher_env( tmp_path, touched )
@@ -153,6 +154,7 @@ def test_build_package_creates_archive_when_staging_newer( tmp_path, monkeypatch
     publisher._package_source_dir = "widget"
     publisher._package_file_name = archive.name
     publisher._source_lib_dir = str( lib_dir )
+    publisher._dependencies = []
 
     env = _publisher_env( tmp_path )
 


### PR DESCRIPTION
## Summary

- GitLab publishers can declare transitive edges with `GitlabPackagePublisher(..., dependencies=[...])`, which writes `cuppa-dependency.json` into the package archive when non-empty.
- Consumers that `BuildWith` / link package **A** also apply **B** (includes on `BuildWith`; edge `use_libs` on `A.use_libs` / `A.use_all_libs()`).
- Cycles and conflicting concrete versions raise `StopError`. `use_all_libs()` links every static library under the package `lib/` directory.
- Docs, unit tests, and a publish integration check; design plan [#279](https://github.com/ja11sop/cuppa/issues/279).

## Test plan

- [x] `flake8 cuppa` / `pylint -E cuppa`
- [x] `pytest -m unit`
- [x] `pytest -m integration`
- [x] `python -m scripts.check_docs_urls`
- [x] CI green on the matrix
