### PR TITLE
Refresh GitLab package staging when source trees are newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ``GitlabPackagePublisher.build_package`` refreshes staged include/lib/modules when
+  the source tree is newer than the package stage (not only when the stage is missing),
+  and ``sources()`` lists include and lib outside ``abs_final_dir`` so package stamps
+  invalidate correctly for external install prefixes
+  ([#209](https://github.com/ja11sop/cuppa/issues/209)).
 - Integration ``run_cuppa`` default subprocess timeout is 360s on Windows (180s elsewhere) so
   MSVC modules, coverage, and nested ``-D`` builds on ``windows-latest`` are less likely to flake
   at the former 180s ceiling.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ Minor cycle after **1.10.0**. Prefer work that changes opt-in toolchain or packa
 | Transitive GitLab packages | [`gitlab-package-transitive.md`](design/plans/gitlab-package-transitive.md) — `cuppa-dependency.json` + `--list-dependencies` `requires` (shipped #280 / #281; #279 follow-ons deferred) |
 | Sconscript exports / sharing | [`sconscript-exports.md`](design/archive/sconscript-exports.md) — #282 / #283 shipped; remaining: dynamic `Import(name)`, MSVC `/Fd` under `--parallel` |
 | Static lib archive members | [`static-lib-archive-members.md`](design/archive/static-lib-archive-members.md) — #287 / #288 shipped (collide-only); always-flatten deferred to 2.0 |
-| GitLab CMake staging | [#209](https://github.com/ja11sop/cuppa/issues/209) — drive CMake from publishers + staging: [`cmake-drive-and-package-staging.md`](design/plans/cmake-drive-and-package-staging.md) |
+| GitLab CMake staging | [#209](https://github.com/ja11sop/cuppa/issues/209) — docs+plan shipped; **min refresh + broader `sources()`** in flight; accessors / Option B / in-place tar remain: [`cmake-drive-and-package-staging.md`](design/plans/cmake-drive-and-package-staging.md) |
 | Artefact removal design | [#135](https://github.com/ja11sop/cuppa/issues/135) |
 | Console bundle | `--terse-output`, log hygiene, `cuppa --info` |
 | Boost package identity | [`boost-updates.md`](design/plans/boost-updates.md) (`-patched` / `-clean`) |

--- a/cuppa/package_managers/gitlab.py
+++ b/cuppa/package_managers/gitlab.py
@@ -218,6 +218,50 @@ def package_archive_is_up_to_date( archive_path, staging_roots ):
     return True
 
 
+def staging_tree_needs_refresh( source_root, staging_root ):
+    """Return True when ``staging_root`` is missing or older than ``source_root``.
+
+    Same-path source and staging (identity) never refreshes — that would
+    ``rmtree`` the only copy. Absent source does not refresh either.
+    """
+    if not source_root or not os.path.exists( source_root ):
+        return False
+    if not staging_root or not os.path.exists( staging_root ):
+        return True
+    source_real = os.path.realpath( source_root )
+    staging_real = os.path.realpath( staging_root )
+    if source_real == staging_real:
+        return False
+    return newest_mtime_under( source_root ) > newest_mtime_under( staging_root )
+
+
+def refresh_staging_tree( source_root, staging_root, ignore=None ):
+    """Replace ``staging_root`` from ``source_root`` when a refresh is needed.
+
+    Returns True when a copy was performed.
+    """
+    if not staging_tree_needs_refresh( source_root, staging_root ):
+        return False
+    if os.path.exists( staging_root ):
+        shutil.rmtree( staging_root )
+    parent = os.path.dirname( staging_root )
+    if parent:
+        os.makedirs( parent, exist_ok=True )
+    shutil.copytree( source_root, staging_root, ignore=ignore )
+    return True
+
+
+def path_outside_package_final( path, abs_final_dir ):
+    """True when ``path`` is not ``abs_final_dir`` and not nested under it."""
+    if not path or not abs_final_dir:
+        return True
+    real = os.path.realpath( path )
+    final = os.path.realpath( abs_final_dir )
+    if real == final:
+        return False
+    return not real.startswith( final + os.sep )
+
+
 def package_sidecar_id( package_file_path, suffix ):
     """Sidecar stamp basename (``.packaged`` / ``.published``) for a package archive path."""
     return (
@@ -534,8 +578,9 @@ class GitlabPackagePublisher:
         self._package_file_name = package_file_name(
                 env, package=package, variant=variant, omit_os=omit_os
         )
+        self._abs_final_dir = env['abs_final_dir']
         self._package_archive = env.File(
-                os.path.join( env['abs_final_dir'], self._package_file_name )
+                os.path.join( self._abs_final_dir, self._package_file_name )
         )
         self._package_source_dir = package
 
@@ -567,40 +612,39 @@ class GitlabPackagePublisher:
 
         from SCons.Script import Touch
 
-        if not os.path.exists( str(self._target_include_dir) ):
-            source_include = _resolve_node_path( self._source_include_dir )
-            logger.info( "For package [{}], include dir [{}] does not exist so copying include files from [{}]...".format(
+        source_include = _resolve_node_path( self._source_include_dir )
+        target_include = str( self._target_include_dir )
+        if refresh_staging_tree( source_include, target_include ):
+            logger.info( "For package [{}], refreshed include staging [{}] from [{}]".format(
                     as_info( self._package_file_name ),
-                    as_info( str(self._target_include_dir) ),
-                    as_notice( source_include )
+                    as_info( target_include ),
+                    as_notice( source_include ),
             ) )
-            shutil.copytree( source_include, str(self._target_include_dir) )
 
         source_lib = _resolve_node_path( self._source_lib_dir )
-        if not os.path.exists( str(self._target_lib_dir) ):
-            logger.info( "For package [{}], lib dir [{}] does not exist so copying lib files from [{}]...".format(
+        target_lib = str( self._target_lib_dir )
+        package_dir_name = os.path.normpath( str( self._package_source_dir ) )
+        package_file_name = os.path.basename( str( self._package_file_name ) )
+        lib_ignore = lambda _directory, names: lib_copy_ignore_names(
+                names, package_dir_name, package_file_name
+        )
+        if refresh_staging_tree( source_lib, target_lib, ignore=lib_ignore ):
+            logger.info( "For package [{}], refreshed lib staging [{}] from [{}]".format(
                     as_info( self._package_file_name ),
-                    as_info( str(self._target_lib_dir) ),
-                    as_notice( source_lib )
+                    as_info( target_lib ),
+                    as_notice( source_lib ),
             ) )
-            package_dir_name = os.path.normpath( str( self._package_source_dir ) )
-            package_file_name = os.path.basename( str( self._package_file_name ) )
-            shutil.copytree(
-                source_lib,
-                str( self._target_lib_dir ),
-                ignore=lambda _directory, names: lib_copy_ignore_names(
-                        names, package_dir_name, package_file_name
-                ),
-            )
 
         source_modules = os.path.join( source_lib, 'modules' )
         target_modules = os.path.join( str( self._package_base_dir ), 'modules' )
-        if os.path.isdir( source_modules ) and not os.path.exists( target_modules ):
-            logger.info( "For package [{}], copying modules from [{}]...".format(
+        if os.path.isdir( source_modules ) and refresh_staging_tree(
+                source_modules, target_modules
+        ):
+            logger.info( "For package [{}], refreshed modules staging [{}] from [{}]".format(
                     as_info( self._package_file_name ),
+                    as_info( target_modules ),
                     as_notice( source_modules ),
             ) )
-            shutil.copytree( source_modules, target_modules )
 
         from cuppa.package_managers.cuppa_dependency_manifest import write_manifest
         manifest_path_written = write_manifest(
@@ -678,7 +722,22 @@ class GitlabPackagePublisher:
 
 
     def sources( self ):
-        return [ self._source_include_dir ]
+        # List include/lib as SCons sources when they live outside ``abs_final_dir``.
+        # Do not add dirs under (or equal to) ``abs_final_dir``: the archive and
+        # stamps live there, and listing that tree as a Command source creates a
+        # dependency cycle. Library rebuilds in the usual Cuppa-built case are
+        # already covered by the ``source`` argument to ``env.PublishPackage``.
+        abs_final = getattr( self, '_abs_final_dir', None )
+        if abs_final is None and self._package_archive is not None:
+            abs_final = os.path.dirname( str( self._package_archive ) )
+        result = []
+        for node in ( self._source_include_dir, self._source_lib_dir ):
+            if node is None:
+                continue
+            if path_outside_package_final( str( node ), abs_final ):
+                result.append( node )
+        return result
+
 
 
     def package_published( self ):

--- a/design/plans/cmake-drive-and-package-staging.md
+++ b/design/plans/cmake-drive-and-package-staging.md
@@ -2,17 +2,15 @@
 
 - **Status:** in progress
 - **Related:** [`ROADMAP.md`](../../ROADMAP.md) — 1.11.0 / [#209](https://github.com/ja11sop/cuppa/issues/209); [`cmake-to-cuppa-migration.md`](cmake-to-cuppa-migration.md) (migrate *onto* Cuppa — orthogonal); packages / custom-commands Antora; [`gitlab.py`](../../cuppa/package_managers/gitlab.py) `GitlabPackagePublisher`; preferred `Toolchain()`/`Variant()`, `Has*` inspection, deprecate `Using` / keyed `Toolchain`
-- **Updated:** 2026-09-10
-- **Impact:** `none` for docs+plan; staging refresh likely `patch`; accessors/`Has*`/deprecations and Option B helper `minor`
+- **Updated:** 2026-09-11
+- **Impact:** staging refresh `patch` (`cmake-pkg-stage-min` done); accessors/`Has*`/deprecations and Option B helper `minor`; in-place packaging later
 
 ## Intent
 
 Two related pains show up in real publisher sconscripts:
 
 1. **Cuppa→CMake mismatch** — authors hardcode `CMAKE_BUILD_TYPE=Release`, absolute `g++-N`, and ad-hoc `-B` trees instead of mirroring `--dbg`/`--rel`, the active toolchain, and Cuppa layout (`abs_build_dir` / `abs_final_dir` / `publisher.package_variant()`).
-2. **#209 staging** — `GitlabPackagePublisher.build_package` copytrees include/lib into `final/<pkg>/<ver>/` only when the staging dir is **missing**, so CMake reinstalls leave stale package trees; large install prefixes also **double** disk use on first package.
-
-This workstream starts with **docs + this design plan**. Helper / accessor / staging code lands after vocabulary settles; staging may fold into the docs PR if kept minimal.
+2. **#209 staging** — historically `build_package` copytreed only when staging was **missing** (stale after CMake reinstall); large install prefixes also **double** disk use on first package. **Min refresh + broader `sources()` shipped**; in-place packaging remains.
 
 **Public docs:** generic names (`widget`, “external CMake library”). Do not name private consumer trees. Citing [#209](https://github.com/ja11sop/cuppa/issues/209) is fine.
 
@@ -39,9 +37,9 @@ flowchart TD
 | Pattern | Typical Cuppa wiring today | Gaps |
 |---------|---------------------------|------|
 | Small lib | `-B _build/<package_variant()>`, active toolchain `.binary()`, copy `.a` into `abs_build_dir`, `Install` into `final/.../package`, then publish | Often hardcodes `Release`; `-B` under the **dependency** checkout |
-| Large install | `CMAKE_INSTALL_PREFIX` → `final/.../installed`, publish with `source_*` = that prefix | Hardcoded compiler + standard + Release; **#209** double-copy and stale staging |
+| Large install | `CMAKE_INSTALL_PREFIX` → `final/.../installed`, publish with `source_*` = that prefix | Hardcoded compiler + standard + Release; **#209** double-copy remains (stale staging fixed by min refresh) |
 
-Current staging: [`GitlabPackagePublisher.build_package`](../../cuppa/package_managers/gitlab.py) — copy only if target include/lib dirs do not exist; then tar (or skip via `.packaged` / mtime). `publisher.sources()` is **include only**.
+Current staging: [`GitlabPackagePublisher.build_package`](../../cuppa/package_managers/gitlab.py) — refresh include/lib/modules when source is newer than stage (identity path skipped); then tar (or skip via `.packaged` / mtime). `publisher.sources()` lists include **and** lib when outside `abs_final_dir`.
 
 ## Method return patterns (align accessors with existing Cuppa)
 
@@ -228,7 +226,7 @@ If minimal refresh grows, **split**: docs+plan first; staging as #209-only PR.
 |----|-------------|--------|
 | `cmake-pkg-plan` | This design plan + design README / ROADMAP pointers | **Done** (docs PR) |
 | `cmake-pkg-docs` | Antora mapping + two generic patterns | **Done** (docs PR) |
-| `cmake-pkg-stage-min` | Optional refresh-when-stale + broader `sources()` | Fold if small |
+| `cmake-pkg-stage-min` | Optional refresh-when-stale + broader `sources()` | **Done** (this PR) |
 | `toolchain-variant-accessors` | Zero-arg `Toolchain()` / `Variant()`; `HasToolchain` / `HasDependency`; deprecate `Using` + keyed `Toolchain`; strip docs; warn at runtime | Later `minor` |
 | `cmake-pkg-args-helper` | Option B + unit tests | Later `minor` |
 | `cmake-pkg-stage-inplace` | No-double-copy packaging | Later (#209 remainder) |
@@ -238,4 +236,4 @@ If minimal refresh grows, **split**: docs+plan first; staging as #209-only PR.
 1. Design index lists this plan; links resolve.
 2. Antora table is usable for CMake-novice authors; `--cov` honesty present.
 3. Accessor redesign and helper options are settled in prose before code PRs.
-4. If staging folded: unit tests for refresh-when-newer and broader `sources()`.
+4. Staging min: unit tests for refresh-when-newer and broader `sources()`; Antora NOTE matches behaviour.

--- a/docs/modules/ROOT/pages/packages.adoc
+++ b/docs/modules/ROOT/pages/packages.adoc
@@ -245,11 +245,16 @@ publisher = GitlabPackagePublisher(
 
 [NOTE]
 ====
-Today `GitlabPackagePublisher.build_package` copies include/lib into
-`final/<package>/<version>/` when those staging directories are **missing**. A later CMake
-reinstall into the same prefix does **not** refresh an existing stage tree, and the first
-package of a large install prefix **duplicates** disk use. See
-https://github.com/ja11sop/cuppa/issues/209[#209] for tracking.
+`GitlabPackagePublisher.build_package` stages include/lib (and modules, when
+present) under `final/<package>/<version>/`. Staging is created when missing
+and **refreshed when the source tree is newer** than the staged copy (same-path
+source and stage are left alone). `publisher.sources()` lists include and lib
+when those paths sit **outside** `abs_final_dir`; trees under the final
+directory are omitted to avoid SCons dependency cycles — wire the install or
+library node through `env.PublishPackage(source, publisher)` instead. Packaging
+a large install prefix still **duplicates** disk use on the first package; see
+https://github.com/ja11sop/cuppa/issues/209[#209] for in-place packaging
+follow-on.
 ====
 
 [#conan-package-publishing]

--- a/tests/unit/test_gitlab_package_publisher.py
+++ b/tests/unit/test_gitlab_package_publisher.py
@@ -81,6 +81,51 @@ def test_package_archive_is_up_to_date(tmp_path):
     )
 
 
+def test_staging_tree_needs_refresh( tmp_path ):
+    source = tmp_path / "install" / "include"
+    staging = tmp_path / "widget" / "1.0.0" / "include"
+    source.mkdir( parents=True )
+    ( source / "widget.hpp" ).write_text( "v1\n", encoding="utf-8" )
+
+    assert gitlab.staging_tree_needs_refresh( str( source ), str( staging ) )
+
+    staging.mkdir( parents=True )
+    ( staging / "widget.hpp" ).write_text( "v1\n", encoding="utf-8" )
+    time.sleep( 0.02 )
+    assert not gitlab.staging_tree_needs_refresh( str( source ), str( staging ) )
+
+    ( source / "widget.hpp" ).write_text( "v2\n", encoding="utf-8" )
+    assert gitlab.staging_tree_needs_refresh( str( source ), str( staging ) )
+
+    assert not gitlab.staging_tree_needs_refresh( str( staging ), str( staging ) )
+
+
+def test_path_outside_package_final( tmp_path ):
+    final = tmp_path / "final"
+    final.mkdir()
+    assert gitlab.path_outside_package_final( str( tmp_path / "install" ), str( final ) )
+    assert not gitlab.path_outside_package_final( str( final ), str( final ) )
+    assert not gitlab.path_outside_package_final(
+            str( final / "widget" / "1.0.0" / "include" ),
+            str( final ),
+    )
+
+
+def _bare_publisher( tmp_path, staging, include_dir, lib_dir, archive, source_include=None, source_lib=None ):
+    publisher = gitlab.GitlabPackagePublisher.__new__( gitlab.GitlabPackagePublisher )
+    publisher._target_include_dir = str( include_dir )
+    publisher._target_lib_dir = str( lib_dir )
+    publisher._package_base_dir = str( staging )
+    publisher._package_archive = str( archive )
+    publisher._abs_final_dir = str( tmp_path )
+    publisher._package_source_dir = "widget"
+    publisher._package_file_name = archive.name
+    publisher._source_include_dir = str( source_include if source_include is not None else include_dir )
+    publisher._source_lib_dir = str( source_lib if source_lib is not None else lib_dir )
+    publisher._dependencies = []
+    return publisher
+
+
 def test_build_package_skips_create_when_archive_current( tmp_path, monkeypatch ):
     create_calls = []
 
@@ -103,15 +148,7 @@ def test_build_package_skips_create_when_archive_current( tmp_path, monkeypatch 
     archive.write_bytes( b"archive" )
 
     stamp = tmp_path / "widget_debian_gcc15_rel.packaged"
-    publisher = gitlab.GitlabPackagePublisher.__new__( gitlab.GitlabPackagePublisher )
-    publisher._target_include_dir = str( include_dir )
-    publisher._target_lib_dir = str( lib_dir )
-    publisher._package_base_dir = str( staging )
-    publisher._package_archive = str( archive )
-    publisher._package_source_dir = "widget"
-    publisher._package_file_name = archive.name
-    publisher._source_lib_dir = str( lib_dir )
-    publisher._dependencies = []
+    publisher = _bare_publisher( tmp_path, staging, include_dir, lib_dir, archive )
 
     touched = []
     env = _publisher_env( tmp_path, touched )
@@ -146,15 +183,7 @@ def test_build_package_creates_archive_when_staging_newer( tmp_path, monkeypatch
     ( lib_dir / "libwidget.a" ).write_text( "new\n", encoding="utf-8" )
 
     stamp = tmp_path / "widget_debian_gcc15_rel.packaged"
-    publisher = gitlab.GitlabPackagePublisher.__new__( gitlab.GitlabPackagePublisher )
-    publisher._target_include_dir = str( include_dir )
-    publisher._target_lib_dir = str( lib_dir )
-    publisher._package_base_dir = str( staging )
-    publisher._package_archive = str( archive )
-    publisher._package_source_dir = "widget"
-    publisher._package_file_name = archive.name
-    publisher._source_lib_dir = str( lib_dir )
-    publisher._dependencies = []
+    publisher = _bare_publisher( tmp_path, staging, include_dir, lib_dir, archive )
 
     env = _publisher_env( tmp_path )
 
@@ -162,3 +191,85 @@ def test_build_package_creates_archive_when_staging_newer( tmp_path, monkeypatch
     assert create_calls == [
             ( str( archive ), str( tmp_path ), "widget" ),
     ]
+
+
+def test_build_package_refreshes_staging_when_source_newer( tmp_path, monkeypatch ):
+    monkeypatch.setattr( gitlab, 'create_package_archive', lambda *args, **kwargs: 0 )
+
+    install_include = tmp_path / "install" / "include"
+    install_lib = tmp_path / "install" / "lib"
+    install_include.mkdir( parents=True )
+    install_lib.mkdir( parents=True )
+    ( install_include / "widget.hpp" ).write_text( "old-header\n", encoding="utf-8" )
+    ( install_lib / "libwidget.a" ).write_text( "old-lib\n", encoding="utf-8" )
+
+    staging = tmp_path / "widget" / "1.0.0"
+    include_dir = staging / "include"
+    lib_dir = staging / "lib"
+    include_dir.mkdir( parents=True )
+    lib_dir.mkdir( parents=True )
+    ( include_dir / "widget.hpp" ).write_text( "stale\n", encoding="utf-8" )
+    ( lib_dir / "libwidget.a" ).write_text( "stale\n", encoding="utf-8" )
+    time.sleep( 0.02 )
+    ( install_include / "widget.hpp" ).write_text( "fresh-header\n", encoding="utf-8" )
+    ( install_lib / "libwidget.a" ).write_text( "fresh-lib\n", encoding="utf-8" )
+
+    archive = tmp_path / "widget_debian_gcc15_rel.tar.gz"
+    archive.write_bytes( b"old" )
+    stamp = tmp_path / "widget_debian_gcc15_rel.packaged"
+    publisher = _bare_publisher(
+            tmp_path,
+            staging,
+            include_dir,
+            lib_dir,
+            archive,
+            source_include=install_include,
+            source_lib=install_lib,
+    )
+
+    env = _publisher_env( tmp_path )
+    assert publisher.build_package( [ str( stamp ) ], [], env ) is None
+    assert ( include_dir / "widget.hpp" ).read_text( encoding="utf-8" ) == "fresh-header\n"
+    assert ( lib_dir / "libwidget.a" ).read_text( encoding="utf-8" ) == "fresh-lib\n"
+
+
+def test_publisher_sources_includes_lib_outside_final( tmp_path ):
+    abs_final = tmp_path / "final"
+    abs_final.mkdir()
+    install_include = tmp_path / "prefix" / "include"
+    install_lib = tmp_path / "prefix" / "lib"
+    install_include.mkdir( parents=True )
+    install_lib.mkdir( parents=True )
+
+    archive = abs_final / "widget_debian_gcc15_rel.tar.gz"
+    archive.write_bytes( b"x" )
+    publisher = _bare_publisher(
+            abs_final,
+            abs_final / "widget" / "1.0.0",
+            abs_final / "widget" / "1.0.0" / "include",
+            abs_final / "widget" / "1.0.0" / "lib",
+            archive,
+            source_include=install_include,
+            source_lib=install_lib,
+    )
+    assert publisher.sources() == [ str( install_include ), str( install_lib ) ]
+
+
+def test_publisher_sources_omits_dirs_under_final( tmp_path ):
+    archive = tmp_path / "widget_debian_gcc15_rel.tar.gz"
+    archive.write_bytes( b"x" )
+    under_include = tmp_path / "installed" / "include"
+    under_lib = tmp_path / "installed" / "lib"
+    under_include.mkdir( parents=True )
+    under_lib.mkdir( parents=True )
+
+    publisher = _bare_publisher(
+            tmp_path,
+            tmp_path / "widget" / "1.0.0",
+            tmp_path / "widget" / "1.0.0" / "include",
+            tmp_path / "widget" / "1.0.0" / "lib",
+            archive,
+            source_include=under_include,
+            source_lib=under_lib,
+    )
+    assert publisher.sources() == []


### PR DESCRIPTION
## Summary

- `GitlabPackagePublisher.build_package` refreshes staged include/lib/modules when the source tree is newer than the package stage (same-path identity skipped).
- `publisher.sources()` lists include and lib when outside `abs_final_dir`, so package stamps invalidate for external install prefixes without SCons cycles.
- Antora packages NOTE, CHANGELOG, ROADMAP, and plan `cmake-pkg-stage-min` updated for [#209](https://github.com/ja11sop/cuppa/issues/209) min slice (in-place / no-double-copy packaging still deferred).

## Test plan

- [x] `flake8 cuppa` / `pylint -E cuppa`
- [x] `pytest -m unit`
- [x] `pytest -m integration`
- [x] CI green on the matrix
