### PR TITLE
Raise Windows default run_cuppa timeout to 360s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Integration ``run_cuppa`` default subprocess timeout is 360s on Windows (180s elsewhere) so
+  MSVC modules, coverage, and nested ``-D`` builds on ``windows-latest`` are less likely to flake
+  at the former 180s ceiling.
 - Top navbar and README absolute docs links used versionless ``/cuppa/….html`` paths after
   ``latest_version_segment``; they now target ``/cuppa/latest/…``. ``scripts.check_docs_urls``
   guards sources and the built site (also wired into ``check_release`` and the documentation

--- a/tests/helpers/cuppa_runner.py
+++ b/tests/helpers/cuppa_runner.py
@@ -48,7 +48,19 @@ def cuppa_test_env_args():
     return _split_extra_args(os.environ.get("CUPPA_TEST_ARGS", "").strip())
 
 
-def run_cuppa(project_dir, *flags, extra_env=None, timeout=180, offline=True):
+_DEFAULT_RUN_CUPPA_TIMEOUT = 180
+# MSVC modules/cov and nested -D builds often exceed 180s on windows-latest.
+_DEFAULT_RUN_CUPPA_TIMEOUT_WINDOWS = 360
+
+
+def default_run_cuppa_timeout():
+    """Subprocess timeout when integration tests omit an explicit ``timeout=``."""
+    if os.name == 'nt':
+        return _DEFAULT_RUN_CUPPA_TIMEOUT_WINDOWS
+    return _DEFAULT_RUN_CUPPA_TIMEOUT
+
+
+def run_cuppa(project_dir, *flags, extra_env=None, timeout=None, offline=True):
     require_cxx()
     env = os.environ.copy()
     root = str(REPO_ROOT)
@@ -83,6 +95,9 @@ def run_cuppa(project_dir, *flags, extra_env=None, timeout=180, offline=True):
 
     # Env extras first; explicit *flags override (e.g. import std forcing libc++).
     args.extend(merge_cuppa_args(default_tc, cuppa_test_env_args(), list(flags)))
+
+    if timeout is None:
+        timeout = default_run_cuppa_timeout()
 
     logger.info("Running in %s: %s", project_dir, " ".join(args))
     result = subprocess.run(

--- a/tests/unit/test_cuppa_runner.py
+++ b/tests/unit/test_cuppa_runner.py
@@ -17,6 +17,42 @@ from tests.helpers.toolchains import REPO_ROOT
 pytestmark = pytest.mark.unit
 
 
+def test_default_run_cuppa_timeout_is_longer_on_windows( monkeypatch ):
+    monkeypatch.setattr( cuppa_runner.os, 'name', 'nt' )
+    assert cuppa_runner.default_run_cuppa_timeout() == 360
+    monkeypatch.setattr( cuppa_runner.os, 'name', 'posix' )
+    assert cuppa_runner.default_run_cuppa_timeout() == 180
+
+
+def test_run_cuppa_uses_platform_default_timeout( monkeypatch, tmp_path ):
+    captured = {}
+
+    def fake_run( args, cwd=None, env=None, timeout=None, **kwargs ):
+        captured['timeout'] = timeout
+        return subprocess.CompletedProcess( args, 0, stdout='', stderr='' )
+
+    monkeypatch.setattr( cuppa_runner, 'require_cxx', lambda: None )
+    monkeypatch.setattr( cuppa_runner, 'default_run_cuppa_timeout', lambda: 360 )
+    monkeypatch.setattr( subprocess, 'run', fake_run )
+
+    cuppa_runner.run_cuppa( tmp_path / 'project', '--dbg' )
+    assert captured['timeout'] == 360
+
+
+def test_run_cuppa_honours_explicit_timeout( monkeypatch, tmp_path ):
+    captured = {}
+
+    def fake_run( args, cwd=None, env=None, timeout=None, **kwargs ):
+        captured['timeout'] = timeout
+        return subprocess.CompletedProcess( args, 0, stdout='', stderr='' )
+
+    monkeypatch.setattr( cuppa_runner, 'require_cxx', lambda: None )
+    monkeypatch.setattr( subprocess, 'run', fake_run )
+
+    cuppa_runner.run_cuppa( tmp_path / 'project', '--dbg', timeout=120 )
+    assert captured['timeout'] == 120
+
+
 def test_run_cuppa_keeps_repo_root_when_extra_pythonpath( monkeypatch, tmp_path ):
     """Plugin tests put a site-packages first; REPO_ROOT must remain importable."""
     captured = {}


### PR DESCRIPTION
## Summary

- Raise the default `run_cuppa` subprocess timeout to **360s on Windows** (180s elsewhere) so MSVC modules/coverage/nested `-D` integration tests on `windows-latest` stop flaking at the old 180s ceiling.
- Explicit `timeout=` arguments are unchanged.

## Test plan

- [x] `flake8` on touched files
- [x] `pytest -m unit tests/unit/test_cuppa_runner.py`
- [x] CI green on the matrix (especially `integration-windows`)

