### PR TITLE
Uniquify BuildStaticLib archive members on basename collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#285](https://github.com/ja11sop/cuppa/issues/285)). Stable ``add_dependent_libraries``
   order from [#267](https://github.com/ja11sop/cuppa/issues/267) /
   [#269](https://github.com/ja11sop/cuppa/pull/269) is unchanged.
+- ``BuildStaticLib`` / static ``BuildLib`` stage uniquely named object copies under
+  ``working/.archive_members/<lib>/`` when compile outputs share a basename, so ``ar`` /
+  the MSVC librarian no longer silently drop nested same-basename objects after the #213
+  ``working/`` mirror ([#287](https://github.com/ja11sop/cuppa/issues/287)).
 
 ### Security
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,8 @@ Minor cycle after **1.10.0**. Prefer work that changes opt-in toolchain or packa
 |------|------------------|
 | `cuppa.run` default_dependencies objects | [`run-default-dependency-objects.md`](design/plans/run-default-dependency-objects.md) — objects in both lists; teach register vs auto-apply; optional clearer names later |
 | Transitive GitLab packages | [`gitlab-package-transitive.md`](design/plans/gitlab-package-transitive.md) — `cuppa-dependency.json` + `--list-dependencies` `requires` (shipped #280 / #281; #279 follow-ons deferred) |
-| Sconscript exports / sharing | [`sconscript-exports.md`](design/plans/sconscript-exports.md) — discovery + `ExportShared`; dedupe nested `SConscript` (in progress; #282 spike shipped) |
+| Sconscript exports / sharing | [`sconscript-exports.md`](design/plans/sconscript-exports.md) — #282 / #283 shipped; Capylike smoke done; follow-ons below |
+| Static lib archive members | [`static-lib-archive-members.md`](design/plans/static-lib-archive-members.md) — unique `ar` members after #213 object mirroring |
 | GitLab CMake staging | [#209](https://github.com/ja11sop/cuppa/issues/209) |
 | Artefact removal design | [#135](https://github.com/ja11sop/cuppa/issues/135) |
 | Console bundle | `--terse-output`, log hygiene, `cuppa --info` |
@@ -574,16 +575,17 @@ Design: [#213](https://github.com/ja11sop/cuppa/issues/213) (compile object path
 |------------|--------|
 | Single root `sconscript` + `env.Build*` / `RecursiveGlob` | Yes — nested same-basename sources ([#213](https://github.com/ja11sop/cuppa/issues/213)); path roots + Filter parity; RecursiveGlob merges declared Files + full Repository trees ([#231](https://github.com/ja11sop/cuppa/pull/231)) |
 | Cuppa auto-discovers every `sconscript` under launch dir | Yes — each run gets standard `env` exports only |
-| Nested `SConscript(..., exports=...)` + discovery | **No** — child scripts cannot import parent build nodes; duplicate invocation risk |
-| CMake-equivalent `GLOB_RECURSE` into one static lib | Yes — when object paths mirror source tree under `working/` ([#213](https://github.com/ja11sop/cuppa/issues/213)) |
+| Nested `SConscript(..., exports=...)` + discovery | **Yes** — string-literal nested targets are not double-run ([#283](https://github.com/ja11sop/cuppa/pull/283)); prefer `ExportShared` / `ImportShared` ([#282](https://github.com/ja11sop/cuppa/pull/282)) |
+| CMake-equivalent `GLOB_RECURSE` into one static lib | **Partial** — objects mirror under `working/` ([#213](https://github.com/ja11sop/cuppa/issues/213)); **static archive members still collide on basename** (see `static-lib-archive-members`) |
 
 ### Planned / potential
 
 | ID | Work | Priority | Notes |
 |----|------|----------|-------|
 | `compile-object-paths` | Mirror source tree under `working/` for `Compile` | — | **Shipped 1.8.1** — [#213](https://github.com/ja11sop/cuppa/issues/213) / [#214](https://github.com/ja11sop/cuppa/pull/214) |
-| `sconscript-exports` | Discovery + Import/Export execution graph; `ExportShared` / `ImportShared`; nested `SConscript` dedupe | Medium | [`sconscript-exports.md`](design/plans/sconscript-exports.md) — spike #282; dedupe in flight |
-| `cmake-to-cuppa-migration` | Antora matrix + phased tutorial + agent checklist | Medium | Compile-path fix shipped — [`cmake-to-cuppa-migration.md`](design/plans/cmake-to-cuppa-migration.md) |
+| `sconscript-exports` | Discovery + Import/Export execution graph; `ExportShared` / `ImportShared`; nested `SConscript` dedupe | Medium | [`sconscript-exports.md`](design/plans/sconscript-exports.md) — #282 / #283; Capylike validated |
+| `static-lib-archive-members` | Unique static-archive members for nested same-basename `.o` | High | [`static-lib-archive-members.md`](design/plans/static-lib-archive-members.md) — silent `ar` drop after #213 |
+| `cmake-to-cuppa-migration` | Antora matrix + phased tutorial + agent checklist | Medium | Compile-path fix shipped; exports validated — [`cmake-to-cuppa-migration.md`](design/plans/cmake-to-cuppa-migration.md) |
 | `static-glob` | RecursiveGlob (disk + `Dir.entries` + full Repository); GlobFiles; Filter path parity | — | **Shipped** — [#232](https://github.com/ja11sop/cuppa/issues/232) / [#231](https://github.com/ja11sop/cuppa/pull/231), [`recursive-glob-parity.md`](design/archive/recursive-glob-parity.md); follow-on [`path-vocabulary-and-scons-nodes.md`](design/plans/path-vocabulary-and-scons-nodes.md) |
 
 ### Out of scope (layout / migration)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -584,7 +584,7 @@ Design: [#213](https://github.com/ja11sop/cuppa/issues/213) (compile object path
 |----|------|----------|-------|
 | `compile-object-paths` | Mirror source tree under `working/` for `Compile` | — | **Shipped 1.8.1** — [#213](https://github.com/ja11sop/cuppa/issues/213) / [#214](https://github.com/ja11sop/cuppa/pull/214) |
 | `sconscript-exports` | Discovery + Import/Export execution graph; `ExportShared` / `ImportShared`; nested `SConscript` dedupe | Medium | [`sconscript-exports.md`](design/plans/sconscript-exports.md) — #282 / #283; Capylike validated |
-| `static-lib-archive-members` | Unique static-archive members for nested same-basename `.o` | High | [`static-lib-archive-members.md`](design/plans/static-lib-archive-members.md) — silent `ar` drop after #213 |
+| `static-lib-archive-members` | Unique static-archive members for nested same-basename `.o` | High | [`static-lib-archive-members.md`](design/plans/static-lib-archive-members.md) — collide-only staging in 1.x (#287); always-flatten deferred to 2.0 |
 | `cmake-to-cuppa-migration` | Antora matrix + phased tutorial + agent checklist | Medium | Compile-path fix shipped; exports validated — [`cmake-to-cuppa-migration.md`](design/plans/cmake-to-cuppa-migration.md) |
 | `static-glob` | RecursiveGlob (disk + `Dir.entries` + full Repository); GlobFiles; Filter path parity | — | **Shipped** — [#232](https://github.com/ja11sop/cuppa/issues/232) / [#231](https://github.com/ja11sop/cuppa/pull/231), [`recursive-glob-parity.md`](design/archive/recursive-glob-parity.md); follow-on [`path-vocabulary-and-scons-nodes.md`](design/plans/path-vocabulary-and-scons-nodes.md) |
 

--- a/cuppa/methods/build_library.py
+++ b/cuppa/methods/build_library.py
@@ -1,5 +1,4 @@
-
-#          Copyright Jamie Allsop 2014-2017
+#          Copyright Jamie Allsop 2014-2026
 # Distributed under the Boost Software License, Version 1.0.
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)
@@ -10,6 +9,8 @@
 
 import cuppa.progress
 import os.path
+
+from cuppa.utility.static_archive_members import stage_objects_for_static_archive
 
 
 class BuildLibMethod:
@@ -24,7 +25,10 @@ class BuildLibMethod:
         if self._shared:
             lib = env.SharedLibrary( os.path.join( final_dir, target ), env.CompileShared( source ), **kwargs )
         else:
-            lib = env.StaticLibrary( os.path.join( final_dir, target ), env.CompileStatic( source ), **kwargs )
+            objects = stage_objects_for_static_archive(
+                    env, target, env.CompileStatic( source )
+            )
+            lib = env.StaticLibrary( os.path.join( final_dir, target ), objects, **kwargs )
 
         if env.get( 'modules' ):
             from cuppa.cpp.cxx_modules import install_packaged_modules
@@ -42,4 +46,3 @@ class BuildLibMethod:
         cuppa_env.add_method( "BuildLib", cls( False ) )
         cuppa_env.add_method( "BuildStaticLib", cls( False ) )
         cuppa_env.add_method( "BuildSharedLib", cls( True ) )
-

--- a/cuppa/utility/static_archive_members.py
+++ b/cuppa/utility/static_archive_members.py
@@ -1,0 +1,88 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   Unique static-archive members for BuildStaticLib
+#-------------------------------------------------------------------------------
+#
+# Compile mirrors nested sources under working/ (#213), but traditional ar / lib.exe
+# store archive members by basename. When two objects share a basename, the second
+# silently replaces the first. Stage colliding inputs under unique names derived
+# from the build_dir-relative path before StaticLibrary runs.
+
+import os
+
+from SCons.Defaults import Copy
+from SCons.Errors import StopError
+from SCons.Script import Flatten
+
+
+def object_relpath_under_build( env, object_node ):
+    """Return the object path relative to ``env['build_dir']``, using ``/`` separators."""
+    build_dir = os.path.abspath( env['build_dir'] )
+    if hasattr( object_node, 'get_abspath' ):
+        obj_path = object_node.get_abspath()
+    else:
+        obj_path = os.path.abspath( str( object_node ) )
+    try:
+        rel = os.path.relpath( obj_path, build_dir )
+    except ValueError:
+        rel = os.path.basename( obj_path )
+    return rel.replace( '\\', '/' )
+
+
+def archive_member_name( relpath ):
+    """Flatten a working/-relative object path into a single archive member basename."""
+    return relpath.replace( '/', '_' )
+
+
+def basenames_collide( objects ):
+    """True when two or more object nodes share the same basename."""
+    seen = set()
+    for obj in objects:
+        base = os.path.basename( str( obj ) )
+        if base in seen:
+            return True
+        seen.add( base )
+    return False
+
+
+def stage_objects_for_static_archive( env, library_target, objects ):
+    """
+    Ensure StaticLibrary inputs have unique archive member basenames.
+
+    When every object basename is already unique, return ``objects`` unchanged.
+    On collision, copy each object to ``working/.archive_members/<target>/<flat>``
+    so ``ar`` / the MSVC librarian keep one member per object. Flattened name
+    collisions raise ``StopError``.
+    """
+    objects = [ node for node in Flatten( [ objects ] ) if node ]
+    if not objects or not basenames_collide( objects ):
+        return objects
+
+    stage_root = os.path.join( '.archive_members', str( library_target ) )
+    used_names = {}
+    staged = []
+
+    for obj in objects:
+        rel = object_relpath_under_build( env, obj )
+        member = archive_member_name( rel )
+        if member in used_names:
+            raise StopError(
+                "Static library [{target}]: archive member [{member}] collides for "
+                "objects [{first}] and [{second}] under working/. "
+                "Rename one source or shorten a path segment so flattened names differ."
+                .format(
+                    target=library_target,
+                    member=member,
+                    first=used_names[member],
+                    second=rel,
+                )
+            )
+        used_names[member] = rel
+        dest = os.path.join( stage_root, member )
+        staged.extend( env.Command( dest, obj, Copy( '$TARGET', '$SOURCE' ) ) )
+
+    return staged

--- a/design/README.md
+++ b/design/README.md
@@ -53,6 +53,7 @@ maintainer workflow evolved.
 | [`archive/conan-consumer-plan.md`](archive/conan-consumer-plan.md) | shipped | Design of `conan_deps` / `conan_dependency` consumer support |
 | [`archive/conan-publish-plan.md`](archive/conan-publish-plan.md) | shipped | Design of `ConanPackagePublisher` and `--publish-package` |
 | [`plans/sconscript-exports.md`](plans/sconscript-exports.md) | in progress | Shared exports between discovered sconscripts; nested lib/test layout |
+| [`plans/static-lib-archive-members.md`](plans/static-lib-archive-members.md) | in progress | Unique `ar` / `.lib` members when nested same-basename `.o` share one `BuildStaticLib` — [#287](https://github.com/ja11sop/cuppa/issues/287) |
 | [`plans/cmake-to-cuppa-migration.md`](plans/cmake-to-cuppa-migration.md) | proposal | CMake ↔ Cuppa matrix and migration phases for humans and agents |
 | [`archive/recursive-glob-parity.md`](archive/recursive-glob-parity.md) | shipped | RecursiveGlob / GlobFiles / Filter parity — ROADMAP `static-glob`; [#232](https://github.com/ja11sop/cuppa/issues/232) / [#231](https://github.com/ja11sop/cuppa/pull/231) |
 | [`archive/method-behaviour-audit.md`](archive/method-behaviour-audit.md) | shipped | Method returns, evaluation, paths; #213 + glob + #233 + cov nested-path; hub classification — ROADMAP `method-behaviour-audit` |

--- a/design/plans/sconscript-exports.md
+++ b/design/plans/sconscript-exports.md
@@ -149,4 +149,15 @@ Static scan will not catch every dynamic `Import(name)` constructed at runtime; 
 | Variant-aware shared exports | Covered (`tool_variant_dir` scope; `--dbg --rel` integration) |
 | `--parallel` build with imported lib | Covered (`BuildStaticLib` + `ExportShared` → consumer `Build` under `-j` on non-Windows; Windows omits `-j` due to MSVC `/Zi`/`vc140.pdb` C1090 across variant dirs) |
 | `scons-export-dedupe` | Covered — string-literal nested `SConscript` targets dropped from outer invoke; live nested call marks path per `tool_variant_dir`; Concepts updated |
-| `scons-export-capy` | Not started |
+| `scons-export-capy` | Validated 2026-09-07 on Boost.Capy develop: root `ExportShared('capy_libs')` → `test/sconscript` `ImportShared` + `BuildTest`; **50 suites / 0 failures** with cuppa master (#282/#283). Consumer sketch uses git-tracked sources only while local buffer WIP does not compile. Surfaced follow-on: [`static-lib-archive-members.md`](static-lib-archive-members.md) (`ar` basename collision). |
+| Method index | `ExportShared` / `ImportShared` / native `Export` / `Import` / `SConscript` listed (#283) |
+
+## Follow-ons outside this plan
+
+| Item | Notes |
+|------|-------|
+| Static archive member uniquify | [`static-lib-archive-members.md`](static-lib-archive-members.md) — not an Export/Import bug |
+| Doc: `#/` sources from nested discovered sconscripts | Capylike needed `#/extra/...` from `test/sconscript`; teach on Concepts or Build |
+| Doc / ROADMAP Today rows | Nested discovery + sharing now shipped; update migration tutorial when written |
+| Dynamic `Import(name)` | Still unsupported (string-literal scan bound) |
+| MSVC `/Fd` under `--parallel` | Pre-existing dbg PDB race across variant dirs; separate from exports |

--- a/design/plans/static-lib-archive-members.md
+++ b/design/plans/static-lib-archive-members.md
@@ -55,6 +55,7 @@ step still flattens identity.
 | Collision policy if uniquify impossible | `StopError` listing the colliding flattened names and relative paths — never silent drop |
 | Scope | Static archives only; same staging helps MSVC `.lib` when basenames collide |
 | Relation to #213 | Treat as the archive half of “nested same-basename sources in one library” |
+| Always stage / always flatten | **Deferred to 2.0** — one code path and uniform `ar t` names, but changes member names for *every* static lib (wider SCons signature churn and copy cost). Keep collide-only for the 1.x patch; revisit as a major when simplifying the staging branch is worth the rebuild blast radius |
 
 ## Design directions
 
@@ -62,7 +63,8 @@ step still flattens identity.
 
 Map each object node to a member name that encodes enough of the relative path under
 `working/` to be unique, then stage a file whose **basename** is that name before
-`StaticLibrary` / `$ARCOM`.
+`StaticLibrary` / `$ARCOM`. **1.x:** only when basenames collide. **2.0 candidate:**
+always flatten/stage (drop the detection branch).
 
 ### B — Detect-only (interim)
 
@@ -80,6 +82,7 @@ Deferred — portability across GCC/Clang/MSVC unclear.
 | `archive-member-detect` | Basename collision → stage (not bare StopError) |
 | `archive-member-uniquify` | Product fix in `build_library.py` + `static_archive_members.py` |
 | `archive-member-doc` | Build methods note + changelog + plan/ROADMAP |
+| `archive-member-always` | **2.0** — always stage/flatten; remove collide-only branch |
 
 ## Open questions
 
@@ -93,6 +96,7 @@ Deferred — portability across GCC/Clang/MSVC unclear.
 |-------|--------|
 | Problem seen on Boost.Capy Cuppa sketch | done (2026-09-07) |
 | Plan + ROADMAP row | done |
-| Repro integration test | in progress |
-| Uniquify / detect fix | in progress |
-| Docs | in progress |
+| Repro integration test | done (PR) |
+| Uniquify / detect fix | done (PR) |
+| Docs | done (PR) |
+| Always stage / flatten (2.0) | deferred |

--- a/design/plans/static-lib-archive-members.md
+++ b/design/plans/static-lib-archive-members.md
@@ -1,0 +1,98 @@
+# Plan: Unique static-library archive members
+
+- **Status:** in progress
+- **Related:** [`ROADMAP.md`](../../ROADMAP.md) — follow-on to `compile-object-paths` (#213); [#287](https://github.com/ja11sop/cuppa/issues/287); [`sconscript-exports.md`](sconscript-exports.md) (Boost.Capy validation 2026-09-07); [`path-vocabulary-and-scons-nodes.md`](path-vocabulary-and-scons-nodes.md); methods Build / `BuildStaticLib`
+- **Updated:** 2026-09-09
+- **Impact:** patch — fix incorrect link / missing symbols when a static archive silently drops objects; may change `.a` member names (ABI of the archive file layout, not the C++ ABI)
+
+## Problem
+
+`Compile` / `CompileStatic` mirror nested sources under `working/` so two files named
+`except.cpp` in different directories become distinct objects (shipped as
+[#213](https://github.com/ja11sop/cuppa/issues/213) / [#214](https://github.com/ja11sop/cuppa/pull/214)):
+
+```text
+_build/…/working/src/detail/except.o
+_build/…/working/src/buffers/detail/except.o
+```
+
+`BuildStaticLib` then feeds those nodes to SCons `StaticLibrary` → typically `ar rc
+lib….a …`. Traditional `ar` stores members by **basename** only. A second `except.o`
+replaces or shadows the first inside the archive. Linkers then see a subset of the
+objects: undefined references that look like “missing source” or “wrong flags”, not
+“archive ate my twin basename”.
+
+Boost.Capy’s Cuppa sketch hit this on 2026-09-07 while validating `ExportShared`:
+`src/detail/except.cpp` and `src/buffers/detail/except.cpp` both archive as `except.o`.
+`ar t libcapy.a` listed duplicate basenames; extract kept one member. The failure mode
+was easy to mis-attribute to Import/Export sharing (which was fine).
+
+This is **orthogonal** to sconscript exports. #213 fixed the compile graph; the archive
+step still flattens identity.
+
+## Goals
+
+1. Every object node passed to `BuildStaticLib` / `BuildLib` (static) must remain
+   addressable inside the produced `.a` (no silent basename loss).
+2. Fail loudly if the platform/toolchain cannot uniquify and a collision remains —
+   never ship a “successful” archive that dropped members.
+3. Document the rule next to Build methods and the #213 “same basename under
+   `working/`” story so agents do not assume object-path mirroring implies archive safety.
+
+## Non-goals
+
+- Changing shared-library (`.so` / `.dll`) link behaviour (no `ar` member table).
+- Renaming sources on disk or forbidding duplicate basenames in the project tree.
+- Replacing SCons `StaticLibrary` with a custom archiver for every toolchain on day one
+  if a smaller fix (unique member names / `ar` flags) works.
+
+## Settled lean
+
+| Topic | Decision |
+|-------|----------|
+| Where to fix | Cuppa’s static-lib path (`BuildStaticLib` / `BuildLib` static), not consumer workarounds |
+| Preferred mechanism | On **basename collision only**, stage copies under `working/.archive_members/<lib>/` with names flattened from the `build_dir`-relative path (`src/detail/except.o` → `src_detail_except.o`); pass staged nodes to `StaticLibrary`. No-collision libraries unchanged (stable `ar` member names / signatures) |
+| Collision policy if uniquify impossible | `StopError` listing the colliding flattened names and relative paths — never silent drop |
+| Scope | Static archives only; same staging helps MSVC `.lib` when basenames collide |
+| Relation to #213 | Treat as the archive half of “nested same-basename sources in one library” |
+
+## Design directions
+
+### A — Unique member names at archive time (preferred) — shipping
+
+Map each object node to a member name that encodes enough of the relative path under
+`working/` to be unique, then stage a file whose **basename** is that name before
+`StaticLibrary` / `$ARCOM`.
+
+### B — Detect-only (interim)
+
+Not used as the sole fix; collision detection gates staging instead.
+
+### C — Thin archives / `ar` path members
+
+Deferred — portability across GCC/Clang/MSVC unclear.
+
+## Work slices
+
+| Slice | Deliverable |
+|-------|-------------|
+| `archive-member-repro` | Integration fixture: two `except.cpp` → one `BuildStaticLib` → link a TU that needs symbols from **both** |
+| `archive-member-detect` | Basename collision → stage (not bare StopError) |
+| `archive-member-uniquify` | Product fix in `build_library.py` + `static_archive_members.py` |
+| `archive-member-doc` | Build methods note + changelog + plan/ROADMAP |
+
+## Open questions
+
+- Interaction with incremental `ar` / thin archives and `--parallel` archive updates (monitor after ship).
+- Does `BuildSharedLib` need any analogous note for export libs that aggregate objects?
+  (Likely no for ELF shared objects.)
+
+## Progress snapshot
+
+| Slice | Status |
+|-------|--------|
+| Problem seen on Boost.Capy Cuppa sketch | done (2026-09-07) |
+| Plan + ROADMAP row | done |
+| Repro integration test | in progress |
+| Uniquify / detect fix | in progress |
+| Docs | in progress |

--- a/docs/modules/ROOT/pages/methods/build.adoc
+++ b/docs/modules/ROOT/pages/methods/build.adoc
@@ -133,6 +133,12 @@ When `env['modules']` is true (see xref:cxx-modules.adoc[{cpp} Modules]), `Compi
 `BuildSharedLib()` produces a shared library there (via `CompileShared()` then
 `SharedLibrary()`), so object PIC and link mode stay matched.
 
+When two object files share a basename (for example nested `except.cpp` trees mirrored
+under `working/` — https://github.com/ja11sop/cuppa/issues/213[#213]), traditional
+`ar` / the MSVC librarian would keep only one archive member. `BuildStaticLib()` /
+static `BuildLib()` detect that collision and stage uniquely named copies under
+`working/.archive_members/<lib>/` before archiving, so every object remains linkable.
+
 [source,python]
 ----
 Import('env')

--- a/tests/integration/methods/test_static_lib_archive_members.py
+++ b/tests/integration/methods/test_static_lib_archive_members.py
@@ -1,0 +1,109 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+"""Integration: BuildStaticLib keeps both same-basename objects in the archive."""
+
+import subprocess
+
+import pytest
+
+from tests.helpers.cuppa_runner import assert_success, find_final_binaries, run_cuppa
+from tests.helpers.project import copy_dummy_project, write_sconstruct, write_sconscript
+
+
+pytestmark = pytest.mark.integration
+
+
+def _write_archive_collision_fixture( project ):
+    ( project / "src" / "detail" ).mkdir( parents=True, exist_ok=True )
+    ( project / "src" / "buffers" / "detail" ).mkdir( parents=True, exist_ok=True )
+    ( project / "src" / "detail" / "except.cpp" ).write_text(
+        "namespace detail { int except() { return 1; } }\n",
+        encoding="utf-8",
+    )
+    ( project / "src" / "buffers" / "detail" / "except.cpp" ).write_text(
+        "namespace buffers { namespace detail { int except() { return 2; } } }\n",
+        encoding="utf-8",
+    )
+    ( project / "apps" ).mkdir( parents=True, exist_ok=True )
+    ( project / "apps" / "both_excepts.cpp" ).write_text(
+        "namespace detail { int except(); }\n"
+        "namespace buffers { namespace detail { int except(); } }\n"
+        "int main() {\n"
+        "    return detail::except() + buffers::detail::except() == 3 ? 0 : 1;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    write_sconstruct( project )
+    write_sconscript(
+        project,
+        "Import('env')\n"
+        "sources = env.RecursiveGlob('except.cpp', start='src')\n"
+        "assert len(sources) == 2\n"
+        "lib = env.BuildStaticLib('excepts', sources)\n"
+        "env.Build('both_excepts', ['apps/both_excepts.cpp'], LIBS=[lib])\n",
+    )
+
+
+def _static_libs( project, name_stem ):
+    matches = []
+    for path in project.glob( "_build/**/final/**" ):
+        if not path.is_file():
+            continue
+        name = path.name
+        if name == "lib{}.a".format( name_stem ) or name == "{}.lib".format( name_stem ):
+            matches.append( path )
+    return sorted( matches )
+
+
+def _archive_member_names( archive_path ):
+    """List member basenames in a static archive (ar t or dumpbin /lib)."""
+    if archive_path.suffix == ".lib":
+        result = subprocess.run(
+            [ "dumpbin", "/HEADERS", str( archive_path ) ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        # Fallback: if dumpbin is awkward, rely on link success alone on MSVC.
+        if result.returncode != 0:
+            return None
+        members = []
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if line.endswith( ".obj" ) and " " not in line:
+                members.append( line )
+        return members
+
+    result = subprocess.run(
+        [ "ar", "t", str( archive_path ) ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [ line.strip() for line in result.stdout.splitlines() if line.strip() ]
+
+
+def test_build_static_lib_keeps_nested_same_basename_objects( tmp_path ):
+    """Both except() symbols must remain linkable after BuildStaticLib."""
+    project = copy_dummy_project( tmp_path )
+    _write_archive_collision_fixture( project )
+
+    result = run_cuppa( project, "--dbg", "--offline" )
+    assert_success( result )
+
+    binaries = find_final_binaries( project, "both_excepts" )
+    assert binaries, "expected both_excepts under final/"
+
+    run = subprocess.run( [ str( binaries[0] ) ], capture_output=True, text=True )
+    assert run.returncode == 0, run.stdout + run.stderr
+
+    archives = _static_libs( project, "excepts" )
+    assert archives, "expected libexcepts.a / excepts.lib under final/"
+    members = _archive_member_names( archives[0] )
+    if members is not None:
+        basenames = [ m.split( "/" )[-1] for m in members ]
+        assert len( basenames ) == len( set( basenames ) ), members
+        assert len( basenames ) >= 2, members

--- a/tests/integration/methods/test_static_lib_archive_members.py
+++ b/tests/integration/methods/test_static_lib_archive_members.py
@@ -9,7 +9,12 @@ import subprocess
 
 import pytest
 
-from tests.helpers.cuppa_runner import assert_success, find_final_binaries, run_cuppa
+from tests.helpers.cuppa_runner import (
+    assert_success,
+    find_final_binaries,
+    find_under_build,
+    run_cuppa,
+)
 from tests.helpers.project import copy_dummy_project, write_sconstruct, write_sconscript
 
 
@@ -48,34 +53,23 @@ def _write_archive_collision_fixture( project ):
 
 
 def _static_libs( project, name_stem ):
-    matches = []
-    for path in project.glob( "_build/**/final/**" ):
-        if not path.is_file():
-            continue
-        name = path.name
-        if name == "lib{}.a".format( name_stem ) or name == "{}.lib".format( name_stem ):
-            matches.append( path )
-    return sorted( matches )
+    """Find the static archive under final/ (libNAME.a or NAME.lib, any LIBPREFIX)."""
+    return sorted(
+        path
+        for path in find_under_build( project )
+        if path.is_file()
+        and path.suffix in ( ".a", ".lib" )
+        and "final" in path.parts
+        and name_stem in path.stem
+    )
 
 
 def _archive_member_names( archive_path ):
-    """List member basenames in a static archive (ar t or dumpbin /lib)."""
+    """List member basenames in a static archive (ar t). MSVC listing is optional."""
     if archive_path.suffix == ".lib":
-        result = subprocess.run(
-            [ "dumpbin", "/HEADERS", str( archive_path ) ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        # Fallback: if dumpbin is awkward, rely on link success alone on MSVC.
-        if result.returncode != 0:
-            return None
-        members = []
-        for line in result.stdout.splitlines():
-            line = line.strip()
-            if line.endswith( ".obj" ) and " " not in line:
-                members.append( line )
-        return members
+        # Link+run already proves both objects were kept; dumpbin member listing is
+        # awkward and not required on Windows CI.
+        return None
 
     result = subprocess.run(
         [ "ar", "t", str( archive_path ) ],
@@ -101,9 +95,9 @@ def test_build_static_lib_keeps_nested_same_basename_objects( tmp_path ):
     assert run.returncode == 0, run.stdout + run.stderr
 
     archives = _static_libs( project, "excepts" )
-    assert archives, "expected libexcepts.a / excepts.lib under final/"
+    assert archives, "expected excepts static archive under final/"
     members = _archive_member_names( archives[0] )
     if members is not None:
-        basenames = [ m.split( "/" )[-1] for m in members ]
+        basenames = [ m.replace( "\\", "/" ).split( "/" )[-1] for m in members ]
         assert len( basenames ) == len( set( basenames ) ), members
         assert len( basenames ) >= 2, members

--- a/tests/unit/test_static_archive_members.py
+++ b/tests/unit/test_static_archive_members.py
@@ -1,0 +1,28 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+"""Unit tests for static archive member uniquify helpers."""
+
+import pytest
+
+from cuppa.utility.static_archive_members import (
+    archive_member_name,
+    basenames_collide,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_archive_member_name_flattens_working_relative_path():
+    assert archive_member_name( 'src/detail/except.o' ) == 'src_detail_except.o'
+    assert archive_member_name( 'src/buffers/detail/except.o' ) == 'src_buffers_detail_except.o'
+    assert archive_member_name( 'except.o' ) == 'except.o'
+
+
+def test_basenames_collide_detects_duplicate_leaf_names():
+    assert basenames_collide( [ 'a/except.o', 'b/except.o' ] ) is True
+    assert basenames_collide( [ 'a/except.o', 'b/other.o' ] ) is False
+    assert basenames_collide( [] ) is False


### PR DESCRIPTION
## Summary

- Fix silent loss of nested same-basename objects inside static archives after the #213 `working/` mirror: when `BuildStaticLib` / static `BuildLib` inputs share a basename, stage uniquely named copies under `working/.archive_members/<lib>/` before `StaticLibrary` ([#287](https://github.com/ja11sop/cuppa/issues/287)).
- Libraries without basename collisions are unchanged (stable `ar` member names). Always-flatten deferred to 2.0.
- Plan, ROADMAP, Build methods docs, unit + integration coverage (link a TU that needs both `except()` symbols). Windows archive discovery aligned with other integration finders.

## Test plan

- [x] `flake8 cuppa` / `pylint -E cuppa`
- [x] `pytest -m unit`
- [x] Focused integration: `test_static_lib_archive_members`, `test_compile_object_paths`, `test_build_library`
- [x] CI green on the matrix (including `integration-windows`)

