### PR TITLE
Dedupe nested SConscript under discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   name under ``--dbg`` / ``--rel`` resolves correctly — a concrete reason to prefer the
   Cuppa API over native SCons ``Export`` / ``Import``. Concepts and Building CLI docs
   cover discovery vs sharing ([`sconscript-exports`](design/plans/sconscript-exports.md)).
+- Sconscript discovery **dedupe**: when a discovered script nests another via string-literal
+  ``SConscript(...)``, Cuppa omits that child from the outer discovery invoke list (and skips
+  a path already evaluated by a live nested call for the same toolchain/variant). Stops the
+  classic double-run that broke parent ``exports=`` under folder-and-below discovery
+  ([`sconscript-exports`](design/plans/sconscript-exports.md) ``scons-export-dedupe``).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a path already evaluated by a live nested call for the same toolchain/variant). Stops the
   classic double-run that broke parent ``exports=`` under folder-and-below discovery
   ([`sconscript-exports`](design/plans/sconscript-exports.md) ``scons-export-dedupe``).
+  Method index and Methods hub list ``ExportShared()`` / ``ImportShared()`` and native
+  ``Export()`` / ``Import()`` / ``SConscript()`` with Concepts cross-links.
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@ Minor cycle after **1.10.0**. Prefer work that changes opt-in toolchain or packa
 |------|------------------|
 | `cuppa.run` default_dependencies objects | [`run-default-dependency-objects.md`](design/plans/run-default-dependency-objects.md) — objects in both lists; teach register vs auto-apply; optional clearer names later |
 | Transitive GitLab packages | [`gitlab-package-transitive.md`](design/plans/gitlab-package-transitive.md) — `cuppa-dependency.json` + `--list-dependencies` `requires` (shipped #280 / #281; #279 follow-ons deferred) |
-| Sconscript exports / sharing | [`sconscript-exports.md`](design/plans/sconscript-exports.md) — discovery stays; Import/Export graph + `ExportShared` (in progress) |
+| Sconscript exports / sharing | [`sconscript-exports.md`](design/plans/sconscript-exports.md) — discovery + `ExportShared`; dedupe nested `SConscript` (in progress; #282 spike shipped) |
 | GitLab CMake staging | [#209](https://github.com/ja11sop/cuppa/issues/209) |
 | Artefact removal design | [#135](https://github.com/ja11sop/cuppa/issues/135) |
 | Console bundle | `--terse-output`, log hygiene, `cuppa --info` |
@@ -582,7 +582,7 @@ Design: [#213](https://github.com/ja11sop/cuppa/issues/213) (compile object path
 | ID | Work | Priority | Notes |
 |----|------|----------|-------|
 | `compile-object-paths` | Mirror source tree under `working/` for `Compile` | — | **Shipped 1.8.1** — [#213](https://github.com/ja11sop/cuppa/issues/213) / [#214](https://github.com/ja11sop/cuppa/pull/214) |
-| `sconscript-exports` | Discovery + Import/Export execution graph; `ExportShared` / `ImportShared` | Medium | [`sconscript-exports.md`](design/plans/sconscript-exports.md) — spike in progress |
+| `sconscript-exports` | Discovery + Import/Export execution graph; `ExportShared` / `ImportShared`; nested `SConscript` dedupe | Medium | [`sconscript-exports.md`](design/plans/sconscript-exports.md) — spike #282; dedupe in flight |
 | `cmake-to-cuppa-migration` | Antora matrix + phased tutorial + agent checklist | Medium | Compile-path fix shipped — [`cmake-to-cuppa-migration.md`](design/plans/cmake-to-cuppa-migration.md) |
 | `static-glob` | RecursiveGlob (disk + `Dir.entries` + full Repository); GlobFiles; Filter path parity | — | **Shipped** — [#232](https://github.com/ja11sop/cuppa/issues/232) / [#231](https://github.com/ja11sop/cuppa/pull/231), [`recursive-glob-parity.md`](design/archive/recursive-glob-parity.md); follow-on [`path-vocabulary-and-scons-nodes.md`](design/plans/path-vocabulary-and-scons-nodes.md) |
 

--- a/cuppa/construct.py
+++ b/cuppa/construct.py
@@ -984,7 +984,10 @@ class Construct(object):
                     sconscripts.append( project )
 
             cuppa.core.sconscript_coupling.clear_session_shared()
+            cuppa.core.sconscript_coupling.clear_invoked_sconscripts()
+            cuppa.core.sconscript_coupling.install_sconscript_dedupe_wrapper()
             search_root = cuppa_env.get( 'sconstruct_dir' ) or cuppa_env.get( 'launch_dir' )
+            cuppa.core.sconscript_coupling.set_dedupe_project_root( search_root )
             widen = not bool( cuppa_env.get_option( 'strict_sconscript_exports' ) )
             try:
                 sconscripts = cuppa.core.sconscript_coupling.order_sconscripts(
@@ -1059,6 +1062,18 @@ class Construct(object):
             sconscript_env['tool_variant_dir'] = cuppa.core.build_layout.tool_variant_dir(
                     toolchain.name(), variant, target_arch, abi
             )
+            invoke_scope = cuppa.core.sconscript_coupling.shared_export_scope( sconscript_env )
+            if cuppa.core.sconscript_coupling.was_sconscript_invoked(
+                    sconscript_file, scope=invoke_scope
+            ):
+                logger.info(
+                        "Skipping sconscript [{}] — already invoked "
+                        "(nested SConscript or prior discovery) for [{}]".format(
+                                as_notice( sconscript_file ),
+                                as_notice( invoke_scope ),
+                        )
+                )
+                return
             sconscript_env['package_tool_variant_dir'] = os.path.join( toolchain.package_name(), variant, target_arch, abi )
             sconscript_env['tool_variant_working_dir'] = os.path.join( sconscript_env['tool_variant_dir'], working_folder )
 
@@ -1124,12 +1139,19 @@ class Construct(object):
                 dump = sconscript_env.Dump()
                 logger.info( "\n" + dump + "\n" )
             else:
-                SCons.Script.SConscript(
-                    [ sconscript_file ],
-                    variant_dir = sconscript_exports['build_dir'],
-                    duplicate   = 0,
-                    exports     = sconscript_exports
-                )
+                cuppa.core.sconscript_coupling.push_invoke_scope( invoke_scope )
+                try:
+                    SCons.Script.SConscript(
+                        [ sconscript_file ],
+                        variant_dir = sconscript_exports['build_dir'],
+                        duplicate   = 0,
+                        exports     = sconscript_exports
+                    )
+                    cuppa.core.sconscript_coupling.mark_sconscript_invoked(
+                            sconscript_file, scope=invoke_scope
+                    )
+                finally:
+                    cuppa.core.sconscript_coupling.pop_invoke_scope()
 
         else:
             logger.error( "Skipping non-existent project [{}] using [{},{},{}]".format(

--- a/cuppa/core/sconscript_coupling.py
+++ b/cuppa/core/sconscript_coupling.py
@@ -47,14 +47,16 @@ _CUPPA_IMPORT_METHODS = frozenset( { 'ImportShared', 'import_shared' } )
 
 
 class ScriptCoupling( object ):
-    """Exports and imports found in one sconscript file."""
+    """Exports, imports, and nested ``SConscript`` targets found in one file."""
 
-    __slots__ = ( 'path', 'exports', 'imports' )
+    __slots__ = ( 'path', 'exports', 'imports', 'nested' )
 
-    def __init__( self, path, exports=None, imports=None ):
+    def __init__( self, path, exports=None, imports=None, nested=None ):
         self.path = path
         self.exports = set( exports or () )
         self.imports = set( imports or () )
+        # Relative path strings passed to ``SConscript(...)`` (first arg), as written.
+        self.nested = set( nested or () )
 
 
 def _string_names_from_ast_value( node ):
@@ -88,11 +90,44 @@ def _method_name( node ):
     return None
 
 
+def _is_sconscript_call( func ):
+    """True for ``SConscript(...)`` or ``….SConscript(...)``."""
+    if _is_name( func, 'SConscript' ):
+        return True
+    return _method_name( func ) == 'SConscript'
+
+
+def _string_from_ast( node ):
+    if isinstance( node, ast.Constant ) and isinstance( node.value, str ):
+        return node.value
+    if hasattr( ast, 'Str' ) and isinstance( node, ast.Str ):  # pragma: no cover
+        return node.s
+    return None
+
+
+def _sconscript_target_strings( call_node ):
+    """Yield string-literal script paths from the first positional ``SConscript`` arg."""
+    if not call_node.args:
+        return
+    first = call_node.args[0]
+    text = _string_from_ast( first )
+    if text is not None:
+        yield text
+        return
+    if isinstance( first, ( ast.List, ast.Tuple ) ):
+        for elt in first.elts:
+            text = _string_from_ast( elt )
+            if text is not None:
+                yield text
+
+
 def scan_sconscript_source( source, path='<sconscript>' ):
     """Parse *source* and return :class:`ScriptCoupling` for string-literal names.
 
     Dynamic ``Import(variable)`` forms are ignored (spike bound). ``Import('*')``
     is recorded as the literal name ``*`` so callers can treat it specially.
+    Literal ``SConscript('…')`` / ``SConscript(['…'])`` targets are recorded in
+    ``nested`` so discovery can avoid double-running those paths.
     """
     try:
         tree = ast.parse( source, filename=path )
@@ -105,11 +140,15 @@ def scan_sconscript_source( source, path='<sconscript>' ):
 
     exports = set()
     imports = set()
+    nested = set()
 
     for node in ast.walk( tree ):
         if not isinstance( node, ast.Call ):
             continue
         func = node.func
+        if _is_sconscript_call( func ):
+            nested.update( _sconscript_target_strings( node ) )
+            continue
         names = _names_from_call_args( node.args )
         if not names:
             continue
@@ -124,7 +163,7 @@ def scan_sconscript_source( source, path='<sconscript>' ):
             elif method in _CUPPA_IMPORT_METHODS:
                 imports.update( names )
 
-    return ScriptCoupling( path, exports=exports, imports=imports )
+    return ScriptCoupling( path, exports=exports, imports=imports, nested=nested )
 
 
 def scan_sconscript_file( path ):
@@ -160,6 +199,65 @@ def _as_project_relative( path, base_dir=None ):
     if not rel.startswith( '.' + os.sep ) and rel != '.':
         rel = os.path.join( '.', rel )
     return rel
+
+
+def resolve_nested_sconscript_target( caller_path, target, base_dir=None ):
+    """Resolve a ``SConscript('target')`` string relative to the calling script.
+
+    Returns a project-relative path (``./…``) when possible so it can match
+    discovered sconscript entries.
+    """
+    if os.path.isabs( target ):
+        return _as_project_relative( target, base_dir=base_dir )
+    caller_dir = os.path.dirname( caller_path )
+    if not caller_dir:
+        caller_dir = '.'
+    joined = os.path.normpath( os.path.join( caller_dir, target ) )
+    return _as_project_relative( joined, base_dir=base_dir )
+
+
+def nested_targets_in_set( paths, couplings_by_norm, base_dir=None ):
+    """Return normpaths of *paths* that another script in the set will ``SConscript``.
+
+    Used to drop those paths from Cuppa's outer discovery invoke list so the
+    nested call (with the parent's ``exports=``) is the only evaluation.
+    """
+    path_norms = { _norm_path( p ) for p in paths }
+    nested = set()
+    for path in paths:
+        coupling = couplings_by_norm.get( _norm_path( path ) )
+        if coupling is None:
+            continue
+        for target in coupling.nested:
+            resolved = resolve_nested_sconscript_target( path, target, base_dir=base_dir )
+            resolved_norm = _norm_path( resolved )
+            if resolved_norm in path_norms:
+                nested.add( resolved_norm )
+            # SCons accepts a directory meaning ``…/SConscript`` / ``…/sconscript``.
+            for suffix in ( 'sconscript', 'SConscript' ):
+                as_file = _norm_path( os.path.join( resolved, suffix ) )
+                if as_file in path_norms:
+                    nested.add( as_file )
+    return nested
+
+
+def exclude_nested_sconscripts( paths, couplings_by_norm, base_dir=None ):
+    """Filter *paths* so scripts nested by another entry are not invoked twice."""
+    if not paths:
+        return paths
+    nested_norms = nested_targets_in_set( paths, couplings_by_norm, base_dir=base_dir )
+    if not nested_norms:
+        return paths
+    kept = []
+    for path in paths:
+        if _norm_path( path ) in nested_norms:
+            logger.info(
+                    "Skipping discovery invoke for [{}] — nested via SConscript "
+                    "from another sconscript in this set".format( as_notice( path ) )
+            )
+            continue
+        kept.append( path )
+    return kept
 
 
 def _discover_sconscripts_under( root ):
@@ -359,17 +457,20 @@ def order_sconscripts( paths, search_root=None, widen=True ):
 
     norm_paths = [ _norm_path( p ) for p in unique ]
     if not edges:
-        return unique
+        ordered = unique
+    else:
+        ordered_norms = _topo_order( norm_paths, edges )
+        ordered = [ _original( n ) for n in ordered_norms ]
+        if ordered != unique:
+            logger.debug(
+                    "Sconscript Export/Import order [{}]".format(
+                            as_notice( ", ".join( ordered ) )
+                    )
+            )
 
-    ordered_norms = _topo_order( norm_paths, edges )
-    ordered = [ _original( n ) for n in ordered_norms ]
-    if ordered != unique:
-        logger.debug(
-                "Sconscript Export/Import order [{}]".format(
-                        as_notice( ", ".join( ordered ) )
-                )
-        )
-    return ordered
+    # Drop paths another script in this set will nest via SConscript(...), so
+    # discovery does not evaluate them a second time without the parent's exports.
+    return exclude_nested_sconscripts( ordered, couplings )
 
 
 # Session registry for Cuppa ``ExportShared`` / ``ImportShared``.
@@ -377,6 +478,14 @@ def order_sconscripts( paths, search_root=None, widen=True ):
 # exports of the same name do not overwrite each other. This is a primary reason
 # the Cuppa API exists above native SCons Export/Import (global last-wins pool).
 _session_shared = {}
+
+# Paths already evaluated for a given invoke scope (tool_variant_dir). Used so a
+# dynamic ``SConscript(...)`` that the static scan missed still suppresses a
+# second Cuppa discovery invoke for the same path.
+_invoked_sconscripts = set()
+_invoke_scope_stack = []
+_original_sconscript = None
+_dedupe_project_root = None
 
 
 def shared_export_scope( env ):
@@ -405,6 +514,117 @@ def shared_export_scope( env ):
 def clear_session_shared():
     """Reset all Cuppa shared exports (call once per ``Construct.build``)."""
     _session_shared.clear()
+
+
+def clear_invoked_sconscripts():
+    """Reset the per-build invoked-path registry (call once per ``Construct.build``)."""
+    global _dedupe_project_root
+    _invoked_sconscripts.clear()
+    _invoke_scope_stack[:] = []
+    _dedupe_project_root = None
+
+
+def set_dedupe_project_root( root ):
+    """Project root used to resolve nested ``SConscript`` targets for dedupe."""
+    global _dedupe_project_root
+    _dedupe_project_root = root
+
+
+def push_invoke_scope( scope ):
+    _invoke_scope_stack.append( scope )
+
+
+def pop_invoke_scope():
+    if _invoke_scope_stack:
+        _invoke_scope_stack.pop()
+
+
+def current_invoke_scope():
+    if _invoke_scope_stack:
+        return _invoke_scope_stack[-1]
+    return ''
+
+
+def mark_sconscript_invoked( path, scope=None ):
+    """Record that *path* has been evaluated for *scope* (default: current)."""
+    if scope is None:
+        scope = current_invoke_scope()
+    _invoked_sconscripts.add( ( scope, _norm_path( path ) ) )
+
+
+def was_sconscript_invoked( path, scope=None ):
+    """True if *path* was already evaluated for *scope* this build."""
+    if scope is None:
+        scope = current_invoke_scope()
+    return ( scope, _norm_path( path ) ) in _invoked_sconscripts
+
+
+def _paths_from_sconscript_call_args( args, kwargs ):
+    """Best-effort extract of script path strings from a live ``SConscript`` call."""
+    targets = []
+    if args:
+        first = args[0]
+        if isinstance( first, str ):
+            targets.append( first )
+        elif isinstance( first, ( list, tuple ) ):
+            targets.extend( part for part in first if isinstance( part, str ) )
+    for key in ( 'dirs', 'name' ):
+        value = kwargs.get( key )
+        if isinstance( value, str ):
+            targets.append( value )
+        elif isinstance( value, ( list, tuple ) ):
+            targets.extend( part for part in value if isinstance( part, str ) )
+    return targets
+
+
+def _mark_live_sconscript_target( target, scope ):
+    """Mark a live ``SConscript`` target using the project root, not VariantDir cwd."""
+    root = _dedupe_project_root or os.getcwd()
+    candidates = []
+    if os.path.isabs( target ):
+        candidates.append( target )
+    else:
+        candidates.append( os.path.join( root, target ) )
+        candidates.append( os.path.abspath( target ) )
+    marked_any = False
+    for cand in candidates:
+        if os.path.isfile( cand ):
+            mark_sconscript_invoked( _as_project_relative( cand, base_dir=root ), scope=scope )
+            marked_any = True
+            break
+        if os.path.isdir( cand ):
+            for suffix in ( 'sconscript', 'SConscript' ):
+                as_file = os.path.join( cand, suffix )
+                if os.path.isfile( as_file ):
+                    mark_sconscript_invoked(
+                            _as_project_relative( as_file, base_dir=root ),
+                            scope=scope,
+                    )
+                    marked_any = True
+            if marked_any:
+                break
+    if not marked_any:
+        mark_sconscript_invoked(
+                _as_project_relative( os.path.join( root, target ), base_dir=root ),
+                scope=scope,
+        )
+
+
+def _wrapped_sconscript( *args, **kwargs ):
+    """SCons ``SConscript`` wrapper that records nested targets for dedupe."""
+    scope = current_invoke_scope()
+    for target in _paths_from_sconscript_call_args( args, kwargs ):
+        _mark_live_sconscript_target( target, scope )
+    return _original_sconscript( *args, **kwargs )
+
+
+def install_sconscript_dedupe_wrapper():
+    """Install the ``SCons.Script.SConscript`` wrapper once for this process."""
+    global _original_sconscript
+    if _original_sconscript is not None:
+        return
+    _original_sconscript = SCons.Script.SConscript
+    SCons.Script.SConscript = _wrapped_sconscript
 
 
 def export_shared( env, name, value ):

--- a/design/plans/sconscript-exports.md
+++ b/design/plans/sconscript-exports.md
@@ -2,8 +2,8 @@
 
 - **Status:** in progress
 - **Related:** [`ROADMAP.md`](../../ROADMAP.md) — `sconscript-exports`; blocks multi-file Cuppa layouts like CMake `add_subdirectory`; pairs with [#213](https://github.com/ja11sop/cuppa/issues/213); graph/cycle vocabulary may later share helpers with [`gitlab-package-transitive.md`](gitlab-package-transitive.md) (different graph; do not force one NetworkX model)
-- **Updated:** 2026-09-06
-- **Impact:** minor — opt-in Export/Import ordering and `ExportShared` / `ImportShared`; flat discovery unchanged when unused
+- **Updated:** 2026-09-07
+- **Impact:** minor — opt-in Export/Import ordering and `ExportShared` / `ImportShared`; flat discovery unchanged when unused; nested `SConscript` no longer double-runs under discovery
 
 ## Problem
 
@@ -135,6 +135,7 @@ Static scan will not catch every dynamic `Import(name)` constructed at runtime; 
 | Widened scripts | Join the run set (exporters execute, not resolve-only). |
 | Variant / toolchain scope | **`ExportShared` / `ImportShared` are keyed by `tool_variant_dir`** (toolchain + variant + arch + abi). Same export name under `--dbg` and `--rel` (or two toolchains) keeps distinct values. **This is a concrete reason the Cuppa API exists above native SCons `Export` / `Import`**, whose global pool is last-wins across the configure pass and cannot honour variants safely. Native `Export` is still updated best-effort for migration; product code should use `ImportShared`. |
 | Graph nodes for scan/order | Script paths only (order is the same for every variant); **values** are per-variant via the Cuppa registry. |
+| Nested `SConscript` + discovery | **Dedupe:** drop string-literal nested targets from the outer invoke list when the parent is also in the set; runtime mark/skip for live nested calls per `tool_variant_dir`. Nested call keeps parent `exports=`. |
 
 ## Progress snapshot
 
@@ -147,5 +148,5 @@ Static scan will not catch every dynamic `Import(name)` constructed at runtime; 
 | `--scripts=` + strict + clean path form | Covered by unit + integration tests |
 | Variant-aware shared exports | Covered (`tool_variant_dir` scope; `--dbg --rel` integration) |
 | `--parallel` build with imported lib | Covered (`BuildStaticLib` + `ExportShared` → consumer `Build` under `-j` on non-Windows; Windows omits `-j` due to MSVC `/Zi`/`vc140.pdb` C1090 across variant dirs) |
-| `scons-export-dedupe` | Not started (explicit `SConscript` + discovery double-run) |
+| `scons-export-dedupe` | Covered — string-literal nested `SConscript` targets dropped from outer invoke; live nested call marks path per `tool_variant_dir`; Concepts updated |
 | `scons-export-capy` | Not started |

--- a/docs/modules/ROOT/pages/concepts.adoc
+++ b/docs/modules/ROOT/pages/concepts.adoc
@@ -76,10 +76,12 @@ toolchain/variant/arch/abi (`tool_variant_dir`), so the same name exported under
 concrete reason to prefer the Cuppa API over native SCons `Export` / `Import`,
 whose global pool is last-wins across the whole configure pass.
 
-Without product imports, execution order stays the discovery walk (a flat graph). Nested
-`SConscript(..., exports=...)` from one script while Cuppa also auto-discovers the same path
-can still double-run that path — prefer `ExportShared` / discovery, or avoid listing a path
-Cuppa will discover again.
+Without product imports, execution order stays the discovery walk (a flat graph).
+When one discovered script nests another with ``SConscript(..., exports=...)``,
+Cuppa **drops the nested path from the outer discovery invoke list** (string-literal
+targets) and also skips a path if a live nested call already evaluated it for that
+toolchain/variant. Prefer ``ExportShared`` / ``ImportShared`` for new layouts; nested
+``SConscript`` remains supported for SCons-style ``exports=`` without double-running.
 
 [#methods]
 == Methods

--- a/docs/modules/ROOT/pages/methods.adoc
+++ b/docs/modules/ROOT/pages/methods.adoc
@@ -94,6 +94,9 @@ See <<progress-tracking-and-variant-scoping>> for when progress attaches.
 | CreateVersion
 | xref:methods/create-version.adoc[CreateVersion]
 
+| Sconscript sharing (`ExportShared()`, nested `SConscript`, …)
+| xref:concepts.adoc#sconscript-discovery[Concepts: sconscript discovery and sharing]
+
 | Packages
 | xref:methods/packages.adoc[Packages]
 

--- a/docs/modules/ROOT/pages/methods/method-index.adoc
+++ b/docs/modules/ROOT/pages/methods/method-index.adoc
@@ -376,6 +376,38 @@ For tutorials and Related-method chains, start from the xref:methods.adoc[Method
 |
 |===
 
+[#sconscript-sharing]
+== Sconscript sharing and nesting
+
+Publish values between discovered `sconscript` files, or nest a child with SCons
+`SConscript(..., exports=...)`. Behaviour (ordering, widen, dedupe, variant scope):
+xref:concepts.adoc#sconscript-discovery[Concepts: sconscript discovery and sharing].
+
+[cols="2,4,3"]
+|===
+| Method | Description | Notes
+
+| xref:concepts.adoc#sconscript-discovery[`ExportShared()`]
+| Cuppa preferred export: publish a name for this toolchain/variant (`tool_variant_dir`)
+| Prefer over native `Export()` for product sharing under discovery
+
+| xref:concepts.adoc#sconscript-discovery[`ImportShared()`]
+| Cuppa preferred import: read a name published by `ExportShared()` for this variant
+| Prefer over native `Import()` of product names
+
+| link:{scons-man}#f-Export[`Export()`]
+| SCons global export pool (string-literal names are scanned for ordering)
+| Global last-wins across the configure pass — not variant-safe; prefer `ExportShared()`
+
+| link:{scons-man}#f-Import[`Import()`]
+| Import names into the sconscript (Cuppa always exports `env` and related keys)
+| Product names: prefer `ImportShared()`, or nest with `SConscript(..., exports=...)`
+
+| link:{scons-man}#f-SConscript[`SConscript()`]
+| Evaluate another sconscript (optional `exports=`)
+| Under Cuppa discovery, nested string-literal targets are not double-run; see Concepts
+|===
+
 [#depends]
 == Ordering and aliases
 

--- a/tests/integration/test_sconscript_exports.py
+++ b/tests/integration/test_sconscript_exports.py
@@ -266,3 +266,82 @@ def test_export_shared_static_lib_builds_under_parallel( tmp_path ):
             if path.is_file() and path.suffix in ( '.a', '.lib' ) and 'answer' in path.name
     ]
     assert archives, 'expected BuildStaticLib archive under _build'
+
+
+def test_nested_sconscript_not_double_run_by_discovery( tmp_path ):
+    """Explicit ``SConscript`` + discovery must evaluate the child once.
+
+    Capylike layout: root nests ``test/sconscript`` with ``exports=`` while Cuppa
+    still discovers both files. Without dedupe the second discovery invoke fails
+    ``Import`` of the parent-only name.
+    """
+    project = copy_dummy_project( tmp_path )
+    write_sconstruct( project, default_variants=['dbg'] )
+
+    counter = project / 'nested_run_count.txt'
+    marker = project / 'nested_marker.txt'
+    ( project / 'sconscript' ).write_text(
+            "Import('env')\n"
+            "nested_marker = 'from-nested-export'\n"
+            "Export('nested_marker')\n"
+            "SConscript('test/sconscript', exports=['nested_marker'])\n",
+            encoding='utf-8',
+    )
+    test_dir = project / 'test'
+    test_dir.mkdir()
+    ( test_dir / 'sconscript' ).write_text(
+            "Import('nested_marker')\n"
+            "path = r'{counter}'\n"
+            "count = 0\n"
+            "try:\n"
+            "    with open( path, 'r', encoding='utf-8' ) as handle:\n"
+            "        count = int( handle.read().strip() or '0' )\n"
+            "except OSError:\n"
+            "    pass\n"
+            "with open( path, 'w', encoding='utf-8' ) as handle:\n"
+            "    handle.write( str( count + 1 ) )\n"
+            "with open( r'{marker}', 'w', encoding='utf-8' ) as handle:\n"
+            "    handle.write( nested_marker )\n".format(
+                    counter=str( counter ).replace( '\\', '\\\\' ),
+                    marker=str( marker ).replace( '\\', '\\\\' ),
+            ),
+            encoding='utf-8',
+    )
+
+    result = run_cuppa( project, '--dbg' )
+    assert_success( result )
+    assert counter.read_text( encoding='utf-8' ).strip() == '1', result.stdout
+    assert marker.read_text( encoding='utf-8' ) == 'from-nested-export'
+
+
+def test_nested_sconscript_once_per_variant( tmp_path ):
+    """``--dbg --rel`` nests the child once per variant, not twice per variant."""
+    project = copy_dummy_project( tmp_path )
+    write_sconstruct( project, default_variants=['dbg', 'rel'] )
+
+    counter = project / 'nested_variant_count.txt'
+    ( project / 'sconscript' ).write_text(
+            "Import('env')\n"
+            "SConscript('test/sconscript')\n",
+            encoding='utf-8',
+    )
+    test_dir = project / 'test'
+    test_dir.mkdir()
+    ( test_dir / 'sconscript' ).write_text(
+            "path = r'{counter}'\n"
+            "count = 0\n"
+            "try:\n"
+            "    with open( path, 'r', encoding='utf-8' ) as handle:\n"
+            "        count = int( handle.read().strip() or '0' )\n"
+            "except OSError:\n"
+            "    pass\n"
+            "with open( path, 'w', encoding='utf-8' ) as handle:\n"
+            "    handle.write( str( count + 1 ) )\n".format(
+                    counter=str( counter ).replace( '\\', '\\\\' ),
+            ),
+            encoding='utf-8',
+    )
+
+    result = run_cuppa( project, '--dbg', '--rel' )
+    assert_success( result )
+    assert counter.read_text( encoding='utf-8' ).strip() == '2', result.stdout

--- a/tests/unit/test_sconscript_coupling.py
+++ b/tests/unit/test_sconscript_coupling.py
@@ -307,3 +307,60 @@ def test_parse_error_in_sconscript_is_stop_error():
     with pytest.raises( SCons.Errors.StopError ) as caught:
         scan_sconscript_source( "Export('oops'\n", path='bad.sconscript' )
     assert 'cannot parse' in str( caught.value )
+
+
+def test_scan_nested_sconscript_string_and_list():
+    source = """
+Import('env')
+SConscript('test/sconscript', exports=['marker'])
+SConscript(['mid/sconscript', 'leaf/sconscript'])
+SCons.Script.SConscript('other/sconscript')
+"""
+    coupling = scan_sconscript_source( source, path='sconscript' )
+    assert coupling.nested == {
+            'test/sconscript',
+            'mid/sconscript',
+            'leaf/sconscript',
+            'other/sconscript',
+    }
+
+
+def test_order_excludes_nested_sconscript_from_discovery_list( tmp_path ):
+    """Parent nests child — child must not remain on the outer invoke list."""
+    root = tmp_path / 'sconscript'
+    child = tmp_path / 'test' / 'sconscript'
+    child.parent.mkdir()
+    root.write_text(
+            "Import('env')\n"
+            "Export('marker')\n"
+            "SConscript('test/sconscript', exports=['marker'])\n",
+            encoding='utf-8',
+    )
+    child.write_text( "Import('env', 'marker')\n", encoding='utf-8' )
+    # Importer first in the input list (would double-run without exclusion).
+    ordered = order_sconscripts( [ str( child ), str( root ) ] )
+    assert _norm_list( ordered ) == _norm_list( [ str( root ) ] )
+
+
+def test_resolve_nested_sconscript_target_relative_to_caller( tmp_path, monkeypatch ):
+    from cuppa.core.sconscript_coupling import resolve_nested_sconscript_target
+
+    monkeypatch.chdir( tmp_path )
+    caller = './mid/sconscript'
+    resolved = resolve_nested_sconscript_target( caller, 'leaf/sconscript', base_dir=str( tmp_path ) )
+    assert os.path.normpath( resolved ) == os.path.normpath( './mid/leaf/sconscript' )
+
+
+def test_invoked_registry_is_scope_aware():
+    from cuppa.core.sconscript_coupling import (
+            clear_invoked_sconscripts,
+            mark_sconscript_invoked,
+            was_sconscript_invoked,
+    )
+
+    clear_invoked_sconscripts()
+    mark_sconscript_invoked( './test/sconscript', scope='gcc/dbg/x86_64/cxx2c' )
+    assert was_sconscript_invoked( 'test/sconscript', scope='gcc/dbg/x86_64/cxx2c' )
+    assert not was_sconscript_invoked( './test/sconscript', scope='gcc/rel/x86_64/cxx2c' )
+    clear_invoked_sconscripts()
+    assert not was_sconscript_invoked( './test/sconscript', scope='gcc/dbg/x86_64/cxx2c' )


### PR DESCRIPTION
## Summary

- Continue [`sconscript-exports`](design/plans/sconscript-exports.md) **`scons-export-dedupe`**: drop string-literal nested `SConscript(...)` targets from the outer discovery invoke list when the parent is also in the set.
- Runtime safety net: wrap `SCons.Script.SConscript`, mark nested paths per `tool_variant_dir`, skip a second Cuppa discovery invoke for the same path.
- Concepts / CHANGELOG / plan: nested `exports=` no longer double-runs under folder-and-below discovery (spike was #282).
- Method index + Methods hub: `ExportShared()` / `ImportShared()` and native `Export()` / `Import()` / `SConscript()`.

## Test plan

- [x] `flake8` / `pylint -E` on touched modules
- [x] `pytest -m unit` (`test_sconscript_coupling` nested scan / exclude / registry)
- [x] `pytest -m integration` (`test_sconscript_exports`: nested once; once per variant)
- [x] CI green on the matrix