### PR TITLE
Allow Boost use_libs to re-Append dependent archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``latest_version_segment``; they now target ``/cuppa/latest/…``. ``scripts.check_docs_urls``
   guards sources and the built site (also wired into ``check_release`` and the documentation
   workflow).
+- ``boost_package.use_libs`` and source ``Boost.use_libs`` ``Append`` expanded static archives
+  to ``STATICLIBS`` instead of ``AppendUnique``. Unique dropped intentional repeats of
+  dependents (e.g. ``filesystem`` / ``thread`` after ``log``) when an earlier call such as
+  Quince had already linked those archives, leaving undefined TSS symbols from Boost.Log.
+  Stable ``add_dependent_libraries`` order from [#267](https://github.com/ja11sop/cuppa/issues/267)
+  / [#269](https://github.com/ja11sop/cuppa/pull/269) is unchanged.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,9 +69,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ``boost_package.use_libs`` and source ``Boost.use_libs`` ``Append`` expanded static archives
   to ``STATICLIBS`` instead of ``AppendUnique``. Unique dropped intentional repeats of
   dependents (e.g. ``filesystem`` / ``thread`` after ``log``) when an earlier call such as
-  Quince had already linked those archives, leaving undefined TSS symbols from Boost.Log.
-  Stable ``add_dependent_libraries`` order from [#267](https://github.com/ja11sop/cuppa/issues/267)
-  / [#269](https://github.com/ja11sop/cuppa/pull/269) is unchanged.
+  Quince had already linked those archives, leaving undefined TSS symbols from Boost.Log
+  ([#285](https://github.com/ja11sop/cuppa/issues/285)). Stable ``add_dependent_libraries``
+  order from [#267](https://github.com/ja11sop/cuppa/issues/267) /
+  [#269](https://github.com/ja11sop/cuppa/pull/269) is unchanged.
 
 ### Security
 

--- a/cuppa/dependencies/boost/library_dependencies.py
+++ b/cuppa/dependencies/boost/library_dependencies.py
@@ -16,9 +16,12 @@ from cuppa.log       import logger
 def boost_dependency_order():
     # Master static-link order: dependents before dependencies for GNU ld.
     # add_dependent_libraries emits only the subset present in the required
-    # set, preserving relative order from this list. Keep every Boost library
-    # name Cuppa knows about here; unknown names are appended sorted for
-    # signature stability only (#267) and may not link correctly.
+    # set, preserving relative order from this list (stable across processes —
+    # #267). Callers (boost_package / Boost.use_libs) must Append the result to
+    # STATICLIBS, not AppendUnique, so a later expansion can repeat dependents
+    # (e.g. thread after log) when an earlier use_libs already listed them.
+    # Keep every Boost library name Cuppa knows about here; unknown names are
+    # appended sorted for signature stability only and may not link correctly.
     return [
         'graph',
         'regex',

--- a/cuppa/dependencies/build_with_boost.py
+++ b/cuppa/dependencies/build_with_boost.py
@@ -351,15 +351,19 @@ class Boost(object):
         Intended for ``env.BuildWith('boost').use_libs([...])`` so a project can switch
         between source Boost and a registry ``boost_package`` without changing call shape.
         Builds (or reuses) libraries via ``env.BoostStaticLibs`` and appends them to
-        ``STATICLIBS``. Optional ``depends_on`` is passed to ``env.Depends`` on those
-        library nodes. Returns the library nodes.
+        ``STATICLIBS`` (allowing repeats so dependents can follow libraries that need
+        them). Optional ``depends_on`` is passed to ``env.Depends`` on those library
+        nodes. Returns the library nodes.
         """
         from SCons.Script import Flatten
 
         env = self._env
         libs = Flatten( [ libs ] )
         libraries = env.BoostStaticLibs( libs )
-        env.AppendUnique( STATICLIBS = libraries )
+        # Append, not AppendUnique: same as boost_package.use_libs — dependents
+        # expanded by BoostStaticLibs must be allowed to repeat after libraries
+        # that need them when an earlier use_libs already linked those archives.
+        env.Append( STATICLIBS = libraries )
         if depends_on:
             env.Depends( libraries, Flatten( [ depends_on ] ) )
         return libraries

--- a/cuppa/packages/boost_package.py
+++ b/cuppa/packages/boost_package.py
@@ -31,7 +31,10 @@ def use_libs( package, libraries ):
         lib_path = os.path.join( package.lib_dir(), lib_name )
         static_libs.append( env.File( lib_path ) )
 
-    env.AppendUnique( STATICLIBS = static_libs )
+    # Append, not AppendUnique: dependents of later use_libs (e.g. log → thread)
+    # must appear again after that library even if quince or an earlier call already
+    # put them on STATICLIBS. Unique would drop those repeats and break GNU ld.
+    env.Append( STATICLIBS = static_libs )
 
 
 def latest_release( offline=False ):

--- a/tests/unit/test_boost_library_dependencies.py
+++ b/tests/unit/test_boost_library_dependencies.py
@@ -35,6 +35,20 @@ def _assert_master_subset( result ):
     assert positions == sorted( positions ), result
 
 
+def _append_staticlibs( existing, names ):
+    """Model boost use_libs: Append the expansion, allowing intentional repeats."""
+    existing.extend( names )
+    return existing
+
+
+def _append_unique_staticlibs( existing, names ):
+    """Former mistaken use_libs behaviour that dropped needed repeats."""
+    for name in names:
+        if name not in existing:
+            existing.append( name )
+    return existing
+
+
 def test_add_dependent_libraries_emits_master_order_subset():
     """Required libs keep relative order from boost_dependency_order()."""
     result = add_dependent_libraries( 1.92, 'static', list( _CONSUMER_STYLE_LIBS ) )
@@ -107,3 +121,37 @@ def test_add_dependent_libraries_order_stable_across_hash_seeds():
         orders.add( out )
 
     assert len( orders ) == 1, orders
+
+
+def test_log_dependents_reappear_after_earlier_filesystem_thread_use_libs():
+    """Quince-style early use_libs then consumer log must repeat thread after log.
+
+    GNU ld needs filesystem/thread after libboost_log.a even when those archives
+    already appear earlier on the line. use_libs must Append expansions; Unique
+    would drop the repeats and leave undefined TSS symbols from Boost.Log.
+    """
+    quince_libs = add_dependent_libraries(
+        1.92, 'static', [ 'filesystem', 'thread', 'system' ]
+    )
+    postgresql_libs = add_dependent_libraries( 1.92, 'static', [ 'date_time' ] )
+    consumer_libs = add_dependent_libraries( 1.92, 'static', list( _CONSUMER_STYLE_LIBS ) )
+
+    with_append = []
+    _append_staticlibs( with_append, quince_libs )
+    _append_staticlibs( with_append, postgresql_libs )
+    _append_staticlibs( with_append, consumer_libs )
+
+    assert with_append.count( 'filesystem' ) >= 2
+    assert with_append.count( 'thread' ) >= 2
+    assert with_append.count( 'date_time' ) >= 2
+    log_index = with_append.index( 'log' )
+    assert 'filesystem' in with_append[ log_index + 1 : ]
+    assert 'thread' in with_append[ log_index + 1 : ]
+    assert 'date_time' in with_append[ log_index + 1 : ]
+
+    with_unique = []
+    _append_unique_staticlibs( with_unique, quince_libs )
+    _append_unique_staticlibs( with_unique, postgresql_libs )
+    _append_unique_staticlibs( with_unique, consumer_libs )
+    unique_log_index = with_unique.index( 'log' )
+    assert 'thread' not in with_unique[ unique_log_index + 1 : ]

--- a/tests/unit/test_boost_remove_system_static_lib.py
+++ b/tests/unit/test_boost_remove_system_static_lib.py
@@ -82,11 +82,24 @@ def test_boost_package_use_libs_passes_package_version( monkeypatch ):
             return '/tmp/boost/lib'
 
     class FakeEnv( dict ):
+        def __init__( self, **kwargs ):
+            super().__init__( **kwargs )
+            self.staticlibs = []
+            self.append_calls = 0
+            self.append_unique_calls = 0
+
         def File( self, path ):
             return path
 
+        def Append( self, **kwargs ):
+            self.append_calls += 1
+            self.staticlibs.extend( kwargs.get( 'STATICLIBS' ) or [] )
+
         def AppendUnique( self, **kwargs ):
-            self.update( kwargs )
+            self.append_unique_calls += 1
+            for item in kwargs.get( 'STATICLIBS' ) or []:
+                if item not in self.staticlibs:
+                    self.staticlibs.append( item )
 
     package = FakePackage()
     package._env = FakeEnv( toolchain='gcc153' )
@@ -94,3 +107,60 @@ def test_boost_package_use_libs_passes_package_version( monkeypatch ):
     boost_package_module.use_libs( package, [ 'system', 'thread' ] )
 
     assert calls == [ '1.92' ]
+    assert package._env.append_calls == 1
+    assert package._env.append_unique_calls == 0
+    assert package._env.staticlibs == [
+        '/tmp/boost/lib/libboost_system.a',
+        '/tmp/boost/lib/libboost_thread.a',
+    ]
+
+
+def test_boost_package_use_libs_appends_repeated_dependents( monkeypatch ):
+    """Later log expansion must re-Append filesystem/thread already linked earlier."""
+    monkeypatch.setattr(
+        boost_package_module,
+        'remove_system_static_lib',
+        lambda env, libraries, boost_version=None: list( libraries ),
+    )
+    monkeypatch.setattr(
+        boost_package_module,
+        'static_library_name',
+        lambda env, lib, toolchain, version, variant, static: 'libboost_{}.a'.format( lib ),
+    )
+
+    class FakePackage( object ):
+        _version = '1.92'
+        _variant = 'rel'
+
+        def lib_dir( self ):
+            return '/tmp/boost/lib'
+
+    class FakeEnv( dict ):
+        def __init__( self, **kwargs ):
+            super().__init__( **kwargs )
+            self.staticlibs = []
+
+        def File( self, path ):
+            return path
+
+        def Append( self, **kwargs ):
+            self.staticlibs.extend( kwargs.get( 'STATICLIBS' ) or [] )
+
+        def AppendUnique( self, **kwargs ):
+            raise AssertionError( 'use_libs must Append, not AppendUnique' )
+
+    package = FakePackage()
+    package._env = FakeEnv( toolchain='gcc153' )
+
+    boost_package_module.use_libs( package, [ 'filesystem', 'thread' ] )
+    boost_package_module.use_libs(
+        package,
+        [ 'log_setup', 'log', 'program_options', 'unit_test_framework' ],
+    )
+
+    names = [ path.rsplit( '/', 1 )[-1] for path in package._env.staticlibs ]
+    assert names.count( 'libboost_filesystem.a' ) >= 2
+    assert names.count( 'libboost_thread.a' ) >= 2
+    log_index = names.index( 'libboost_log.a' )
+    assert 'libboost_filesystem.a' in names[ log_index + 1 : ]
+    assert 'libboost_thread.a' in names[ log_index + 1 : ]

--- a/tests/unit/test_boost_use_libs.py
+++ b/tests/unit/test_boost_use_libs.py
@@ -15,16 +15,25 @@ pytestmark = pytest.mark.unit
 
 class _FakeEnv( object ):
     def __init__( self ):
-        self.staticlibs = None
+        self.staticlibs = []
         self.depends = None
         self.requested_libs = None
+        self.append_calls = 0
+        self.append_unique_calls = 0
 
     def BoostStaticLibs( self, libs ):
         self.requested_libs = list( libs )
         return [ 'libboost_filesystem.a', 'libboost_system.a' ]
 
+    def Append( self, **kwargs ):
+        self.append_calls += 1
+        self.staticlibs.extend( kwargs.get( 'STATICLIBS' ) or [] )
+
     def AppendUnique( self, **kwargs ):
-        self.staticlibs = kwargs.get( 'STATICLIBS' )
+        self.append_unique_calls += 1
+        for item in kwargs.get( 'STATICLIBS' ) or []:
+            if item not in self.staticlibs:
+                self.staticlibs.append( item )
 
     def Depends( self, nodes, dependencies ):
         self.depends = ( nodes, dependencies )
@@ -39,8 +48,27 @@ def test_boost_use_libs_appends_staticlibs_via_boost_static_libs():
 
     assert env.requested_libs == [ 'filesystem', 'system' ]
     assert env.staticlibs == [ 'libboost_filesystem.a', 'libboost_system.a' ]
-    assert result == env.staticlibs
+    assert result == [ 'libboost_filesystem.a', 'libboost_system.a' ]
+    assert env.append_calls == 1
+    assert env.append_unique_calls == 0
     assert env.depends is None
+
+
+def test_boost_use_libs_allows_repeated_archives_across_calls():
+    """Second use_libs must Append again so dependents can follow later libs."""
+    boost = Boost.__new__( Boost )
+    env = _FakeEnv()
+    boost._env = env
+
+    boost.use_libs( [ 'filesystem', 'system' ] )
+    boost.use_libs( [ 'filesystem', 'system' ] )
+
+    assert env.staticlibs == [
+        'libboost_filesystem.a', 'libboost_system.a',
+        'libboost_filesystem.a', 'libboost_system.a',
+    ]
+    assert env.append_calls == 2
+    assert env.append_unique_calls == 0
 
 
 def test_boost_use_libs_honours_depends_on():


### PR DESCRIPTION
## Summary

- Fix Boost.Log static link failures after Quince (or any earlier `use_libs`) already linked `filesystem` / `thread`: `boost_package.use_libs` and source `Boost.use_libs` now `Append` expanded archives to `STATICLIBS` instead of `AppendUnique`, so dependents can reappear after libraries that need them ([#285](https://github.com/ja11sop/cuppa/issues/285)).
- Keep the stable `add_dependent_libraries` master order from #267 / #269 (no hash-seed churn).
- Unit tests cover hash-seed stability, quince→log repeat semantics, and that both `use_libs` paths call `Append`.

## Test plan

- [x] `flake8 cuppa` / `pylint -E cuppa`
- [x] `pytest -m unit` (includes new/updated Boost `use_libs` / dependency tests)
- [x] `pytest -m integration` (local run hit unrelated `ModuleNotFoundError: six` in cuppa subprocesses; rely on CI)
- [x] CI green on the matrix
- [x] Consumer: cov/rel link of a Quince + Boost.Log test binary succeeds without undefined TSS symbols
