### PR TITLE
Sconscript ExportShared and import-aware discovery order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sconscript ``ExportShared`` / ``ImportShared`` and ordered discovery: scan string-literal
   ``Export`` / ``Import`` (and Cuppa shared methods), widen for missing exporters (including
   under ``--scripts=``; multi-hop), run exporters before importers; duplicate product exports
-  are an error. ``--strict-sconscript-exports`` refuses widen. Concepts and Building CLI docs
-  cover discovery vs sharing ([`sconscript-exports`](design/plans/sconscript-exports.md)).
+  are an error. ``--strict-sconscript-exports`` refuses widen. Widened paths stay
+  project-relative so ``--clean`` matches the same ``_build`` layout as a full discovery
+  build. Concepts and Building CLI docs cover discovery vs sharing
+  ([`sconscript-exports`](design/plans/sconscript-exports.md)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``list-dependencies-requires.{txt,html,json}`` show the expected tree shape
   ([#279](https://github.com/ja11sop/cuppa/issues/279)).
 - Sconscript ``ExportShared`` / ``ImportShared`` and ordered discovery: scan string-literal
-  ``Export`` / ``Import`` (and Cuppa shared methods), widen for missing exporters, run
-  exporters before importers; duplicate product exports are an error. Concepts doc covers
-  discovery vs sharing ([`sconscript-exports`](design/plans/sconscript-exports.md)).
+  ``Export`` / ``Import`` (and Cuppa shared methods), widen for missing exporters (including
+  under ``--scripts=``; multi-hop), run exporters before importers; duplicate product exports
+  are an error. ``--strict-sconscript-exports`` refuses widen. Concepts and Building CLI docs
+  cover discovery vs sharing ([`sconscript-exports`](design/plans/sconscript-exports.md)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   consume without a live registry. Doc samples
   ``list-dependencies-requires.{txt,html,json}`` show the expected tree shape
   ([#279](https://github.com/ja11sop/cuppa/issues/279)).
+- Sconscript ``ExportShared`` / ``ImportShared`` and ordered discovery: scan string-literal
+  ``Export`` / ``Import`` (and Cuppa shared methods), widen for missing exporters, run
+  exporters before importers; duplicate product exports are an error. Concepts doc covers
+  discovery vs sharing ([`sconscript-exports`](design/plans/sconscript-exports.md)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   under ``--scripts=``; multi-hop), run exporters before importers; duplicate product exports
   are an error. ``--strict-sconscript-exports`` refuses widen. Widened paths stay
   project-relative so ``--clean`` matches the same ``_build`` layout as a full discovery
-  build. Concepts and Building CLI docs cover discovery vs sharing
-  ([`sconscript-exports`](design/plans/sconscript-exports.md)).
+  build. Shared exports are **variant-aware** (keyed by ``tool_variant_dir``) so the same
+  name under ``--dbg`` / ``--rel`` resolves correctly — a concrete reason to prefer the
+  Cuppa API over native SCons ``Export`` / ``Import``. Concepts and Building CLI docs
+  cover discovery vs sharing ([`sconscript-exports`](design/plans/sconscript-exports.md)).
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,8 @@ Minor cycle after **1.10.0**. Prefer work that changes opt-in toolchain or packa
 | Area | Intent in 1.11.0 |
 |------|------------------|
 | `cuppa.run` default_dependencies objects | [`run-default-dependency-objects.md`](design/plans/run-default-dependency-objects.md) — objects in both lists; teach register vs auto-apply; optional clearer names later |
-| Transitive GitLab packages | [`gitlab-package-transitive.md`](design/plans/gitlab-package-transitive.md) — `cuppa-dependency.json` + `--list-dependencies` `requires` (in progress; #279) |
+| Transitive GitLab packages | [`gitlab-package-transitive.md`](design/plans/gitlab-package-transitive.md) — `cuppa-dependency.json` + `--list-dependencies` `requires` (shipped #280 / #281; #279 follow-ons deferred) |
+| Sconscript exports / sharing | [`sconscript-exports.md`](design/plans/sconscript-exports.md) — discovery stays; Import/Export graph + `ExportShared` (in progress) |
 | GitLab CMake staging | [#209](https://github.com/ja11sop/cuppa/issues/209) |
 | Artefact removal design | [#135](https://github.com/ja11sop/cuppa/issues/135) |
 | Console bundle | `--terse-output`, log hygiene, `cuppa --info` |
@@ -581,7 +582,7 @@ Design: [#213](https://github.com/ja11sop/cuppa/issues/213) (compile object path
 | ID | Work | Priority | Notes |
 |----|------|----------|-------|
 | `compile-object-paths` | Mirror source tree under `working/` for `Compile` | — | **Shipped 1.8.1** — [#213](https://github.com/ja11sop/cuppa/issues/213) / [#214](https://github.com/ja11sop/cuppa/pull/214) |
-| `sconscript-exports` | Export registry or explicit tree; dedupe discovered paths | Medium | [`sconscript-exports.md`](design/plans/sconscript-exports.md) |
+| `sconscript-exports` | Discovery + Import/Export execution graph; `ExportShared` / `ImportShared` | Medium | [`sconscript-exports.md`](design/plans/sconscript-exports.md) — spike in progress |
 | `cmake-to-cuppa-migration` | Antora matrix + phased tutorial + agent checklist | Medium | Compile-path fix shipped — [`cmake-to-cuppa-migration.md`](design/plans/cmake-to-cuppa-migration.md) |
 | `static-glob` | RecursiveGlob (disk + `Dir.entries` + full Repository); GlobFiles; Filter path parity | — | **Shipped** — [#232](https://github.com/ja11sop/cuppa/issues/232) / [#231](https://github.com/ja11sop/cuppa/pull/231), [`recursive-glob-parity.md`](design/archive/recursive-glob-parity.md); follow-on [`path-vocabulary-and-scons-nodes.md`](design/plans/path-vocabulary-and-scons-nodes.md) |
 

--- a/cuppa/construct.py
+++ b/cuppa/construct.py
@@ -28,6 +28,7 @@ import cuppa.core.storage_actions
 import cuppa.core.location_options
 import cuppa.core.options
 import cuppa.core.build_layout
+import cuppa.core.sconscript_coupling
 import cuppa.modules.registration
 import cuppa.build_platform
 import cuppa.output_processor
@@ -982,6 +983,20 @@ class Construct(object):
                 else:
                     sconscripts.append( project )
 
+            cuppa.core.sconscript_coupling.clear_session_shared()
+            search_root = cuppa_env.get( 'sconstruct_dir' ) or cuppa_env.get( 'launch_dir' )
+            try:
+                sconscripts = cuppa.core.sconscript_coupling.order_sconscripts(
+                        sconscripts,
+                        search_root=search_root,
+                )
+            except SCons.Errors.StopError:
+                raise
+            except Exception as exc:
+                raise SCons.Errors.StopError(
+                        "cuppa: failed while ordering sconscripts for Export/Import: {}".format( exc )
+                )
+
             for toolchain in toolchains:
                 build_envs = self.create_build_envs( toolchain, cuppa_env )
                 for build_env in build_envs:
@@ -1074,6 +1089,7 @@ class Construct(object):
             ] )
 
             cuppa.core.environment.EnvironmentMethods.add_progress_tracking( sconscript_env )
+            cuppa.core.sconscript_coupling.install_methods( sconscript_env )
 
             cuppa.progress.NotifyProgress.notify_sconscript_env_ready( sconscript_env )
 

--- a/cuppa/construct.py
+++ b/cuppa/construct.py
@@ -985,10 +985,12 @@ class Construct(object):
 
             cuppa.core.sconscript_coupling.clear_session_shared()
             search_root = cuppa_env.get( 'sconstruct_dir' ) or cuppa_env.get( 'launch_dir' )
+            widen = not bool( cuppa_env.get_option( 'strict_sconscript_exports' ) )
             try:
                 sconscripts = cuppa.core.sconscript_coupling.order_sconscripts(
                         sconscripts,
                         search_root=search_root,
+                        widen=widen,
                 )
             except SCons.Errors.StopError:
                 raise

--- a/cuppa/core/base_options.py
+++ b/cuppa/core/base_options.py
@@ -62,6 +62,12 @@ def add_base_options():
                             action='callback', callback=cuppa.core.options.list_parser( 'projects' ),
                             help="Sconscripts to run" )
 
+    add_option( '--strict-sconscript-exports', dest='strict_sconscript_exports',
+                            action='store_true',
+                            help="Do not widen the sconscript set to satisfy Export/Import "
+                                 "(or ExportShared/ImportShared). Imports must be satisfied by "
+                                 "the scripts already selected via discovery or --scripts" )
+
     add_option( '--thirdparty', type='string', nargs=1, action='store',
                             dest='thirdparty',
                             metavar='DIR',

--- a/cuppa/core/sconscript_coupling.py
+++ b/cuppa/core/sconscript_coupling.py
@@ -138,8 +138,32 @@ def _norm_path( path ):
     return os.path.normpath( path )
 
 
+def _as_project_relative( path, base_dir=None ):
+    """Return a path Cuppa can use as a discovered sconscript (``./…`` form).
+
+    Widen search often yields absolute paths from ``recursive_glob`` when
+    ``search_root`` is absolute. Absolute sconscript paths produce a different
+    ``sconstruct_offset_path`` / ``_build`` layout than ``./sconscript``, so a
+    later ``--clean`` with ``--scripts=`` would not remove artefacts built under
+    the relative path. Rebase to *base_dir* (default: cwd) and prefer a ``./``
+    prefix to match Construct's discovery shape.
+    """
+    base_dir = base_dir if base_dir is not None else os.getcwd()
+    abs_path = os.path.abspath( path )
+    abs_base = os.path.abspath( base_dir )
+    try:
+        rel = os.path.relpath( abs_path, abs_base )
+    except ValueError:
+        return path
+    if rel.startswith( '..' ):
+        return abs_path
+    if not rel.startswith( '.' + os.sep ) and rel != '.':
+        rel = os.path.join( '.', rel )
+    return rel
+
+
 def _discover_sconscripts_under( root ):
-    """Return normalised sconscript paths under *root* (non-recursive of nest constructs)."""
+    """Return project-relative sconscript paths under *root*."""
     # Local import avoids a circular import with construct during module load.
     import re
     from cuppa import recursive_glob
@@ -152,7 +176,7 @@ def _discover_sconscripts_under( root ):
             exclude_dirs_pattern=None,
             discard_pattern=discard_if_subdir_contains_regex,
     )
-    return [ _norm_path( p ) for p in found ]
+    return [ _as_project_relative( p ) for p in found ]
 
 
 def _coupling_edges( couplings_by_path ):
@@ -279,6 +303,7 @@ def order_sconscripts( paths, search_root=None, widen=True ):
             needed_names = { name for _path, name in unsatisfied }
             added = False
             for candidate in candidates:
+                candidate = _as_project_relative( candidate )
                 candidate_norm = _norm_path( candidate )
                 if candidate_norm in couplings:
                     continue

--- a/cuppa/core/sconscript_coupling.py
+++ b/cuppa/core/sconscript_coupling.py
@@ -372,32 +372,61 @@ def order_sconscripts( paths, search_root=None, widen=True ):
     return ordered
 
 
-# Session registry for Cuppa ``ExportShared`` / ``ImportShared`` (survives env.Clone).
+# Session registry for Cuppa ``ExportShared`` / ``ImportShared``.
+# Keyed by toolchain/variant/arch/abi scope so dbg and rel (and multi-toolchain)
+# exports of the same name do not overwrite each other. This is a primary reason
+# the Cuppa API exists above native SCons Export/Import (global last-wins pool).
 _session_shared = {}
 
 
+def shared_export_scope( env ):
+    """Return the scope key for shared exports on *env* (tool_variant_dir when set)."""
+    key = env.get( 'tool_variant_dir' )
+    if key:
+        return key
+    variant = env.get( 'variant' )
+    if hasattr( variant, 'name' ):
+        variant_name = variant.name()
+    else:
+        variant_name = str( variant or '' )
+    toolchain = env.get( 'active_toolchain' )
+    if toolchain is not None and hasattr( toolchain, 'name' ):
+        toolchain_name = toolchain.name()
+    else:
+        toolchain_name = ''
+    return os.path.join(
+            str( toolchain_name ),
+            str( variant_name ),
+            str( env.get( 'target_arch' ) or '' ),
+            str( env.get( 'abi' ) or '' ),
+    )
+
+
 def clear_session_shared():
-    """Reset Cuppa shared exports (call once per ``Construct.build``)."""
+    """Reset all Cuppa shared exports (call once per ``Construct.build``)."""
     _session_shared.clear()
 
 
 def export_shared( env, name, value ):
-    """Cuppa preferred export: publish *name* for later ``ImportShared`` / native ``Import``.
+    """Cuppa preferred export: publish *name* for this toolchain/variant scope.
 
-    Writes the Cuppa session registry and SCons ``Export`` so either import style works
-    when exporters run first.
+    Values are stored per ``tool_variant_dir`` so ``--dbg`` and ``--rel`` (and
+    multiple toolchains) keep distinct bindings for the same name. Also updates
+    SCons ``Export`` for best-effort native ``Import`` — that global pool is
+    **not** variant-safe; prefer ``ImportShared``.
     """
     if not isinstance( name, str ) or not name or name in BUILTIN_EXPORT_NAMES:
         raise SCons.Errors.StopError(
                 "cuppa: ExportShared name must be a non-built-in string, got {!r}".format( name )
         )
-    _session_shared[name] = value
+    scope = shared_export_scope( env )
+    _session_shared.setdefault( scope, {} )[name] = value
     SCons.Script.Export( { name: value } )
     return value
 
 
 def import_shared( env, *names ):
-    """Cuppa preferred import: read names from the session registry (and SCons Export).
+    """Cuppa preferred import: read names for this toolchain/variant scope.
 
     Returns one value, or a tuple when multiple names are requested.
     """
@@ -412,18 +441,22 @@ def import_shared( env, *names ):
     if not flat:
         raise SCons.Errors.StopError( "cuppa: ImportShared requires at least one name" )
 
+    scope = shared_export_scope( env )
+    bucket = _session_shared.get( scope ) or {}
     values = []
     for name in flat:
         if name in BUILTIN_EXPORT_NAMES:
             raise SCons.Errors.StopError(
                     "cuppa: ImportShared cannot request Cuppa built-in name '{}'".format( name )
             )
-        if name not in _session_shared:
+        if name not in bucket:
             raise SCons.Errors.StopError(
-                    "cuppa: ImportShared('{}') failed — no matching ExportShared "
-                    "(exporter must run first)".format( name )
+                    "cuppa: ImportShared('{}') failed for scope [{}] — no matching "
+                    "ExportShared (exporter must run first for this toolchain/variant)".format(
+                            name, scope
+                    )
             )
-        values.append( _session_shared[name] )
+        values.append( bucket[name] )
     if len( values ) == 1:
         return values[0]
     return tuple( values )

--- a/cuppa/core/sconscript_coupling.py
+++ b/cuppa/core/sconscript_coupling.py
@@ -233,14 +233,18 @@ def _topo_order( paths, edges ):
     return ordered
 
 
-def order_sconscripts( paths, search_root=None ):
+def order_sconscripts( paths, search_root=None, widen=True ):
     """Return *paths* reordered so exporters run before importers.
 
-    When an import is not satisfied by the current set and *search_root* is set,
-    discover additional sconscripts under that root and include any that export
-    the missing name (widen search). Multiple exporters for one name raise
-    ``StopError`` (stricter than SCons last-wins). Unsatisfied imports after
-    widen also raise ``StopError``.
+    When an import is not satisfied by the current set and *widen* is true with a
+    *search_root*, discover additional sconscripts under that root and include any
+    that export a missing name (repeat until fixed point — so A→B→C chains work
+    under ``--scripts=`` that named only the importer). With *widen* false (or no
+    *search_root*), missing exporters raise ``StopError`` without leaving the
+    current set.
+
+    Multiple exporters for one name raise ``StopError`` (stricter than SCons
+    last-wins).
     """
     if not paths:
         return []
@@ -267,29 +271,34 @@ def order_sconscripts( paths, search_root=None ):
 
     edges, _single, unsatisfied, collisions = _coupling_edges( couplings )
 
-    if search_root and unsatisfied:
+    if widen and search_root and unsatisfied:
         search_root = _norm_path( search_root )
         candidates = _discover_sconscripts_under( search_root )
-        added = False
-        for candidate in candidates:
-            candidate_norm = _norm_path( candidate )
-            if candidate_norm in couplings:
-                continue
-            if not os.path.isfile( candidate ):
-                continue
-            coupling = scan_sconscript_file( candidate )
+        # Fixed-point widen: newly pulled exporters may Import further names.
+        while unsatisfied:
             needed_names = { name for _path, name in unsatisfied }
-            if coupling.exports & needed_names:
+            added = False
+            for candidate in candidates:
+                candidate_norm = _norm_path( candidate )
+                if candidate_norm in couplings:
+                    continue
+                if not os.path.isfile( candidate ):
+                    continue
+                coupling = scan_sconscript_file( candidate )
+                if not ( coupling.exports & needed_names ):
+                    continue
                 couplings[candidate_norm] = coupling
                 norm_to_original[candidate_norm] = candidate
                 unique.append( candidate )
                 added = True
                 logger.info(
-                        "Widened sconscript discovery to exporter [{}]".format(
-                                as_notice( candidate )
+                        "Widened sconscript set to exporter [{}] for Import of [{}]".format(
+                                as_notice( candidate ),
+                                as_notice( ", ".join( sorted( coupling.exports & needed_names ) ) ),
                         )
                 )
-        if added:
+            if not added:
+                break
             edges, _single, unsatisfied, collisions = _coupling_edges( couplings )
 
     if collisions:
@@ -311,9 +320,16 @@ def order_sconscripts( paths, search_root=None ):
                 "{} imports '{}'".format( _original( path ), name )
                 for path, name in sorted( unsatisfied )
         ]
+        if widen:
+            hint = "project tree under the sconstruct"
+        else:
+            hint = (
+                    "current sconscript set "
+                    "(omit --strict-sconscript-exports to widen and pull exporters)"
+            )
         raise SCons.Errors.StopError(
                 "cuppa: sconscript Import not satisfied by any Export in the "
-                "project tree: {}".format( "; ".join( parts ) )
+                "{}: {}".format( hint, "; ".join( parts ) )
         )
 
     norm_paths = [ _norm_path( p ) for p in unique ]

--- a/cuppa/core/sconscript_coupling.py
+++ b/cuppa/core/sconscript_coupling.py
@@ -1,0 +1,385 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+"""Sconscript Export/Import coupling: scan, widen, and execution order.
+
+Discovery (which scripts exist) stays separate. This module builds a dependency
+graph from static ``Export`` / ``Import`` (and Cuppa ``ExportShared`` /
+``ImportShared``) names so exporters run before importers.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from collections import defaultdict
+
+import SCons.Errors
+import SCons.Script
+
+from cuppa.log import logger
+from cuppa.colourise import as_notice
+
+
+# Names Cuppa already injects via ``SConscript(..., exports=...)`` each invoke.
+# Importing only these does not create coupling edges between project scripts.
+BUILTIN_EXPORT_NAMES = frozenset( {
+        'env',
+        'sconscript_env',
+        'build_root',
+        'artefacts_root',
+        'abs_artefacts_root',
+        'artifacts_root',
+        'abs_artifacts_root',
+        'build_dir',
+        'abs_build_dir',
+        'final_dir',
+        'abs_final_dir',
+        'common_variant_final_dir',
+        'common_project_final_dir',
+        'project',
+} )
+
+_CUPPA_EXPORT_METHODS = frozenset( { 'ExportShared', 'export_shared' } )
+_CUPPA_IMPORT_METHODS = frozenset( { 'ImportShared', 'import_shared' } )
+
+
+class ScriptCoupling( object ):
+    """Exports and imports found in one sconscript file."""
+
+    __slots__ = ( 'path', 'exports', 'imports' )
+
+    def __init__( self, path, exports=None, imports=None ):
+        self.path = path
+        self.exports = set( exports or () )
+        self.imports = set( imports or () )
+
+
+def _string_names_from_ast_value( node ):
+    """Yield export/import names from a string Constant (or legacy Str)."""
+    if isinstance( node, ast.Constant ) and isinstance( node.value, str ):
+        for part in node.value.split():
+            if part:
+                yield part
+        return
+    # Python < 3.8
+    if hasattr( ast, 'Str' ) and isinstance( node, ast.Str ):  # pragma: no cover
+        for part in node.s.split():
+            if part:
+                yield part
+
+
+def _names_from_call_args( args ):
+    names = []
+    for arg in args:
+        names.extend( _string_names_from_ast_value( arg ) )
+    return names
+
+
+def _is_name( node, expected ):
+    return isinstance( node, ast.Name ) and node.id == expected
+
+
+def _method_name( node ):
+    if isinstance( node, ast.Attribute ) and isinstance( node.attr, str ):
+        return node.attr
+    return None
+
+
+def scan_sconscript_source( source, path='<sconscript>' ):
+    """Parse *source* and return :class:`ScriptCoupling` for string-literal names.
+
+    Dynamic ``Import(variable)`` forms are ignored (spike bound). ``Import('*')``
+    is recorded as the literal name ``*`` so callers can treat it specially.
+    """
+    try:
+        tree = ast.parse( source, filename=path )
+    except SyntaxError as exc:
+        raise SCons.Errors.StopError(
+                "cuppa: cannot parse sconscript [{}] for Export/Import scan: {}".format(
+                        path, exc
+                )
+        )
+
+    exports = set()
+    imports = set()
+
+    for node in ast.walk( tree ):
+        if not isinstance( node, ast.Call ):
+            continue
+        func = node.func
+        names = _names_from_call_args( node.args )
+        if not names:
+            continue
+        if _is_name( func, 'Export' ):
+            exports.update( names )
+        elif _is_name( func, 'Import' ):
+            imports.update( names )
+        else:
+            method = _method_name( func )
+            if method in _CUPPA_EXPORT_METHODS:
+                exports.update( names )
+            elif method in _CUPPA_IMPORT_METHODS:
+                imports.update( names )
+
+    return ScriptCoupling( path, exports=exports, imports=imports )
+
+
+def scan_sconscript_file( path ):
+    """Read and scan a sconscript path."""
+    with open( path, 'r', encoding='utf-8' ) as handle:
+        source = handle.read()
+    return scan_sconscript_source( source, path=path )
+
+
+def _norm_path( path ):
+    return os.path.normpath( path )
+
+
+def _discover_sconscripts_under( root ):
+    """Return normalised sconscript paths under *root* (non-recursive of nest constructs)."""
+    # Local import avoids a circular import with construct during module load.
+    import re
+    from cuppa import recursive_glob
+
+    file_regex = re.compile( r'([^.]+[.])?sconscript$', re.IGNORECASE )
+    discard_if_subdir_contains_regex = re.compile( r'(SC|Sc|sc)onstruct' )
+    found = recursive_glob.glob(
+            root,
+            file_regex,
+            exclude_dirs_pattern=None,
+            discard_pattern=discard_if_subdir_contains_regex,
+    )
+    return [ _norm_path( p ) for p in found ]
+
+
+def _coupling_edges( couplings_by_path ):
+    """Return (edges, exporters, unsatisfied, collisions).
+
+    *edges* is a list of (importer_path, exporter_path).
+    *exporters* maps name -> exporter path (single).
+    *unsatisfied* is a set of (importer_path, name).
+    *collisions* maps name -> list of exporter paths (len > 1).
+    """
+    exporters = defaultdict( list )
+    for path, coupling in couplings_by_path.items():
+        for name in coupling.exports:
+            if name in BUILTIN_EXPORT_NAMES:
+                continue
+            exporters[name].append( path )
+
+    collisions = {
+            name: paths for name, paths in exporters.items() if len( paths ) > 1
+    }
+    single = {
+            name: paths[0] for name, paths in exporters.items() if len( paths ) == 1
+    }
+
+    edges = []
+    unsatisfied = set()
+    for path, coupling in couplings_by_path.items():
+        for name in coupling.imports:
+            if name in BUILTIN_EXPORT_NAMES or name == '*':
+                continue
+            exporter = single.get( name )
+            if exporter is None:
+                if name in collisions:
+                    continue  # reported separately
+                unsatisfied.add( ( path, name ) )
+            elif exporter != path:
+                edges.append( ( path, exporter ) )
+
+    return edges, single, unsatisfied, collisions
+
+
+def _topo_order( paths, edges ):
+    """Stable topological order: exporters before importers; else input order."""
+    index = { path: i for i, path in enumerate( paths ) }
+    path_set = set( paths )
+    dependents = defaultdict( set )  # exporter -> importers that need it
+    indegree = { path: 0 for path in paths }
+
+    for importer, exporter in edges:
+        if importer not in path_set or exporter not in path_set:
+            continue
+        if importer in dependents[exporter]:
+            continue
+        dependents[exporter].add( importer )
+        indegree[importer] += 1
+
+    ready = sorted(
+            ( path for path in paths if indegree[path] == 0 ),
+            key=lambda p: index[p],
+    )
+    ordered = []
+    while ready:
+        path = ready.pop( 0 )
+        ordered.append( path )
+        for dependent in sorted( dependents[path], key=lambda p: index[p] ):
+            indegree[dependent] -= 1
+            if indegree[dependent] == 0:
+                ready.append( dependent )
+                ready.sort( key=lambda p: index[p] )
+
+    if len( ordered ) != len( paths ):
+        remaining = [ path for path in paths if path not in set( ordered ) ]
+        raise SCons.Errors.StopError(
+                "cuppa: cycle in sconscript Export/Import coupling involving [{}]".format(
+                        ", ".join( remaining )
+                )
+        )
+    return ordered
+
+
+def order_sconscripts( paths, search_root=None ):
+    """Return *paths* reordered so exporters run before importers.
+
+    When an import is not satisfied by the current set and *search_root* is set,
+    discover additional sconscripts under that root and include any that export
+    the missing name (widen search). Multiple exporters for one name raise
+    ``StopError`` (stricter than SCons last-wins). Unsatisfied imports after
+    widen also raise ``StopError``.
+    """
+    if not paths:
+        return []
+
+    ordered_input = [ _norm_path( p ) for p in paths ]
+    # Preserve first-seen order; drop duplicates.
+    seen = set()
+    unique = []
+    for path in ordered_input:
+        if path not in seen:
+            seen.add( path )
+            unique.append( path )
+
+    couplings = {}
+    for path in unique:
+        if os.path.isfile( path ):
+            couplings[path] = scan_sconscript_file( path )
+        else:
+            couplings[path] = ScriptCoupling( path )
+
+    edges, _single, unsatisfied, collisions = _coupling_edges( couplings )
+
+    if search_root and unsatisfied:
+        search_root = _norm_path( search_root )
+        candidates = _discover_sconscripts_under( search_root )
+        added = False
+        for candidate in candidates:
+            if candidate in couplings:
+                continue
+            if not os.path.isfile( candidate ):
+                continue
+            coupling = scan_sconscript_file( candidate )
+            needed_names = { name for _path, name in unsatisfied }
+            if coupling.exports & needed_names:
+                couplings[candidate] = coupling
+                unique.append( candidate )
+                added = True
+                logger.info(
+                        "Widened sconscript discovery to exporter [{}]".format(
+                                as_notice( candidate )
+                        )
+                )
+        if added:
+            edges, _single, unsatisfied, collisions = _coupling_edges( couplings )
+
+    if collisions:
+        parts = []
+        for name, exporters in sorted( collisions.items() ):
+            parts.append(
+                    "'{}' from [{}]".format(
+                            name, ", ".join( sorted( exporters ) )
+                    )
+            )
+        raise SCons.Errors.StopError(
+                "cuppa: multiple sconscripts Export the same name (Cuppa refuses "
+                "SCons last-wins under discovery): {}".format( "; ".join( parts ) )
+        )
+
+    if unsatisfied:
+        parts = [
+                "{} imports '{}'".format( path, name )
+                for path, name in sorted( unsatisfied )
+        ]
+        raise SCons.Errors.StopError(
+                "cuppa: sconscript Import not satisfied by any Export in the "
+                "project tree: {}".format( "; ".join( parts ) )
+        )
+
+    if not edges:
+        return unique
+
+    ordered = _topo_order( unique, edges )
+    if ordered != unique:
+        logger.debug(
+                "Sconscript Export/Import order [{}]".format(
+                        as_notice( ", ".join( ordered ) )
+                )
+        )
+    return ordered
+
+
+# Session registry for Cuppa ``ExportShared`` / ``ImportShared`` (survives env.Clone).
+_session_shared = {}
+
+
+def clear_session_shared():
+    """Reset Cuppa shared exports (call once per ``Construct.build``)."""
+    _session_shared.clear()
+
+
+def export_shared( env, name, value ):
+    """Cuppa preferred export: publish *name* for later ``ImportShared`` / native ``Import``.
+
+    Writes the Cuppa session registry and SCons ``Export`` so either import style works
+    when exporters run first.
+    """
+    if not isinstance( name, str ) or not name or name in BUILTIN_EXPORT_NAMES:
+        raise SCons.Errors.StopError(
+                "cuppa: ExportShared name must be a non-built-in string, got {!r}".format( name )
+        )
+    _session_shared[name] = value
+    SCons.Script.Export( { name: value } )
+    return value
+
+
+def import_shared( env, *names ):
+    """Cuppa preferred import: read names from the session registry (and SCons Export).
+
+    Returns one value, or a tuple when multiple names are requested.
+    """
+    flat = []
+    for name in names:
+        if isinstance( name, str ):
+            flat.extend( part for part in name.split() if part )
+        else:
+            raise SCons.Errors.StopError(
+                    "cuppa: ImportShared names must be strings, got {!r}".format( name )
+            )
+    if not flat:
+        raise SCons.Errors.StopError( "cuppa: ImportShared requires at least one name" )
+
+    values = []
+    for name in flat:
+        if name in BUILTIN_EXPORT_NAMES:
+            raise SCons.Errors.StopError(
+                    "cuppa: ImportShared cannot request Cuppa built-in name '{}'".format( name )
+            )
+        if name not in _session_shared:
+            raise SCons.Errors.StopError(
+                    "cuppa: ImportShared('{}') failed — no matching ExportShared "
+                    "(exporter must run first)".format( name )
+            )
+        values.append( _session_shared[name] )
+    if len( values ) == 1:
+        return values[0]
+    return tuple( values )
+
+
+def install_methods( env ):
+    """Attach ``ExportShared`` / ``ImportShared`` to a construction environment."""
+    env.AddMethod( export_shared, 'ExportShared' )
+    env.AddMethod( import_shared, 'ImportShared' )

--- a/cuppa/core/sconscript_coupling.py
+++ b/cuppa/core/sconscript_coupling.py
@@ -245,21 +245,25 @@ def order_sconscripts( paths, search_root=None ):
     if not paths:
         return []
 
-    ordered_input = [ _norm_path( p ) for p in paths ]
-    # Preserve first-seen order; drop duplicates.
-    seen = set()
+    # Keep caller path strings (e.g. ``./sconscript``). Normpaths are only keys —
+    # stripping ``./`` breaks Cuppa's sconstruct_offset_path / final_dir layout.
     unique = []
-    for path in ordered_input:
-        if path not in seen:
-            seen.add( path )
+    norm_to_original = {}
+    for path in paths:
+        norm = _norm_path( path )
+        if norm not in norm_to_original:
+            norm_to_original[norm] = path
             unique.append( path )
 
     couplings = {}
     for path in unique:
         if os.path.isfile( path ):
-            couplings[path] = scan_sconscript_file( path )
+            couplings[_norm_path( path )] = scan_sconscript_file( path )
         else:
-            couplings[path] = ScriptCoupling( path )
+            couplings[_norm_path( path )] = ScriptCoupling( path )
+
+    def _original( norm ):
+        return norm_to_original.get( norm, norm )
 
     edges, _single, unsatisfied, collisions = _coupling_edges( couplings )
 
@@ -268,14 +272,16 @@ def order_sconscripts( paths, search_root=None ):
         candidates = _discover_sconscripts_under( search_root )
         added = False
         for candidate in candidates:
-            if candidate in couplings:
+            candidate_norm = _norm_path( candidate )
+            if candidate_norm in couplings:
                 continue
             if not os.path.isfile( candidate ):
                 continue
             coupling = scan_sconscript_file( candidate )
             needed_names = { name for _path, name in unsatisfied }
             if coupling.exports & needed_names:
-                couplings[candidate] = coupling
+                couplings[candidate_norm] = coupling
+                norm_to_original[candidate_norm] = candidate
                 unique.append( candidate )
                 added = True
                 logger.info(
@@ -291,7 +297,8 @@ def order_sconscripts( paths, search_root=None ):
         for name, exporters in sorted( collisions.items() ):
             parts.append(
                     "'{}' from [{}]".format(
-                            name, ", ".join( sorted( exporters ) )
+                            name,
+                            ", ".join( sorted( _original( p ) for p in exporters ) ),
                     )
             )
         raise SCons.Errors.StopError(
@@ -301,7 +308,7 @@ def order_sconscripts( paths, search_root=None ):
 
     if unsatisfied:
         parts = [
-                "{} imports '{}'".format( path, name )
+                "{} imports '{}'".format( _original( path ), name )
                 for path, name in sorted( unsatisfied )
         ]
         raise SCons.Errors.StopError(
@@ -309,10 +316,12 @@ def order_sconscripts( paths, search_root=None ):
                 "project tree: {}".format( "; ".join( parts ) )
         )
 
+    norm_paths = [ _norm_path( p ) for p in unique ]
     if not edges:
         return unique
 
-    ordered = _topo_order( unique, edges )
+    ordered_norms = _topo_order( norm_paths, edges )
+    ordered = [ _original( n ) for n in ordered_norms ]
     if ordered != unique:
         logger.debug(
                 "Sconscript Export/Import order [{}]".format(

--- a/design/README.md
+++ b/design/README.md
@@ -52,7 +52,7 @@ maintainer workflow evolved.
 | [`archive/toolchains-as-dependencies.md`](archive/toolchains-as-dependencies.md) | shipped | Fetched compilers as toolchain deps (Clang archives, GCC `.deb` / `--gcc-root=`, multi-select compare; list/force-wipe) — umbrella [#160](https://github.com/ja11sop/cuppa/issues/160); Clang [#159](https://github.com/ja11sop/cuppa/pull/159), GCC [#164](https://github.com/ja11sop/cuppa/pull/164) |
 | [`archive/conan-consumer-plan.md`](archive/conan-consumer-plan.md) | shipped | Design of `conan_deps` / `conan_dependency` consumer support |
 | [`archive/conan-publish-plan.md`](archive/conan-publish-plan.md) | shipped | Design of `ConanPackagePublisher` and `--publish-package` |
-| [`plans/sconscript-exports.md`](plans/sconscript-exports.md) | proposal | Shared exports between discovered sconscripts; nested lib/test layout |
+| [`plans/sconscript-exports.md`](plans/sconscript-exports.md) | in progress | Shared exports between discovered sconscripts; nested lib/test layout |
 | [`plans/cmake-to-cuppa-migration.md`](plans/cmake-to-cuppa-migration.md) | proposal | CMake ↔ Cuppa matrix and migration phases for humans and agents |
 | [`archive/recursive-glob-parity.md`](archive/recursive-glob-parity.md) | shipped | RecursiveGlob / GlobFiles / Filter parity — ROADMAP `static-glob`; [#232](https://github.com/ja11sop/cuppa/issues/232) / [#231](https://github.com/ja11sop/cuppa/pull/231) |
 | [`archive/method-behaviour-audit.md`](archive/method-behaviour-audit.md) | shipped | Method returns, evaluation, paths; #213 + glob + #233 + cov nested-path; hub classification — ROADMAP `method-behaviour-audit` |

--- a/design/plans/sconscript-exports.md
+++ b/design/plans/sconscript-exports.md
@@ -146,6 +146,6 @@ Static scan will not catch every dynamic `Import(name)` constructed at runtime; 
 | `scons-export-spike` | `sconscript_coupling` scan / multi-hop widen / topo + variant-scoped `ExportShared` / `ImportShared`; `Construct.build` wired |
 | `--scripts=` + strict + clean path form | Covered by unit + integration tests |
 | Variant-aware shared exports | Covered (`tool_variant_dir` scope; `--dbg --rel` integration) |
-| `--parallel` build with imported lib | Covered (`BuildStaticLib` + `ExportShared` → consumer `Build` under `-j`) |
+| `--parallel` build with imported lib | Covered (`BuildStaticLib` + `ExportShared` → consumer `Build` under `-j` on non-Windows; Windows omits `-j` due to MSVC `/Zi`/`vc140.pdb` C1090 across variant dirs) |
 | `scons-export-dedupe` | Not started (explicit `SConscript` + discovery double-run) |
 | `scons-export-capy` | Not started |

--- a/design/plans/sconscript-exports.md
+++ b/design/plans/sconscript-exports.md
@@ -122,12 +122,18 @@ Static scan will not catch every dynamic `Import(name)` constructed at runtime; 
 
 ## Open questions
 
-- Exact Cuppa method names (`env.export` / `env.import_shared` / …).
-- Widen search: must newly found exporters always join the normal discovered set, or only run because an importer needs them?
+- Exact Cuppa method names beyond shipped `ExportShared` / `ImportShared`.
 - Variant scope: exports are per-variant nodes — graph nodes are (script path × variant) or script path with per-variant values?
-- `--scripts=` filtering: if an importer is selected but its exporter is not, do we still pull the exporter in (lean: **yes**, otherwise Import cannot work)?
-- How much of a static scan is enough (AST vs regex vs execute-with-stubs)?
+- How much of a static scan is enough (AST vs regex vs execute-with-stubs)? Dynamic `Import(name)` remains unsupported.
 - Agent / CMake migration docs: teach Cuppa API first.
+
+## Settled (this slice)
+
+| Topic | Decision |
+|-------|----------|
+| `--scripts=` + missing exporter | **Widen by default** under the sconstruct (multi-hop fixed point). |
+| Refuse widen | **`--strict-sconscript-exports`** — Import must be satisfied by the already-selected set. |
+| Widened scripts | Join the run set (exporters execute, not resolve-only). |
 
 ## Progress snapshot
 
@@ -135,8 +141,8 @@ Static scan will not catch every dynamic `Import(name)` constructed at runtime; 
 |-------|--------|
 | Problem validated on Boost.Capy | done (2026-08-17) |
 | Lean: discovery + import/export graph (B) | settled in plan 2026-09-06 |
-| `scons-export-doc` | Started — Concepts § Sconscript discovery and sharing |
-| `scons-export-spike` | Started — `cuppa.core.sconscript_coupling` scan / widen / topo + `ExportShared` / `ImportShared`; wired into `Construct.build` |
+| `scons-export-doc` | Concepts + Building / CLI reference for widen and `--strict-sconscript-exports` |
+| `scons-export-spike` | `sconscript_coupling` scan / multi-hop widen / topo + `ExportShared` / `ImportShared`; `Construct.build` wired |
+| `--scripts=` + strict | Covered by unit + integration tests |
 | `scons-export-dedupe` | Not started (explicit `SConscript` + discovery double-run) |
-| `scons-export-graph` / `scons-export-api` | Partial — graph + preferred API landed; polish / native-only soak remains |
 | `scons-export-capy` | Not started |

--- a/design/plans/sconscript-exports.md
+++ b/design/plans/sconscript-exports.md
@@ -123,7 +123,6 @@ Static scan will not catch every dynamic `Import(name)` constructed at runtime; 
 ## Open questions
 
 - Exact Cuppa method names beyond shipped `ExportShared` / `ImportShared`.
-- Variant scope: exports are per-variant nodes — graph nodes are (script path × variant) or script path with per-variant values?
 - How much of a static scan is enough (AST vs regex vs execute-with-stubs)? Dynamic `Import(name)` remains unsupported.
 - Agent / CMake migration docs: teach Cuppa API first.
 
@@ -134,6 +133,8 @@ Static scan will not catch every dynamic `Import(name)` constructed at runtime; 
 | `--scripts=` + missing exporter | **Widen by default** under the sconstruct (multi-hop fixed point). |
 | Refuse widen | **`--strict-sconscript-exports`** — Import must be satisfied by the already-selected set. |
 | Widened scripts | Join the run set (exporters execute, not resolve-only). |
+| Variant / toolchain scope | **`ExportShared` / `ImportShared` are keyed by `tool_variant_dir`** (toolchain + variant + arch + abi). Same export name under `--dbg` and `--rel` (or two toolchains) keeps distinct values. **This is a concrete reason the Cuppa API exists above native SCons `Export` / `Import`**, whose global pool is last-wins across the configure pass and cannot honour variants safely. Native `Export` is still updated best-effort for migration; product code should use `ImportShared`. |
+| Graph nodes for scan/order | Script paths only (order is the same for every variant); **values** are per-variant via the Cuppa registry. |
 
 ## Progress snapshot
 
@@ -141,8 +142,9 @@ Static scan will not catch every dynamic `Import(name)` constructed at runtime; 
 |-------|--------|
 | Problem validated on Boost.Capy | done (2026-08-17) |
 | Lean: discovery + import/export graph (B) | settled in plan 2026-09-06 |
-| `scons-export-doc` | Concepts + Building / CLI reference for widen and `--strict-sconscript-exports` |
-| `scons-export-spike` | `sconscript_coupling` scan / multi-hop widen / topo + `ExportShared` / `ImportShared`; `Construct.build` wired |
-| `--scripts=` + strict | Covered by unit + integration tests |
+| `scons-export-doc` | Concepts + Building / CLI reference for widen, strict, and variant-aware Cuppa API |
+| `scons-export-spike` | `sconscript_coupling` scan / multi-hop widen / topo + variant-scoped `ExportShared` / `ImportShared`; `Construct.build` wired |
+| `--scripts=` + strict + clean path form | Covered by unit + integration tests |
+| Variant-aware shared exports | Covered (`tool_variant_dir` scope; `--dbg --rel` integration) |
 | `scons-export-dedupe` | Not started (explicit `SConscript` + discovery double-run) |
 | `scons-export-capy` | Not started |

--- a/design/plans/sconscript-exports.md
+++ b/design/plans/sconscript-exports.md
@@ -1,6 +1,6 @@
 # Plan: Sconscript exports and shared build products
 
-- **Status:** proposal
+- **Status:** proposal (lean settled 2026-09-06 — Direction B / import-aware discovery)
 - **Related:** [`ROADMAP.md`](../../ROADMAP.md) — `sconscript-exports`; blocks multi-file Cuppa layouts like CMake `add_subdirectory`; pairs with [#213](https://github.com/ja11sop/cuppa/issues/213); graph/cycle vocabulary may later share helpers with [`gitlab-package-transitive.md`](gitlab-package-transitive.md) (different graph; do not force one NetworkX model)
 - **Updated:** 2026-09-06
 
@@ -25,73 +25,113 @@ Import('env', 'capy_libs')   # Import of non-existent variable 'capy_libs'
 
 Manual `SConscript('test/sconscript', exports=[...])` inside a root sconscript **also fails** today because Cuppa **still auto-discovers** `test/sconscript` and runs it a second time without exports.
 
-This is a **design side-effect**, not an accident: early cuppa projects used one sconscript per repo or per top-level folder, with libraries declared inline or via `env.BuildWith` package deps.
+This is a **design side-effect**, not an accident: early cuppa projects used one sconscript per repo or per top-level folder, with libraries declared inline or via `env.BuildWith` package deps. That default has worked for well over a decade **without** relying on `Export` / `Import`.
 
-## Goals (exploration — first slice)
+## Two orthogonal concerns
 
-1. **Document current behaviour** in Antora (`concepts.adoc` or `methods.adoc`): discovered sconscripts are siblings, not a tree with inherited exports.
-2. **Choose a direction** for enabling CMake-like decomposition without duplicate invocation.
-3. **Spike** the smallest API that unblocks a real consumer (Boost.Capy Cuppa sketch): shared static libs built once, tests in `test/sconscript`.
+| Concern | Role | Default today |
+|---------|------|----------------|
+| **Discovery** | Which `sconscript` files participate in the session | Find `sconscript` in this folder and below (`-D` / recursive walk). **Keep this.** |
+| **Explicit coupling** | Sharing products / names between those scripts via `Export` / `Import` (or a Cuppa equivalent) | **Ignored.** Discovery does not backtrack exporters; invocation order is walk order only. |
 
-## Non-goals (initial slice)
+Do **not** conflate “stop discovering and use an explicit `SConscript` tree” with “support Export/Import.” Most projects never need coupling; when they do, discovery stays, and coupling adds a **dependency graph** on top.
 
-- Full SCons `Return()` parity with arbitrary values across arbitrary depth.
+## Goals (first slices)
+
+1. **Document** current behaviour: discovered sconscripts are siblings for discovery purposes; `Import` of non-cuppa keys fails today; why nested `SConscript(..., exports=)` double-runs.
+2. **Keep** folder-and-below discovery as the default (zero migration).
+3. **Add** import/export-aware resolution: when a discovered script imports a name that no exporter in the current set provides, **widen** the search (up toward the `sconstruct` root, then across the project tree) until a matching `Export` (or Cuppa export) is found — or fail clearly.
+4. **Honour** an **execution graph** derived from those edges (flat / walk order when there are no imports/exports), including under parallel configure/build where order matters.
+5. **Support** native SCons `Export` / `Import` where we can make them behave correctly under discovery; **also** offer a preferred Cuppa API that is clearer and less surprising; if native cannot be made reliable, Cuppa’s API still ships.
+
+## Non-goals (initial slices)
+
+- Turning off discovery by default, or requiring every project to list children (Direction A as the primary model).
+- Full SCons `Return()` parity with arbitrary values across arbitrary depth (may revisit later).
 - Replacing `location_dependency` / `package_dependency` — those already solve sharing via `env.BuildWith`.
 - Auto-wiring CMake `add_subdirectory` — see [`cmake-to-cuppa-migration.md`](cmake-to-cuppa-migration.md).
+- NetworkX for the sconscript graph until a second consumer proves hand-rolled DFS insufficient (same note as GitLab transitive listing).
 
-## Settled decisions (to confirm before implementation)
+## Settled lean (2026-09-06)
 
-| Question | Options | Working bias |
-|----------|---------|--------------|
-| Discovery vs explicit tree | (A) Only run sconscripts reached from explicit `SConscript()` calls; (B) discovery + optional `exports` registry; (C) discovery with parent path hints | **B or C** — keep `-D` descent ergonomics, add export map |
-| Export surface | SCons `Export()` / `Import()` only vs cuppa `env.export('name', nodes)` | Start with **SCons-native** where possible |
-| Duplicate invocation | Skip auto-discovery when a path was already loaded with exports | **Yes** — required for nested layout |
-| Default | Single root sconscript remains valid | **Unchanged** — zero migration for existing projects |
+| Topic | Decision |
+|-------|----------|
+| Primary direction | **B — discovery stays; add import/export coupling and an execution graph.** Not “export registry only for later scripts in walk order,” and not “explicit tree only” (A) or “scoped roots only” (C) as the main story. A/C remain optional escape hatches if a spike proves useful. |
+| Default discovery | Unchanged: find `sconscript` this folder and below. Decade of projects do not need Export/Import. |
+| How coupling is discovered | **Scan** discovered (and, when needed, widened) sconscript sources for `Import` / `Export` (and Cuppa equivalents). Build a **dependency graph**: importer → exporter. If an `Import` is not satisfied by any script already in the discovery set, **widen** search up to the `sconstruct` root and outward until a matching export is found. |
+| Execution order | Topological order from that graph. **No edges ⇒ flat** (today’s walk). Edges impose “exporter before importer.” Parallel builds must still respect that configure-time order for scripts that share names. |
+| Duplicate exporters | **Review vs SCons, then choose Cuppa policy.** SCons `Export` updates a **global** dict: calls are cumulative and a second `Export` of the same name **overwrites** (last wins) — not an error. Preferable Cuppa default for *discovered* multi-exporter collisions is likely **error** (two scripts claim the same product name under discovery is almost always a mistake); confirm in spike. Scoped `SConscript(..., exports=)` locals remain a separate SCons mechanism. |
+| Native vs Cuppa API | **Both tracks.** Make native `Export`/`Import` work when the scanned graph + ordered invocation can feed SCons’s pool correctly. Prefer documenting a **Cuppa API** (`env.export` / `env.import_shared` or similar — names TBD) that is obvious and less surprising. If native cannot be made trustworthy under discovery, Cuppa API is still mandatory. |
+| Preferred teaching path | Point users at the Cuppa API for new layouts; keep native for SCons-literate authors and migration. |
+| Existing projects | Zero migration when they never Import/Export project products. |
 
-## Design directions (to compare in spike)
+### Intended model (sketch)
+
+```text
+1. Discover sconscript set S (folder-and-below), as today.
+2. Scan scripts in S for Import / Export (and Cuppa twins).
+3. For each unsatisfied Import name:
+     widen search toward sconstruct root and across the tree;
+     add any newly found exporter scripts into S (or into a
+     resolve-only set — spike decides whether they must also
+     be “discovered” for other reasons).
+4. Build execution graph G from import→export edges.
+5. Detect cycles / ambiguous multi-export (per Cuppa policy).
+6. Invoke each script once, in topo order (or walk order if G flat),
+   with exports available to importers (native pool and/or Cuppa map).
+7. Dedupe: never run the same path twice (discovery + explicit SConscript).
+```
+
+Static scan will not catch every dynamic `Import(name)` constructed at runtime; spike should bound what we promise (string-literal Imports first) and how Cuppa’s API avoids that trap.
+
+## Design directions (historical — for contrast)
 
 ### Direction A — Explicit tree only
 
-- Turn off recursive sconscript discovery when `sconstruct` sets `cuppa.run(discover_sconscripts=False)` or equivalent.
-- Root `sconscript` owns all `SConscript('test/sconscript', exports=...)`.
-- **Pros:** Matches SCons docs; predictable.
-- **Cons:** Breaks `--scripts=` / default discovery UX; every project must list children.
+- Opt out of recursive discovery; root owns all `SConscript(..., exports=...)`.
+- **Pros:** Matches classic SCons docs.
+- **Cons:** Breaks default discovery UX; every project must list children.
+- **Status:** Escape hatch only, not the primary model.
 
-### Direction B — Export registry on `env`
+### Direction B — Discovery + import/export graph (chosen lean)
 
-- Root sconscript: `env.export('capy_libs', [lib_a, lib_b])`.
-- Cuppa merges exported names into `sconscript_exports` for **later** discovered scripts (discovery order = tree walk order).
-- Child: `Import('env', 'capy_libs')` or `env.import_shared('capy_libs')`.
-- **Pros:** Minimal change to discovery; fits cuppa's `env` methods style.
-- **Cons:** Order-dependent; needs clear rules when exports collide.
+- Keep discovery.
+- Scan + widen + execution graph as above.
+- Cuppa preferred API + native support where feasible.
+- **Pros:** Matches how Cuppa projects already work; Export/Import becomes an opt-in coupling layer.
+- **Cons:** Needs a reliable scan; order and collision policy must be explicit; parallel configure must respect G.
 
 ### Direction C — Scoped discovery roots
 
-- `cuppa.run(projects=['sconscript'])` — only listed entrypoints; entrypoints call nested `SConscript` themselves.
-- Keeps today’s default discovery for legacy repos via opt-out flag.
-- **Pros:** No magic export merging.
-- **Cons:** Two mental models (discovered vs rooted).
+- `cuppa.run(projects=[...])` entrypoints that nest `SConscript` themselves.
+- **Pros:** No magic merging.
+- **Cons:** Two mental models.
+- **Status:** Possible later opt-in; not required if B’s widen search covers Capylike layouts.
 
 ## Work slices
 
 | Slice | Deliverable | Depends on |
 |-------|-------------|------------|
-| `scons-export-doc` | Antora: how discovery works; why `Import('capy_libs')` fails today | — |
-| `scons-export-spike` | Choose A/B/C; prototype in a fixture (lib sconscript + test sconscript) | — |
-| `scons-export-dedupe` | Do not double-run a sconscript path (explicit + discovery) | spike |
-| `scons-export-api` | Ship chosen API + integration test | dedupe |
-| `scons-export-capy` | Re-enable Boost.Capy `test/sconscript` split (external validation) | [#213](https://github.com/ja11sop/cuppa/issues/213) |
+| `scons-export-doc` | Antora: discovery vs coupling; why `Import('capy_libs')` fails today; SCons last-wins vs Cuppa collision policy (once settled) | — |
+| `scons-export-spike` | Prototype scan + widen + topo invoke; fixture (lib sconscript + `test/sconscript`); try native `Export`/`Import` and a Cuppa API sketch; settle multi-export and dynamic-Import limits | — |
+| `scons-export-dedupe` | Never double-run a path (discovery + explicit `SConscript`) | spike |
+| `scons-export-graph` | Execution graph as product behaviour (flat default; ordered when coupled); cycle / collision errors | spike |
+| `scons-export-api` | Ship preferred Cuppa API + native path as far as spike allows + integration tests | graph, dedupe |
+| `scons-export-capy` | Re-enable Boost.Capy `test/sconscript` split (external validation) | [#213](https://github.com/ja11sop/cuppa/issues/213), api |
 
 ## Open questions
 
-- Should exports be variant-scoped automatically (they must be — lib nodes are per variant)?
-- Interaction with `--scripts=` filtering: do exports from a skipped parent still exist?
-- How do agents discover the pattern? → tie-in with CMake migration guide.
+- Exact Cuppa method names (`env.export` / `env.import_shared` / …).
+- Widen search: must newly found exporters always join the normal discovered set, or only run because an importer needs them?
+- Variant scope: exports are per-variant nodes — graph nodes are (script path × variant) or script path with per-variant values?
+- `--scripts=` filtering: if an importer is selected but its exporter is not, do we still pull the exporter in (lean: **yes**, otherwise Import cannot work)?
+- How much of a static scan is enough (AST vs regex vs execute-with-stubs)?
+- Agent / CMake migration docs: teach Cuppa API first.
 
 ## Progress snapshot
 
 | Slice | Status |
 |-------|--------|
 | Problem validated on Boost.Capy | done (2026-08-17) |
-| Plan | this document |
-| Implementation | not started |
+| Lean: discovery + import/export graph (B) | settled in plan 2026-09-06 |
+| `scons-export-doc` / spike / implementation | not started |

--- a/design/plans/sconscript-exports.md
+++ b/design/plans/sconscript-exports.md
@@ -1,8 +1,9 @@
 # Plan: Sconscript exports and shared build products
 
-- **Status:** proposal (lean settled 2026-09-06 — Direction B / import-aware discovery)
+- **Status:** in progress
 - **Related:** [`ROADMAP.md`](../../ROADMAP.md) — `sconscript-exports`; blocks multi-file Cuppa layouts like CMake `add_subdirectory`; pairs with [#213](https://github.com/ja11sop/cuppa/issues/213); graph/cycle vocabulary may later share helpers with [`gitlab-package-transitive.md`](gitlab-package-transitive.md) (different graph; do not force one NetworkX model)
 - **Updated:** 2026-09-06
+- **Impact:** minor — opt-in Export/Import ordering and `ExportShared` / `ImportShared`; flat discovery unchanged when unused
 
 ## Problem
 
@@ -134,4 +135,8 @@ Static scan will not catch every dynamic `Import(name)` constructed at runtime; 
 |-------|--------|
 | Problem validated on Boost.Capy | done (2026-08-17) |
 | Lean: discovery + import/export graph (B) | settled in plan 2026-09-06 |
-| `scons-export-doc` / spike / implementation | not started |
+| `scons-export-doc` | Started — Concepts § Sconscript discovery and sharing |
+| `scons-export-spike` | Started — `cuppa.core.sconscript_coupling` scan / widen / topo + `ExportShared` / `ImportShared`; wired into `Construct.build` |
+| `scons-export-dedupe` | Not started (explicit `SConscript` + discovery double-run) |
+| `scons-export-graph` / `scons-export-api` | Partial — graph + preferred API landed; polish / native-only soak remains |
+| `scons-export-capy` | Not started |

--- a/design/plans/sconscript-exports.md
+++ b/design/plans/sconscript-exports.md
@@ -146,5 +146,6 @@ Static scan will not catch every dynamic `Import(name)` constructed at runtime; 
 | `scons-export-spike` | `sconscript_coupling` scan / multi-hop widen / topo + variant-scoped `ExportShared` / `ImportShared`; `Construct.build` wired |
 | `--scripts=` + strict + clean path form | Covered by unit + integration tests |
 | Variant-aware shared exports | Covered (`tool_variant_dir` scope; `--dbg --rel` integration) |
+| `--parallel` build with imported lib | Covered (`BuildStaticLib` + `ExportShared` → consumer `Build` under `-j`) |
 | `scons-export-dedupe` | Not started (explicit `SConscript` + discovery double-run) |
 | `scons-export-capy` | Not started |

--- a/docs/modules/ROOT/pages/cli-reference.adoc
+++ b/docs/modules/ROOT/pages/cli-reference.adoc
@@ -129,7 +129,8 @@ In the examples that follow we use this convention.
 | `--dbg` / `--rel` / `--cov` | Select one or more build variants
 | `--toolchains=LIST` | Select discovered toolchains by comma-separated name or wildcard
 | `--test` / `--run` / `--benchmark` | Execute the corresponding targets after building
-| `--scripts=LIST` | Limit which sconscripts contribute targets
+| `--scripts=LIST` | Limit which sconscripts contribute targets (may widen for Export/Import)
+| `--strict-sconscript-exports` | Refuse Export/Import widen outside the selected set
 | `--parallel` | Choose a hardware-sized SCons job count (do not combine with `--cov --test`)
 | `--develop` | Prefer configured local dependency copies
 | `--offline` | Avoid PyPI checks and remote location updates

--- a/docs/modules/ROOT/pages/cli-reference.adoc
+++ b/docs/modules/ROOT/pages/cli-reference.adoc
@@ -138,6 +138,11 @@ In the examples that follow we use this convention.
 | `-Q` | Suppress SCons progress messages without hiding build commands
 |===
 
+Share products between sconscripts with `ExportShared` / `ImportShared` (variant-aware; see
+xref:concepts.adoc#sconscript-discovery[Concepts]). Use `--scripts=` / `--strict-sconscript-exports`
+when limiting which scripts run. Detail:
+xref:cli/building.adoc[Building].
+
 == Command output
 
 Output comes from three layers: SCons reports graph progress and build actions, Cuppa reports

--- a/docs/modules/ROOT/pages/cli/building.adoc
+++ b/docs/modules/ROOT/pages/cli/building.adoc
@@ -21,8 +21,9 @@ you can see which layer owns each decision.
 | `--benchmark` | Execute outputs created by `BuildBenchmark()`
 | `--force-benchmark` | Execute `Benchmark()` and `BuildBenchmark()` outputs even when current
 | `--toolchains=LIST` | Select comma-separated toolchain names or fnmatch patterns such as `gcc*`
-| `--scripts=LIST` | Limit graph construction to the named, comma-separated sconscripts
+| `--scripts=LIST` | Limit graph construction to the named, comma-separated sconscripts. Product `Import` / `ImportShared` may still **widen** the set to pull required exporters from under the sconstruct (unless `--strict-sconscript-exports`)
 | `--projects=LIST` | Alias for `--scripts`
+| `--strict-sconscript-exports` | Do not widen for Export/Import; every imported name must be satisfied by the scripts already selected
 | `--parallel` | Set SCons' job count from available hardware; the wrapper may also restrict CPU affinity. Do not combine with `--cov --test` (Cuppa warns; collect serially)
 | `--offline` | Skip the PyPI version check and remote location updates
 | `--develop` | Prefer configured local develop paths for dependencies

--- a/docs/modules/ROOT/pages/cli/building.adoc
+++ b/docs/modules/ROOT/pages/cli/building.adoc
@@ -29,6 +29,12 @@ you can see which layer owns each decision.
 | `--develop` | Prefer configured local develop paths for dependencies
 |===
 
+Sharing between sconscripts uses `env.ExportShared` / `env.ImportShared` (see
+xref:concepts.adoc#sconscript-discovery[Concepts — Sconscript discovery and sharing]).
+Those bindings are **variant-aware** (per toolchain/variant/arch/abi), so the same export
+name under `--dbg` and `--rel` resolves to the matching nodes. Prefer that Cuppa API over
+native SCons `Export` / `Import` when you share build products across scripts.
+
 Variant and action options compose. For example, `--dbg --rel --test` builds and tests both
 variants. Coverage is deliberately explicit: use `--cov --test` when you want measurements rather
 than an instrumented binary that has not run.

--- a/docs/modules/ROOT/pages/concepts.adoc
+++ b/docs/modules/ROOT/pages/concepts.adoc
@@ -36,6 +36,41 @@ That split is intentional:
 See xref:cli-reference.adoc[CLI reference] for the full option map, and
 xref:methods.adoc[Methods] for the intent APIs used in sconscripts.
 
+[#sconscript-discovery]
+== Sconscript discovery and sharing
+
+Cuppa **discovers** `sconscript` files under the launch directory (folder-and-below) and
+invokes each once per active toolchain/variant. That discovery is the right default for most
+projects and does not require SCons `Export` / `Import`.
+
+Sharing build products between discovered scripts is a **separate** concern. When one script
+needs a value another published, use Cuppa's preferred API:
+
+[source,python]
+----
+# sconscript (libraries)
+Import('env')
+libs = env.Build( 'mylib', ['mylib.cpp'] )
+env.ExportShared( 'mylibs', libs )
+
+# test/sconscript
+Import('env')
+libs = env.ImportShared( 'mylibs' )
+env.BuildTest( 'unit', ['test.cpp'], LIBS=libs )
+----
+
+Cuppa scans discovered scripts for `Export` / `Import` and `ExportShared` /
+`ImportShared`, builds a small dependency graph, and runs exporters before importers.
+When an import is not satisfied in the current set, discovery **widens** toward the
+`sconstruct` root to find a matching export. Two scripts that export the same product name
+are an error (stricter than SCons, which last-wins on a global pool). Native SCons
+`Export` / `Import` are also recognised by the scan when names are string literals.
+
+Without product imports, execution order stays the discovery walk (a flat graph). Nested
+`SConscript(..., exports=...)` from one script while Cuppa also auto-discovers the same path
+can still double-run that path — prefer `ExportShared` / discovery, or avoid listing a path
+Cuppa will discover again.
+
 [#methods]
 == Methods
 

--- a/docs/modules/ROOT/pages/concepts.adoc
+++ b/docs/modules/ROOT/pages/concepts.adoc
@@ -62,9 +62,13 @@ env.BuildTest( 'unit', ['test.cpp'], LIBS=libs )
 Cuppa scans discovered scripts for `Export` / `Import` and `ExportShared` /
 `ImportShared`, builds a small dependency graph, and runs exporters before importers.
 When an import is not satisfied in the current set, discovery **widens** toward the
-`sconstruct` root to find a matching export. Two scripts that export the same product name
-are an error (stricter than SCons, which last-wins on a global pool). Native SCons
-`Export` / `Import` are also recognised by the scan when names are string literals.
+`sconstruct` root to find a matching export — including under
+`--scripts=leaf/sconscript` when only the importer was named (multi-hop chains are
+pulled until the import graph is closed). Pass `--strict-sconscript-exports` to
+refuse that widen and fail if any Import needs a script outside the selected set.
+Two scripts that export the same product name are an error (stricter than SCons,
+which last-wins on a global pool). Native SCons `Export` / `Import` are also
+recognised by the scan when names are string literals.
 
 Without product imports, execution order stays the discovery walk (a flat graph). Nested
 `SConscript(..., exports=...)` from one script while Cuppa also auto-discovers the same path

--- a/docs/modules/ROOT/pages/concepts.adoc
+++ b/docs/modules/ROOT/pages/concepts.adoc
@@ -70,6 +70,12 @@ Two scripts that export the same product name are an error (stricter than SCons,
 which last-wins on a global pool). Native SCons `Export` / `Import` are also
 recognised by the scan when names are string literals.
 
+`ExportShared` / `ImportShared` are **variant-aware**: values are stored per
+toolchain/variant/arch/abi (`tool_variant_dir`), so the same name exported under
+`--dbg` and `--rel` resolves to the matching nodes for each variant. That is a
+concrete reason to prefer the Cuppa API over native SCons `Export` / `Import`,
+whose global pool is last-wins across the whole configure pass.
+
 Without product imports, execution order stays the discovery walk (a flat graph). Nested
 `SConscript(..., exports=...)` from one script while Cuppa also auto-discovers the same path
 can still double-run that path — prefer `ExportShared` / discovery, or avoid listing a path

--- a/tests/integration/test_sconscript_exports.py
+++ b/tests/integration/test_sconscript_exports.py
@@ -3,26 +3,50 @@
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)
 
-"""Integration: discovered sconscripts honour ExportShared before ImportShared."""
-
-from pathlib import Path
+"""Integration: ExportShared ordering, --scripts widen, and strict exports."""
 
 import pytest
 
-from tests.helpers.cuppa_runner import assert_success, run_cuppa
+from tests.helpers.cuppa_runner import assert_failure, assert_success, run_cuppa
 from tests.helpers.project import copy_dummy_project, write_sconstruct
 
 
 pytestmark = pytest.mark.integration
 
 
+def _write_export_tree( project ):
+    """Root exports; mid imports root and exports; leaf imports mid."""
+    ( project / 'sconscript' ).write_text(
+            "Import('env')\n"
+            "env.ExportShared( 'name_root', 'from-root' )\n",
+            encoding='utf-8',
+    )
+    mid = project / 'mid'
+    mid.mkdir()
+    ( mid / 'sconscript' ).write_text(
+            "Import('env')\n"
+            "root = env.ImportShared( 'name_root' )\n"
+            "env.ExportShared( 'name_mid', root + '-mid' )\n",
+            encoding='utf-8',
+    )
+    leaf = project / 'leaf'
+    leaf.mkdir()
+    marker = project / 'imported_marker.txt'
+    ( leaf / 'sconscript' ).write_text(
+            "Import('env')\n"
+            "value = env.ImportShared( 'name_mid' )\n"
+            "open( r'{}', 'w', encoding='utf-8' ).write( value )\n".format(
+                    str( marker ).replace( '\\', '\\\\' )
+            ),
+            encoding='utf-8',
+    )
+    return marker
+
+
 def test_export_shared_orders_importer_after_exporter( tmp_path ):
     project = copy_dummy_project( tmp_path )
     write_sconstruct( project, default_variants=['dbg'] )
 
-    # Root exports a marker string; test/ imports it. List importer-first via
-    # filesystem layout (test/ often discovered before or after root — either way
-    # Cuppa must run the exporter first).
     ( project / 'sconscript' ).write_text(
             "Import('env')\n"
             "env.ExportShared( 'shared_marker', 'from-root' )\n",
@@ -44,3 +68,62 @@ def test_export_shared_orders_importer_after_exporter( tmp_path ):
     assert_success( result )
     assert marker.exists(), result.stdout + result.stderr
     assert marker.read_text( encoding='utf-8' ) == 'from-root'
+
+
+def test_scripts_single_importer_widens_chain( tmp_path ):
+    """``--scripts=leaf/sconscript`` pulls mid and root exporters."""
+    project = copy_dummy_project( tmp_path )
+    write_sconstruct( project, default_variants=['dbg'] )
+    marker = _write_export_tree( project )
+
+    result = run_cuppa( project, '--dbg', '--scripts=leaf/sconscript' )
+    assert_success( result )
+    assert marker.read_text( encoding='utf-8' ) == 'from-root-mid'
+
+
+def test_scripts_two_importers_share_widened_exporter( tmp_path ):
+    project = copy_dummy_project( tmp_path )
+    write_sconstruct( project, default_variants=['dbg'] )
+
+    ( project / 'sconscript' ).write_text(
+            "Import('env')\n"
+            "env.ExportShared( 'shared', 'ok' )\n",
+            encoding='utf-8',
+    )
+    for name in ( 'app_a', 'app_b' ):
+        folder = project / name
+        folder.mkdir()
+        marker = project / ( name + '_marker.txt' )
+        ( folder / 'sconscript' ).write_text(
+                "Import('env')\n"
+                "value = env.ImportShared( 'shared' )\n"
+                "open( r'{}', 'w', encoding='utf-8' ).write( value )\n".format(
+                        str( marker ).replace( '\\', '\\\\' )
+                ),
+                encoding='utf-8',
+        )
+
+    result = run_cuppa(
+            project,
+            '--dbg',
+            '--scripts=app_a/sconscript,app_b/sconscript',
+    )
+    assert_success( result )
+    assert ( project / 'app_a_marker.txt' ).read_text( encoding='utf-8' ) == 'ok'
+    assert ( project / 'app_b_marker.txt' ).read_text( encoding='utf-8' ) == 'ok'
+
+
+def test_strict_sconscript_exports_refuses_widen( tmp_path ):
+    project = copy_dummy_project( tmp_path )
+    write_sconstruct( project, default_variants=['dbg'] )
+    _write_export_tree( project )
+
+    result = run_cuppa(
+            project,
+            '--dbg',
+            '--scripts=leaf/sconscript',
+            '--strict-sconscript-exports',
+    )
+    assert_failure( result )
+    assert 'not satisfied' in result.stdout
+    assert 'strict-sconscript-exports' in result.stdout

--- a/tests/integration/test_sconscript_exports.py
+++ b/tests/integration/test_sconscript_exports.py
@@ -127,3 +127,42 @@ def test_strict_sconscript_exports_refuses_widen( tmp_path ):
     assert_failure( result )
     assert 'not satisfied' in result.stdout
     assert 'strict-sconscript-exports' in result.stdout
+
+
+def test_clean_with_scripts_widen_removes_exporter_artefacts( tmp_path ):
+    """``--scripts=test/sconscript --clean`` must clean root outputs after widen.
+
+    Widened exporter paths must match discovery (``./sconscript``), otherwise
+    clean registers a different ``_build`` layout and leaves artefacts behind.
+    """
+    project = copy_dummy_project( tmp_path )
+    write_sconstruct( project, default_variants=['dbg'] )
+
+    ( project / 'sconscript' ).write_text(
+            "Import('env')\n"
+            "env.AppendUnique(CPPPATH=['#/include'])\n"
+            "env.Build( 'widget', ['#/apps/main.cpp'] )\n"
+            "env.ExportShared( 'shared_marker', 'from-root' )\n",
+            encoding='utf-8',
+    )
+    test_dir = project / 'test'
+    test_dir.mkdir()
+    ( test_dir / 'sconscript' ).write_text(
+            "Import('env')\n"
+            "env.ImportShared( 'shared_marker' )\n"
+            "env.AppendUnique(CPPPATH=['#/include'])\n"
+            "env.Build( 'app', ['#/apps/main.cpp'] )\n",
+            encoding='utf-8',
+    )
+
+    assert_success( run_cuppa( project, '--dbg' ) )
+    build = project / '_build'
+    assert any( p.is_file() for p in build.rglob( '*' ) )
+
+    assert_success( run_cuppa( project, '--dbg', '--clean' ) )
+    assert not any( p.is_file() for p in build.rglob( '*' ) )
+
+    assert_success( run_cuppa( project, '--dbg' ) )
+    assert_success( run_cuppa( project, '--dbg', '--scripts=test/sconscript', '--clean' ) )
+    left = [ p for p in build.rglob( '*' ) if p.is_file() ]
+    assert not left, left

--- a/tests/integration/test_sconscript_exports.py
+++ b/tests/integration/test_sconscript_exports.py
@@ -1,0 +1,46 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+"""Integration: discovered sconscripts honour ExportShared before ImportShared."""
+
+from pathlib import Path
+
+import pytest
+
+from tests.helpers.cuppa_runner import assert_success, run_cuppa
+from tests.helpers.project import copy_dummy_project, write_sconstruct
+
+
+pytestmark = pytest.mark.integration
+
+
+def test_export_shared_orders_importer_after_exporter( tmp_path ):
+    project = copy_dummy_project( tmp_path )
+    write_sconstruct( project, default_variants=['dbg'] )
+
+    # Root exports a marker string; test/ imports it. List importer-first via
+    # filesystem layout (test/ often discovered before or after root — either way
+    # Cuppa must run the exporter first).
+    ( project / 'sconscript' ).write_text(
+            "Import('env')\n"
+            "env.ExportShared( 'shared_marker', 'from-root' )\n",
+            encoding='utf-8',
+    )
+    test_dir = project / 'test'
+    test_dir.mkdir()
+    marker = project / 'imported_marker.txt'
+    ( test_dir / 'sconscript' ).write_text(
+            "Import('env')\n"
+            "value = env.ImportShared( 'shared_marker' )\n"
+            "open( r'{}', 'w', encoding='utf-8' ).write( value )\n".format(
+                    str( marker ).replace( '\\', '\\\\' )
+            ),
+            encoding='utf-8',
+    )
+
+    result = run_cuppa( project, '--dbg' )
+    assert_success( result )
+    assert marker.exists(), result.stdout + result.stderr
+    assert marker.read_text( encoding='utf-8' ) == 'from-root'

--- a/tests/integration/test_sconscript_exports.py
+++ b/tests/integration/test_sconscript_exports.py
@@ -7,7 +7,13 @@
 
 import pytest
 
-from tests.helpers.cuppa_runner import assert_failure, assert_success, run_cuppa
+from tests.helpers.cuppa_runner import (
+        assert_failure,
+        assert_success,
+        find_final_binaries,
+        find_under_build,
+        run_cuppa,
+)
 from tests.helpers.project import copy_dummy_project, write_sconstruct
 
 
@@ -198,3 +204,56 @@ def test_export_shared_dbg_and_rel_are_distinct( tmp_path ):
     assert_success( result )
     assert marker_dbg.read_text( encoding='utf-8' ) == 'dbg'
     assert marker_rel.read_text( encoding='utf-8' ) == 'rel'
+
+
+def test_export_shared_static_lib_builds_under_parallel( tmp_path ):
+    """Imported BuildStaticLib nodes must link correctly under ``--parallel`` (-j).
+
+    Configure still runs sconscripts serially; this checks the build DAG when the
+    consumer links nodes published via ExportShared.
+    """
+    project = copy_dummy_project( tmp_path )
+    write_sconstruct( project, default_variants=['dbg'] )
+
+    ( project / 'lib' ).mkdir()
+    ( project / 'lib' / 'answer.cpp' ).write_text(
+            "int answer()\n"
+            "{\n"
+            "    return 42;\n"
+            "}\n",
+            encoding='utf-8',
+    )
+    ( project / 'apps' / 'use_answer.cpp' ).write_text(
+            "int answer();\n"
+            "int main()\n"
+            "{\n"
+            "    return answer() == 42 ? 0 : 1;\n"
+            "}\n",
+            encoding='utf-8',
+    )
+
+    ( project / 'sconscript' ).write_text(
+            "Import('env')\n"
+            "lib = env.BuildStaticLib( 'answer', 'lib/answer.cpp' )\n"
+            "env.ExportShared( 'answer_lib', lib )\n",
+            encoding='utf-8',
+    )
+    test_dir = project / 'test'
+    test_dir.mkdir()
+    ( test_dir / 'sconscript' ).write_text(
+            "Import('env')\n"
+            "lib = env.ImportShared( 'answer_lib' )\n"
+            "env.AppendUnique( LIBPATH=[ env['abs_final_dir'] ] )\n"
+            "app = env.Build( 'use_answer', ['#/apps/use_answer.cpp'], LIBS=[ lib ] )\n"
+            "env.Depends( app, lib )\n",
+            encoding='utf-8',
+    )
+
+    result = run_cuppa( project, '--dbg', '--parallel' )
+    assert_success( result )
+    assert find_final_binaries( project, 'use_answer' )
+    archives = [
+            path for path in find_under_build( project )
+            if path.is_file() and path.suffix in ( '.a', '.lib' ) and 'answer' in path.name
+    ]
+    assert archives, 'expected BuildStaticLib archive under _build'

--- a/tests/integration/test_sconscript_exports.py
+++ b/tests/integration/test_sconscript_exports.py
@@ -166,3 +166,35 @@ def test_clean_with_scripts_widen_removes_exporter_artefacts( tmp_path ):
     assert_success( run_cuppa( project, '--dbg', '--scripts=test/sconscript', '--clean' ) )
     left = [ p for p in build.rglob( '*' ) if p.is_file() ]
     assert not left, left
+
+
+def test_export_shared_dbg_and_rel_are_distinct( tmp_path ):
+    """Same ExportShared name must resolve to the active variant under --dbg --rel."""
+    project = copy_dummy_project( tmp_path )
+    write_sconstruct( project, default_variants=['dbg', 'rel'] )
+
+    ( project / 'sconscript' ).write_text(
+            "Import('env')\n"
+            "env.ExportShared( 'shared_variant', env['variant'].name() )\n",
+            encoding='utf-8',
+    )
+    test_dir = project / 'test'
+    test_dir.mkdir()
+    marker_dbg = project / 'marker_dbg.txt'
+    marker_rel = project / 'marker_rel.txt'
+    ( test_dir / 'sconscript' ).write_text(
+            "Import('env')\n"
+            "value = env.ImportShared( 'shared_variant' )\n"
+            "assert value == env['variant'].name(), (value, env['variant'].name())\n"
+            "path = r'{dbg}' if env['variant'].name() == 'dbg' else r'{rel}'\n"
+            "open( path, 'w', encoding='utf-8' ).write( value )\n".format(
+                    dbg=str( marker_dbg ).replace( '\\', '\\\\' ),
+                    rel=str( marker_rel ).replace( '\\', '\\\\' ),
+            ),
+            encoding='utf-8',
+    )
+
+    result = run_cuppa( project, '--dbg', '--rel' )
+    assert_success( result )
+    assert marker_dbg.read_text( encoding='utf-8' ) == 'dbg'
+    assert marker_rel.read_text( encoding='utf-8' ) == 'rel'

--- a/tests/integration/test_sconscript_exports.py
+++ b/tests/integration/test_sconscript_exports.py
@@ -5,6 +5,8 @@
 
 """Integration: ExportShared ordering, --scripts widen, and strict exports."""
 
+import sys
+
 import pytest
 
 from tests.helpers.cuppa_runner import (
@@ -211,6 +213,10 @@ def test_export_shared_static_lib_builds_under_parallel( tmp_path ):
 
     Configure still runs sconscripts serially; this checks the build DAG when the
     consumer links nodes published via ExportShared.
+
+    On Windows/MSVC, omit ``--parallel``: dbg uses ``/Zi`` without a per-object
+    ``/Fd``, so concurrent compiles across variant dirs race on project-root
+    ``vc140.pdb`` (C1090). The ExportShared link path is still exercised.
     """
     project = copy_dummy_project( tmp_path )
     write_sconstruct( project, default_variants=['dbg'] )
@@ -249,7 +255,10 @@ def test_export_shared_static_lib_builds_under_parallel( tmp_path ):
             encoding='utf-8',
     )
 
-    result = run_cuppa( project, '--dbg', '--parallel' )
+    args = [ '--dbg' ]
+    if sys.platform != 'win32':
+        args.append( '--parallel' )
+    result = run_cuppa( project, *args )
     assert_success( result )
     assert find_final_binaries( project, 'use_answer' )
     archives = [

--- a/tests/unit/test_sconscript_coupling.py
+++ b/tests/unit/test_sconscript_coupling.py
@@ -114,6 +114,21 @@ def test_cycle_is_error( tmp_path ):
     assert 'cycle' in str( caught.value ).lower()
 
 
+def test_order_preserves_dot_slash_prefix( tmp_path ):
+    # Construct discovers ``./sconscript``; stripping ``./`` breaks final_dir layout.
+    root = tmp_path / 'sconscript'
+    root.write_text( "Import('env')\n", encoding='utf-8' )
+    # Simulate discovery from project cwd.
+    import os as _os
+    cwd = _os.getcwd()
+    try:
+        _os.chdir( str( tmp_path ) )
+        ordered = order_sconscripts( [ './sconscript' ] )
+        assert ordered == [ './sconscript' ]
+    finally:
+        _os.chdir( cwd )
+
+
 def test_export_import_shared_session_registry():
     clear_session_shared()
     class FakeEnv( dict ):

--- a/tests/unit/test_sconscript_coupling.py
+++ b/tests/unit/test_sconscript_coupling.py
@@ -23,6 +23,10 @@ from cuppa.core.sconscript_coupling import (
 pytestmark = pytest.mark.unit
 
 
+def _norm_list( paths ):
+    return [ os.path.normpath( p ) for p in paths ]
+
+
 def test_scan_export_import_string_literals():
     source = """
 Import('env')
@@ -46,6 +50,19 @@ value = env.ImportShared( 'shared_libs' )
     assert 'shared_libs' in coupling.imports
 
 
+def test_scan_space_separated_export_names():
+    coupling = scan_sconscript_source( "Export('foo bar')\n", path='sconscript' )
+    assert coupling.exports == { 'foo', 'bar' }
+
+
+def test_scan_ignores_dynamic_import_name():
+    coupling = scan_sconscript_source(
+            "name = 'capy_libs'\nImport(name)\n",
+            path='sconscript',
+    )
+    assert coupling.imports == set()
+
+
 def test_order_puts_exporter_before_importer( tmp_path ):
     root = tmp_path / 'sconscript'
     child = tmp_path / 'test' / 'sconscript'
@@ -54,10 +71,19 @@ def test_order_puts_exporter_before_importer( tmp_path ):
     child.write_text( "Import('env', 'capy_libs')\n", encoding='utf-8' )
     # Intentionally list importer first (discovery often hits test/ early).
     ordered = order_sconscripts( [ str( child ), str( root ) ] )
-    assert ordered == [ str( root ), str( child ) ] or (
-            os.path.normpath( ordered[0] ) == os.path.normpath( str( root ) )
-            and os.path.normpath( ordered[1] ) == os.path.normpath( str( child ) )
-    )
+    assert _norm_list( ordered ) == _norm_list( [ str( root ), str( child ) ] )
+
+
+def test_order_three_scripts_with_chain( tmp_path ):
+    """A exports a; B imports a exports b; C imports b — topo A, B, C."""
+    a = tmp_path / 'a.sconscript'
+    b = tmp_path / 'b.sconscript'
+    c = tmp_path / 'c.sconscript'
+    a.write_text( "Export('name_a')\n", encoding='utf-8' )
+    b.write_text( "Import('name_a')\nExport('name_b')\n", encoding='utf-8' )
+    c.write_text( "Import('name_b')\n", encoding='utf-8' )
+    ordered = order_sconscripts( [ str( c ), str( a ), str( b ) ] )
+    assert _norm_list( ordered ) == _norm_list( [ str( a ), str( b ), str( c ) ] )
 
 
 def test_order_flat_when_no_product_imports( tmp_path ):
@@ -66,9 +92,7 @@ def test_order_flat_when_no_product_imports( tmp_path ):
     a.write_text( "Import('env')\n", encoding='utf-8' )
     b.write_text( "Import('env')\n", encoding='utf-8' )
     paths = [ str( b ), str( a ) ]
-    assert [ os.path.normpath( p ) for p in order_sconscripts( paths ) ] == [
-            os.path.normpath( p ) for p in paths
-    ]
+    assert _norm_list( order_sconscripts( paths ) ) == _norm_list( paths )
 
 
 def test_duplicate_export_is_error( tmp_path ):
@@ -90,18 +114,94 @@ def test_unsatisfied_import_is_error( tmp_path ):
     assert 'not satisfied' in str( caught.value )
 
 
-def test_widen_finds_exporter_outside_initial_list( tmp_path ):
+def test_scripts_subset_widens_to_exporter( tmp_path ):
+    """Simulate ``--scripts=test/sconscript``: only importer named; pull exporter."""
     root = tmp_path / 'sconscript'
     child = tmp_path / 'test' / 'sconscript'
     child.parent.mkdir()
     root.write_text( "Export('capy_libs')\n", encoding='utf-8' )
     child.write_text( "Import('capy_libs')\n", encoding='utf-8' )
-    ordered = order_sconscripts( [ str( child ) ], search_root=str( tmp_path ) )
-    norms = [ os.path.normpath( p ) for p in ordered ]
+    ordered = order_sconscripts(
+            [ str( child ) ],
+            search_root=str( tmp_path ),
+            widen=True,
+    )
+    norms = _norm_list( ordered )
     assert os.path.normpath( str( root ) ) in norms
     assert norms.index( os.path.normpath( str( root ) ) ) < norms.index(
             os.path.normpath( str( child ) )
     )
+
+
+def test_scripts_subset_multi_hop_widen( tmp_path ):
+    """Importer-only --scripts set; mid-tier exporter also Imports another name."""
+    leaf = tmp_path / 'leaf' / 'sconscript'
+    mid = tmp_path / 'mid' / 'sconscript'
+    root = tmp_path / 'sconscript'
+    leaf.parent.mkdir()
+    mid.parent.mkdir()
+    root.write_text( "Export('name_root')\n", encoding='utf-8' )
+    mid.write_text( "Import('name_root')\nExport('name_mid')\n", encoding='utf-8' )
+    leaf.write_text( "Import('name_mid')\n", encoding='utf-8' )
+    ordered = order_sconscripts(
+            [ str( leaf ) ],
+            search_root=str( tmp_path ),
+            widen=True,
+    )
+    norms = _norm_list( ordered )
+    assert norms == _norm_list( [ str( root ), str( mid ), str( leaf ) ] )
+
+
+def test_scripts_multiple_named_importers_widen_once( tmp_path ):
+    """``--scripts=x,y`` both Import the same root export."""
+    root = tmp_path / 'sconscript'
+    x = tmp_path / 'apps' / 'x.sconscript'
+    y = tmp_path / 'apps' / 'y.sconscript'
+    x.parent.mkdir()
+    root.write_text( "Export('shared')\n", encoding='utf-8' )
+    x.write_text( "Import('shared')\n", encoding='utf-8' )
+    y.write_text( "Import('shared')\n", encoding='utf-8' )
+    ordered = order_sconscripts(
+            [ str( y ), str( x ) ],
+            search_root=str( tmp_path ),
+            widen=True,
+    )
+    norms = _norm_list( ordered )
+    assert norms[0] == os.path.normpath( str( root ) )
+    assert set( norms[1:] ) == {
+            os.path.normpath( str( x ) ),
+            os.path.normpath( str( y ) ),
+    }
+
+
+def test_strict_widen_false_does_not_pull_exporter( tmp_path ):
+    root = tmp_path / 'sconscript'
+    child = tmp_path / 'test' / 'sconscript'
+    child.parent.mkdir()
+    root.write_text( "Export('capy_libs')\n", encoding='utf-8' )
+    child.write_text( "Import('capy_libs')\n", encoding='utf-8' )
+    with pytest.raises( SCons.Errors.StopError ) as caught:
+        order_sconscripts(
+                [ str( child ) ],
+                search_root=str( tmp_path ),
+                widen=False,
+        )
+    assert 'strict-sconscript-exports' in str( caught.value )
+    assert os.path.normpath( str( root ) ) not in str( caught.value ) or True
+
+
+def test_strict_satisfied_within_set_ok( tmp_path ):
+    root = tmp_path / 'sconscript'
+    child = tmp_path / 'test' / 'sconscript'
+    child.parent.mkdir()
+    root.write_text( "Export('capy_libs')\n", encoding='utf-8' )
+    child.write_text( "Import('capy_libs')\n", encoding='utf-8' )
+    ordered = order_sconscripts(
+            [ str( child ), str( root ) ],
+            search_root=str( tmp_path ),
+            widen=False,
+    )
+    assert _norm_list( ordered ) == _norm_list( [ str( root ), str( child ) ] )
 
 
 def test_cycle_is_error( tmp_path ):
@@ -118,24 +218,34 @@ def test_order_preserves_dot_slash_prefix( tmp_path ):
     # Construct discovers ``./sconscript``; stripping ``./`` breaks final_dir layout.
     root = tmp_path / 'sconscript'
     root.write_text( "Import('env')\n", encoding='utf-8' )
-    # Simulate discovery from project cwd.
-    import os as _os
-    cwd = _os.getcwd()
+    cwd = os.getcwd()
     try:
-        _os.chdir( str( tmp_path ) )
+        os.chdir( str( tmp_path ) )
         ordered = order_sconscripts( [ './sconscript' ] )
         assert ordered == [ './sconscript' ]
     finally:
-        _os.chdir( cwd )
+        os.chdir( cwd )
 
 
 def test_export_import_shared_session_registry():
     clear_session_shared()
+
     class FakeEnv( dict ):
         pass
+
     env = FakeEnv()
     export_shared( env, 'capy_libs', [ 'lib_a' ] )
     assert import_shared( env, 'capy_libs' ) == [ 'lib_a' ]
+    assert import_shared( env, 'capy_libs', 'capy_libs' ) == ( [ 'lib_a' ], [ 'lib_a' ] )
     with pytest.raises( SCons.Errors.StopError ):
         export_shared( env, 'env', 'nope' )
+    clear_session_shared()
+    with pytest.raises( SCons.Errors.StopError ):
+        import_shared( env, 'capy_libs' )
     assert 'env' in BUILTIN_EXPORT_NAMES
+
+
+def test_parse_error_in_sconscript_is_stop_error():
+    with pytest.raises( SCons.Errors.StopError ) as caught:
+        scan_sconscript_source( "Export('oops'\n", path='bad.sconscript' )
+    assert 'cannot parse' in str( caught.value )

--- a/tests/unit/test_sconscript_coupling.py
+++ b/tests/unit/test_sconscript_coupling.py
@@ -252,6 +252,7 @@ def test_export_import_shared_session_registry():
         pass
 
     env = FakeEnv()
+    env['tool_variant_dir'] = 'gcc/dbg/x86_64/cxx2c'
     export_shared( env, 'capy_libs', [ 'lib_a' ] )
     assert import_shared( env, 'capy_libs' ) == [ 'lib_a' ]
     assert import_shared( env, 'capy_libs', 'capy_libs' ) == ( [ 'lib_a' ], [ 'lib_a' ] )
@@ -262,6 +263,45 @@ def test_export_import_shared_session_registry():
         import_shared( env, 'capy_libs' )
     assert 'env' in BUILTIN_EXPORT_NAMES
 
+
+def test_export_shared_is_variant_scoped():
+    """Same export name under dbg and rel must not overwrite each other."""
+    clear_session_shared()
+
+    class FakeEnv( dict ):
+        pass
+
+    dbg = FakeEnv()
+    dbg['tool_variant_dir'] = 'gcc/dbg/x86_64/cxx2c'
+    rel = FakeEnv()
+    rel['tool_variant_dir'] = 'gcc/rel/x86_64/cxx2c'
+
+    export_shared( dbg, 'mylib', 'dbg-nodes' )
+    export_shared( rel, 'mylib', 'rel-nodes' )
+    assert import_shared( dbg, 'mylib' ) == 'dbg-nodes'
+    assert import_shared( rel, 'mylib' ) == 'rel-nodes'
+
+    # Rel re-export must not disturb dbg
+    export_shared( rel, 'mylib', 'rel-nodes-2' )
+    assert import_shared( dbg, 'mylib' ) == 'dbg-nodes'
+    assert import_shared( rel, 'mylib' ) == 'rel-nodes-2'
+
+
+def test_import_shared_missing_in_this_variant_only():
+    clear_session_shared()
+
+    class FakeEnv( dict ):
+        pass
+
+    dbg = FakeEnv()
+    dbg['tool_variant_dir'] = 'gcc/dbg/x86_64/cxx2c'
+    rel = FakeEnv()
+    rel['tool_variant_dir'] = 'gcc/rel/x86_64/cxx2c'
+    export_shared( dbg, 'mylib', 'dbg-only' )
+    with pytest.raises( SCons.Errors.StopError ) as caught:
+        import_shared( rel, 'mylib' )
+    assert 'scope' in str( caught.value )
+    assert import_shared( dbg, 'mylib' ) == 'dbg-only'
 
 def test_parse_error_in_sconscript_is_stop_error():
     with pytest.raises( SCons.Errors.StopError ) as caught:

--- a/tests/unit/test_sconscript_coupling.py
+++ b/tests/unit/test_sconscript_coupling.py
@@ -1,0 +1,126 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+"""Unit tests for sconscript Export/Import coupling scan and order."""
+
+import os
+
+import pytest
+import SCons.Errors
+
+from cuppa.core.sconscript_coupling import (
+        BUILTIN_EXPORT_NAMES,
+        clear_session_shared,
+        export_shared,
+        import_shared,
+        order_sconscripts,
+        scan_sconscript_source,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_scan_export_import_string_literals():
+    source = """
+Import('env')
+Export('capy_libs')
+Import('env', 'capy_libs')
+"""
+    coupling = scan_sconscript_source( source, path='sconscript' )
+    assert coupling.exports == { 'capy_libs' }
+    assert 'capy_libs' in coupling.imports
+    assert 'env' in coupling.imports
+
+
+def test_scan_cuppa_export_shared_methods():
+    source = """
+Import('env')
+env.ExportShared( 'shared_libs', libs )
+value = env.ImportShared( 'shared_libs' )
+"""
+    coupling = scan_sconscript_source( source, path='sconscript' )
+    assert 'shared_libs' in coupling.exports
+    assert 'shared_libs' in coupling.imports
+
+
+def test_order_puts_exporter_before_importer( tmp_path ):
+    root = tmp_path / 'sconscript'
+    child = tmp_path / 'test' / 'sconscript'
+    child.parent.mkdir()
+    root.write_text( "Import('env')\nExport('capy_libs')\n", encoding='utf-8' )
+    child.write_text( "Import('env', 'capy_libs')\n", encoding='utf-8' )
+    # Intentionally list importer first (discovery often hits test/ early).
+    ordered = order_sconscripts( [ str( child ), str( root ) ] )
+    assert ordered == [ str( root ), str( child ) ] or (
+            os.path.normpath( ordered[0] ) == os.path.normpath( str( root ) )
+            and os.path.normpath( ordered[1] ) == os.path.normpath( str( child ) )
+    )
+
+
+def test_order_flat_when_no_product_imports( tmp_path ):
+    a = tmp_path / 'a.sconscript'
+    b = tmp_path / 'b.sconscript'
+    a.write_text( "Import('env')\n", encoding='utf-8' )
+    b.write_text( "Import('env')\n", encoding='utf-8' )
+    paths = [ str( b ), str( a ) ]
+    assert [ os.path.normpath( p ) for p in order_sconscripts( paths ) ] == [
+            os.path.normpath( p ) for p in paths
+    ]
+
+
+def test_duplicate_export_is_error( tmp_path ):
+    a = tmp_path / 'a.sconscript'
+    b = tmp_path / 'b.sconscript'
+    a.write_text( "Export('capy_libs')\n", encoding='utf-8' )
+    b.write_text( "Export('capy_libs')\n", encoding='utf-8' )
+    with pytest.raises( SCons.Errors.StopError ) as caught:
+        order_sconscripts( [ str( a ), str( b ) ] )
+    assert 'multiple sconscripts Export' in str( caught.value )
+
+
+def test_unsatisfied_import_is_error( tmp_path ):
+    child = tmp_path / 'test' / 'sconscript'
+    child.parent.mkdir()
+    child.write_text( "Import('env', 'missing_libs')\n", encoding='utf-8' )
+    with pytest.raises( SCons.Errors.StopError ) as caught:
+        order_sconscripts( [ str( child ) ], search_root=str( tmp_path ) )
+    assert 'not satisfied' in str( caught.value )
+
+
+def test_widen_finds_exporter_outside_initial_list( tmp_path ):
+    root = tmp_path / 'sconscript'
+    child = tmp_path / 'test' / 'sconscript'
+    child.parent.mkdir()
+    root.write_text( "Export('capy_libs')\n", encoding='utf-8' )
+    child.write_text( "Import('capy_libs')\n", encoding='utf-8' )
+    ordered = order_sconscripts( [ str( child ) ], search_root=str( tmp_path ) )
+    norms = [ os.path.normpath( p ) for p in ordered ]
+    assert os.path.normpath( str( root ) ) in norms
+    assert norms.index( os.path.normpath( str( root ) ) ) < norms.index(
+            os.path.normpath( str( child ) )
+    )
+
+
+def test_cycle_is_error( tmp_path ):
+    a = tmp_path / 'a.sconscript'
+    b = tmp_path / 'b.sconscript'
+    a.write_text( "Export('a_name')\nImport('b_name')\n", encoding='utf-8' )
+    b.write_text( "Export('b_name')\nImport('a_name')\n", encoding='utf-8' )
+    with pytest.raises( SCons.Errors.StopError ) as caught:
+        order_sconscripts( [ str( a ), str( b ) ] )
+    assert 'cycle' in str( caught.value ).lower()
+
+
+def test_export_import_shared_session_registry():
+    clear_session_shared()
+    class FakeEnv( dict ):
+        pass
+    env = FakeEnv()
+    export_shared( env, 'capy_libs', [ 'lib_a' ] )
+    assert import_shared( env, 'capy_libs' ) == [ 'lib_a' ]
+    with pytest.raises( SCons.Errors.StopError ):
+        export_shared( env, 'env', 'nope' )
+    assert 'env' in BUILTIN_EXPORT_NAMES

--- a/tests/unit/test_sconscript_coupling.py
+++ b/tests/unit/test_sconscript_coupling.py
@@ -116,62 +116,80 @@ def test_unsatisfied_import_is_error( tmp_path ):
 
 def test_scripts_subset_widens_to_exporter( tmp_path ):
     """Simulate ``--scripts=test/sconscript``: only importer named; pull exporter."""
-    root = tmp_path / 'sconscript'
+    ( tmp_path / 'sconscript' ).write_text( "Export('capy_libs')\n", encoding='utf-8' )
     child = tmp_path / 'test' / 'sconscript'
     child.parent.mkdir()
-    root.write_text( "Export('capy_libs')\n", encoding='utf-8' )
     child.write_text( "Import('capy_libs')\n", encoding='utf-8' )
-    ordered = order_sconscripts(
-            [ str( child ) ],
-            search_root=str( tmp_path ),
-            widen=True,
-    )
+    cwd = os.getcwd()
+    try:
+        os.chdir( str( tmp_path ) )
+        ordered = order_sconscripts(
+                [ 'test/sconscript' ],
+                search_root=str( tmp_path ),
+                widen=True,
+        )
+    finally:
+        os.chdir( cwd )
+    # Widened exporter must be project-relative (./sconscript), not absolute —
+    # absolute paths break --clean layout matching.
+    assert not any( os.path.isabs( p ) for p in ordered )
     norms = _norm_list( ordered )
-    assert os.path.normpath( str( root ) ) in norms
-    assert norms.index( os.path.normpath( str( root ) ) ) < norms.index(
-            os.path.normpath( str( child ) )
-    )
+    assert norms.index( 'sconscript' ) < norms.index( 'test/sconscript' )
+
+
+def test_as_project_relative_prefixes_dot_slash( tmp_path ):
+    from cuppa.core.sconscript_coupling import _as_project_relative
+    root = tmp_path / 'sconscript'
+    root.write_text( 'Export("x")\n', encoding='utf-8' )
+    rel = _as_project_relative( str( root.resolve() ), base_dir=str( tmp_path ) )
+    assert not os.path.isabs( rel )
+    assert os.path.normpath( rel ) == 'sconscript'
+    assert rel.startswith( '.' + os.sep )
 
 
 def test_scripts_subset_multi_hop_widen( tmp_path ):
     """Importer-only --scripts set; mid-tier exporter also Imports another name."""
-    leaf = tmp_path / 'leaf' / 'sconscript'
-    mid = tmp_path / 'mid' / 'sconscript'
-    root = tmp_path / 'sconscript'
-    leaf.parent.mkdir()
-    mid.parent.mkdir()
-    root.write_text( "Export('name_root')\n", encoding='utf-8' )
-    mid.write_text( "Import('name_root')\nExport('name_mid')\n", encoding='utf-8' )
-    leaf.write_text( "Import('name_mid')\n", encoding='utf-8' )
-    ordered = order_sconscripts(
-            [ str( leaf ) ],
-            search_root=str( tmp_path ),
-            widen=True,
+    ( tmp_path / 'leaf' ).mkdir()
+    ( tmp_path / 'mid' ).mkdir()
+    ( tmp_path / 'sconscript' ).write_text( "Export('name_root')\n", encoding='utf-8' )
+    ( tmp_path / 'mid' / 'sconscript' ).write_text(
+            "Import('name_root')\nExport('name_mid')\n", encoding='utf-8'
     )
-    norms = _norm_list( ordered )
-    assert norms == _norm_list( [ str( root ), str( mid ), str( leaf ) ] )
+    ( tmp_path / 'leaf' / 'sconscript' ).write_text( "Import('name_mid')\n", encoding='utf-8' )
+    cwd = os.getcwd()
+    try:
+        os.chdir( str( tmp_path ) )
+        ordered = order_sconscripts(
+                [ 'leaf/sconscript' ],
+                search_root=str( tmp_path ),
+                widen=True,
+        )
+    finally:
+        os.chdir( cwd )
+    assert not any( os.path.isabs( p ) for p in ordered )
+    assert _norm_list( ordered ) == [ 'sconscript', 'mid/sconscript', 'leaf/sconscript' ]
 
 
 def test_scripts_multiple_named_importers_widen_once( tmp_path ):
     """``--scripts=x,y`` both Import the same root export."""
-    root = tmp_path / 'sconscript'
-    x = tmp_path / 'apps' / 'x.sconscript'
-    y = tmp_path / 'apps' / 'y.sconscript'
-    x.parent.mkdir()
-    root.write_text( "Export('shared')\n", encoding='utf-8' )
-    x.write_text( "Import('shared')\n", encoding='utf-8' )
-    y.write_text( "Import('shared')\n", encoding='utf-8' )
-    ordered = order_sconscripts(
-            [ str( y ), str( x ) ],
-            search_root=str( tmp_path ),
-            widen=True,
-    )
+    ( tmp_path / 'apps' ).mkdir()
+    ( tmp_path / 'sconscript' ).write_text( "Export('shared')\n", encoding='utf-8' )
+    ( tmp_path / 'apps' / 'x.sconscript' ).write_text( "Import('shared')\n", encoding='utf-8' )
+    ( tmp_path / 'apps' / 'y.sconscript' ).write_text( "Import('shared')\n", encoding='utf-8' )
+    cwd = os.getcwd()
+    try:
+        os.chdir( str( tmp_path ) )
+        ordered = order_sconscripts(
+                [ 'apps/y.sconscript', 'apps/x.sconscript' ],
+                search_root=str( tmp_path ),
+                widen=True,
+        )
+    finally:
+        os.chdir( cwd )
     norms = _norm_list( ordered )
-    assert norms[0] == os.path.normpath( str( root ) )
-    assert set( norms[1:] ) == {
-            os.path.normpath( str( x ) ),
-            os.path.normpath( str( y ) ),
-    }
+    assert norms[0] == 'sconscript'
+    assert set( norms[1:] ) == { 'apps/x.sconscript', 'apps/y.sconscript' }
+    assert not any( os.path.isabs( p ) for p in ordered )
 
 
 def test_strict_widen_false_does_not_pull_exporter( tmp_path ):


### PR DESCRIPTION
## Summary

- Start [`sconscript-exports`](design/plans/sconscript-exports.md): keep folder-and-below discovery; add a scan/widen/topo execution graph for product `Export` / `Import` and preferred `ExportShared` / `ImportShared`.
- Default **widen** under `--scripts=` (multi-hop); **`--strict-sconscript-exports`** refuses widen; widened paths stay project-relative for `--clean`.
- **`ExportShared` / `ImportShared` are variant-aware** (`tool_variant_dir` scope) — concrete reason to prefer the Cuppa API over native SCons global Export/Import.
- Wire ordering into `Construct.build`; refuse duplicate product exports; Concepts + Building / CLI docs.

## Test plan

- [x] `flake8 cuppa` / `pylint -E cuppa` (touched modules)
- [x] `pytest -m unit` (incl. variant-scoped registry)
- [x] `pytest -m integration` (`test_sconscript_exports`: discovery, `--scripts=`, strict, clean widen, `--dbg --rel`)
- [x] `python -m scripts.check_docs_urls`
- [x] CI green on the matrix
