### PR TITLE
Add preferred Toolchain/Variant accessors and Has* checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Zero-arg ``env.Toolchain()`` / ``env.Variant()`` return the active handles for the current
+  toolchain×variant invoke; ``env.HasToolchain(name)`` and ``env.HasDependency(name)`` provide
+  registry membership checks (``HasToolchain`` accepts registry key or ``toolchain.name()``).
+  Antora and the CMake publisher examples teach the accessors
+  ([`cmake-drive-and-package-staging`](design/plans/cmake-drive-and-package-staging.md)).
 - ``cuppa.run`` preferred kwargs ``import_dependencies`` /
   ``auto_enable_dependencies`` (and ``import_profiles`` /
   ``auto_enable_profiles``), with legacy ``dependencies`` /
@@ -70,6 +75,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [`cmake-drive-and-package-staging`](design/plans/cmake-drive-and-package-staging.md)).
 
 ### Deprecated
+
+- ``env.Using(name)`` — prefer ``env.HasDependency(name)`` for registry existence checks
+  (removed in cuppa 2.0).
+- Keyed ``env.Toolchain(name)`` — prefer ``env.Toolchain()`` for the active toolchain or
+  ``env.HasToolchain(name)`` for registry checks (removed in cuppa 2.0).
 
 ### Removed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ Minor cycle after **1.10.0**. Prefer work that changes opt-in toolchain or packa
 | Transitive GitLab packages | [`gitlab-package-transitive.md`](design/plans/gitlab-package-transitive.md) — `cuppa-dependency.json` + `--list-dependencies` `requires` (shipped #280 / #281; #279 follow-ons deferred) |
 | Sconscript exports / sharing | [`sconscript-exports.md`](design/archive/sconscript-exports.md) — #282 / #283 shipped; remaining: dynamic `Import(name)`, MSVC `/Fd` under `--parallel` |
 | Static lib archive members | [`static-lib-archive-members.md`](design/archive/static-lib-archive-members.md) — #287 / #288 shipped (collide-only); always-flatten deferred to 2.0 |
-| GitLab CMake staging | [#209](https://github.com/ja11sop/cuppa/issues/209) — docs+plan shipped; **min refresh + broader `sources()`** in flight; accessors / Option B / in-place tar remain: [`cmake-drive-and-package-staging.md`](design/plans/cmake-drive-and-package-staging.md) |
+| GitLab CMake staging | [#209](https://github.com/ja11sop/cuppa/issues/209) — docs + min refresh shipped; **accessors in progress** → Option B next; C/E later from friction: [`cmake-drive-and-package-staging.md`](design/plans/cmake-drive-and-package-staging.md) |
 | Artefact removal design | [#135](https://github.com/ja11sop/cuppa/issues/135) |
 | Console bundle | `--terse-output`, log hygiene, `cuppa --info` |
 | Boost package identity | [`boost-updates.md`](design/plans/boost-updates.md) (`-patched` / `-clean`) |

--- a/cuppa/methods/toolchain.py
+++ b/cuppa/methods/toolchain.py
@@ -1,33 +1,64 @@
-#          Copyright Jamie Allsop 2011-2015
+#          Copyright Jamie Allsop 2011-2026
 # Distributed under the Boost Software License, Version 1.0.
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)
 
 #-------------------------------------------------------------------------------
-#   ToolchainMethod
+#   ToolchainMethod / HasToolchainMethod
 #-------------------------------------------------------------------------------
+
+from cuppa.log import logger
+
+
+_TOOLCHAIN_NAME_DEPRECATED = (
+        'env.Toolchain(name) is deprecated; use env.Toolchain() for the active '
+        'toolchain or env.HasToolchain(name) (removed in cuppa 2.0)'
+)
+
+
+def lookup_toolchain( toolchains, name ):
+    """Return a registered toolchain by registry key or ``name()``, else ``None``."""
+    if not name:
+        return None
+    key = str( name )
+    if key in toolchains:
+        return toolchains[ key ]
+    # Also accept toolchain.name() (build/ABI identity), which for Clang may
+    # differ from the registry key when --clang-stdlib tags the name
+    # (e.g. registry "clang" vs name() "clang-libc++").
+    for registered in toolchains.values():
+        if hasattr( registered, 'name' ) and registered.name() == key:
+            return registered
+    return None
+
 
 class ToolchainMethod:
 
     def __init__( self, toolchains ):
         self.__toolchains = toolchains
 
-    def __call__( self, env, toolchain ):
-        # Lookup helper only (returns toolchain metadata/object).
-        # No build nodes are emitted, so NotifyProgress is intentionally unused.
-        if not toolchain:
-            return None
-        key = str( toolchain )
-        if key in self.__toolchains:
-            return self.__toolchains[ key ]
-        # Also accept toolchain.name() (build/ABI identity), which for Clang may
-        # differ from the registry key when --clang-stdlib tags the name
-        # (e.g. registry "clang" vs name() "clang-libc++").
-        for registered in self.__toolchains.values():
-            if hasattr( registered, 'name' ) and registered.name() == key:
-                return registered
-        return None
+    def __call__( self, env, toolchain=None ):
+        # Configure-time handle / lookup only — no build nodes, so NotifyProgress
+        # is intentionally unused.
+        if toolchain is None:
+            return env['toolchain']
+        logger.warn( _TOOLCHAIN_NAME_DEPRECATED )
+        return lookup_toolchain( self.__toolchains, toolchain )
 
     @classmethod
     def add_to_env( cls, cuppa_env ):
         cuppa_env.add_method( "Toolchain", cls( cuppa_env['toolchains'] ) )
+
+
+class HasToolchainMethod:
+
+    def __init__( self, toolchains ):
+        self.__toolchains = toolchains
+
+    def __call__( self, env, name ):
+        # Registry inspection only — no build nodes.
+        return lookup_toolchain( self.__toolchains, name ) is not None
+
+    @classmethod
+    def add_to_env( cls, cuppa_env ):
+        cuppa_env.add_method( "HasToolchain", cls( cuppa_env['toolchains'] ) )

--- a/cuppa/methods/using.py
+++ b/cuppa/methods/using.py
@@ -1,12 +1,19 @@
-
-#          Copyright Jamie Allsop 2011-2015
+#          Copyright Jamie Allsop 2011-2026
 # Distributed under the Boost Software License, Version 1.0.
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)
 
 #-------------------------------------------------------------------------------
-#   UseMethod
+#   UseMethod (deprecated) / HasDependencyMethod
 #-------------------------------------------------------------------------------
+
+from cuppa.log import logger
+
+
+_USING_DEPRECATED = (
+        'env.Using() is deprecated; use env.HasDependency() (removed in cuppa 2.0)'
+)
+
 
 class UseMethod:
 
@@ -14,8 +21,9 @@ class UseMethod:
         self.__dependencies = dependencies
 
     def __call__( self, env, dependency ):
-        # Lookup helper only (returns a dependency factory/instance).
+        # Deprecated factory peek — prefer HasDependency for existence checks.
         # No build nodes are emitted, so NotifyProgress is intentionally unused.
+        logger.warn( _USING_DEPRECATED )
         if dependency in self.__dependencies:
             return self.__dependencies[ dependency ]
         return None
@@ -23,3 +31,18 @@ class UseMethod:
     @classmethod
     def add_to_env( cls, cuppa_env ):
         cuppa_env.add_method( "Using", cls( cuppa_env['dependencies'] ) )
+
+
+class HasDependencyMethod:
+
+    def __init__( self, dependencies ):
+        self.__dependencies = dependencies
+
+    def __call__( self, env, name ):
+        # Registry key membership only — not “BuildWith would succeed”.
+        # No build nodes are emitted, so NotifyProgress is intentionally unused.
+        return name in self.__dependencies
+
+    @classmethod
+    def add_to_env( cls, cuppa_env ):
+        cuppa_env.add_method( "HasDependency", cls( cuppa_env['dependencies'] ) )

--- a/cuppa/methods/variant.py
+++ b/cuppa/methods/variant.py
@@ -1,0 +1,19 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   VariantMethod — active variant handle
+#-------------------------------------------------------------------------------
+
+class VariantMethod:
+
+    def __call__( self, env ):
+        # Configure-time handle only — no build nodes, so NotifyProgress is
+        # intentionally unused.
+        return env['variant']
+
+    @classmethod
+    def add_to_env( cls, cuppa_env ):
+        cuppa_env.add_method( "Variant", cls() )

--- a/design/plans/cmake-drive-and-package-staging.md
+++ b/design/plans/cmake-drive-and-package-staging.md
@@ -3,14 +3,20 @@
 - **Status:** in progress
 - **Related:** [`ROADMAP.md`](../../ROADMAP.md) — 1.11.0 / [#209](https://github.com/ja11sop/cuppa/issues/209); [`cmake-to-cuppa-migration.md`](cmake-to-cuppa-migration.md) (migrate *onto* Cuppa — orthogonal); packages / custom-commands Antora; [`gitlab.py`](../../cuppa/package_managers/gitlab.py) `GitlabPackagePublisher`; preferred `Toolchain()`/`Variant()`, `Has*` inspection, deprecate `Using` / keyed `Toolchain`
 - **Updated:** 2026-09-11
-- **Impact:** staging refresh `patch` (`cmake-pkg-stage-min` done); accessors/`Has*`/deprecations and Option B helper `minor`; in-place packaging later
+- **Impact:** staging refresh `patch` (`cmake-pkg-stage-min` done); accessors/`Has*`/deprecations and Option B helper `minor`; in-place packaging later (power-user / E)
 
 ## Intent
 
 Two related pains show up in real publisher sconscripts:
 
 1. **Cuppa→CMake mismatch** — authors hardcode `CMAKE_BUILD_TYPE=Release`, absolute `g++-N`, and ad-hoc `-B` trees instead of mirroring `--dbg`/`--rel`, the active toolchain, and Cuppa layout (`abs_build_dir` / `abs_final_dir` / `publisher.package_variant()`).
-2. **#209 staging** — historically `build_package` copytreed only when staging was **missing** (stale after CMake reinstall); large install prefixes also **double** disk use on first package. **Min refresh + broader `sources()` shipped**; in-place packaging remains.
+2. **#209 staging** — historically `build_package` copytreed only when staging was **missing** (stale after CMake reinstall); large install prefixes also **double** disk use on first package. **Min refresh + broader `sources()` shipped**; in-place packaging remains (opt-in E).
+
+### Suggested product sequence
+
+1. **`toolchain-variant-accessors`** — preferred vocabulary for B/C.
+2. **Option B** — `cmake_configure_args` (teach with accessors).
+3. **Then** choose from real friction: missing Command ergonomics → lean **C**; multi-GB stage copy → lean **E** (power-user staging knob; not on the CMake teaching ladder). Do not treat E as step 3 by default.
 
 **Public docs:** generic names (`widget`, “external CMake library”). Do not name private consumer trees. Citing [#209](https://github.com/ja11sop/cuppa/issues/209) is fine.
 
@@ -149,7 +155,7 @@ Antora section under [`packages.adoc`](../../docs/modules/ROOT/pages/packages.ad
 
 | Cuppa surface | Typical CMake flag / use | Notes |
 |---------------|--------------------------|-------|
-| `env.Toolchain().binary()` (or `env['toolchain'].binary()` / `env['CXX']` until accessors ship) | `-D CMAKE_CXX_COMPILER=…` | Prefer method once zero-arg ships |
+| `env.Toolchain().binary()` (or `env['toolchain'].binary()` / `env['CXX']`) | `-D CMAKE_CXX_COMPILER=…` | Prefer method |
 | `env['CC']` | `-D CMAKE_C_COMPILER=…` | When the project builds C |
 | `env.Variant().name() == 'dbg'` (or `env['variant']`) | `-D CMAKE_BUILD_TYPE=Debug` | |
 | `'rel'` | `-D CMAKE_BUILD_TYPE=Release` | |
@@ -201,9 +207,11 @@ Full methods with progress wiring.
 
 | Topic | Decision |
 |-------|----------|
-| Near-term | Docs mapping + this plan |
+| Sequence | Accessors → Option B → then C *or* E from friction (not both as “next”) |
 | Accessors | Preferred: zero-arg `Toolchain()` / `Variant()`; inspection: `HasToolchain` / `HasDependency`; **deprecate** `Using` and keyed `Toolchain(name)` (warn + strip from docs) |
-| Helper | Option **B** preferred after accessors; not C/D |
+| Helper | Option **B** preferred after accessors; not C/D yet |
+| **C** | End-state ergonomics after B has callers |
+| **E** | Opt-in power-user staging (`stage='inplace'`); side quest, not default step 3 |
 | `--cov` | Default map to `RelWithDebInfo`; say Cuppa coverage does not auto-instrument CMake |
 
 Refuse: pretend `--cov` covers pure CMake builds; silent `Release` under `--dbg`; private project names in Antora; accessors returning `env`; soft names for inspection (`GetToolchain`, bare `Dependency`) that compete with preferred APIs.
@@ -226,14 +234,15 @@ If minimal refresh grows, **split**: docs+plan first; staging as #209-only PR.
 |----|-------------|--------|
 | `cmake-pkg-plan` | This design plan + design README / ROADMAP pointers | **Done** (docs PR) |
 | `cmake-pkg-docs` | Antora mapping + two generic patterns | **Done** (docs PR) |
-| `cmake-pkg-stage-min` | Optional refresh-when-stale + broader `sources()` | **Done** (this PR) |
-| `toolchain-variant-accessors` | Zero-arg `Toolchain()` / `Variant()`; `HasToolchain` / `HasDependency`; deprecate `Using` + keyed `Toolchain`; strip docs; warn at runtime | Later `minor` |
-| `cmake-pkg-args-helper` | Option B + unit tests | Later `minor` |
-| `cmake-pkg-stage-inplace` | No-double-copy packaging | Later (#209 remainder) |
+| `cmake-pkg-stage-min` | Optional refresh-when-stale + broader `sources()` | **Done** (#292) |
+| `toolchain-variant-accessors` | Zero-arg `Toolchain()` / `Variant()`; `HasToolchain` / `HasDependency`; deprecate `Using` + keyed `Toolchain`; strip docs; warn at runtime | **In progress** (`minor`) |
+| `cmake-pkg-args-helper` | Option B + unit tests | After accessors (`minor`) |
+| `cmake-pkg-stage-inplace` | Opt-in no-double-copy packaging (E) | Side quest when disk friction appears |
+| (later) Option C | `env.CMake*` methods | After B has callers |
 
-## Acceptance (docs + plan)
+## Acceptance
 
 1. Design index lists this plan; links resolve.
 2. Antora table is usable for CMake-novice authors; `--cov` honesty present.
-3. Accessor redesign and helper options are settled in prose before code PRs.
-4. Staging min: unit tests for refresh-when-newer and broader `sources()`; Antora NOTE matches behaviour.
+3. Accessors: zero-arg `Toolchain()` / `Variant()`, `Has*`, deprecations, Antora strip of `Using` / keyed `Toolchain` as primary; unit + integration coverage.
+4. Staging min: unit tests for refresh-when-newer and broader `sources()`; Antora NOTE matches behaviour (#292).

--- a/docs/modules/ROOT/pages/integration-tests.adoc
+++ b/docs/modules/ROOT/pages/integration-tests.adoc
@@ -121,7 +121,7 @@ cuppa.run(default_variants=['dbg'])
 | `Toolchain`
 | xref:integration/test-toolchain-method.adoc[]
 
-| `BuildWith`, `Using`
+| `BuildWith`, `HasDependency`
 | xref:integration/test-build-with.adoc[]
 
 | `fmt` pip plugin (`location_dependency` + static lib)

--- a/docs/modules/ROOT/pages/integration/test-build-with.adoc
+++ b/docs/modules/ROOT/pages/integration/test-build-with.adoc
@@ -1,10 +1,10 @@
-= `test_build_with` — `BuildWith` and `Using`
+= `test_build_with` — `BuildWith` and `HasDependency`
 :description: Cuppa integration test documentation for test_build_with
 
 
 == What is tested
 
-A `location_dependency` over the project `include/` tree is registered, applied with `BuildWith`, and retrievable via `Using`.
+A `location_dependency` over the project `include/` tree is registered, applied with `BuildWith`, and checked with `HasDependency`.
 
 == Generated files
 
@@ -30,7 +30,8 @@ cuppa.run(
 ----
 Import('env')
 env.BuildWith('dummy_headers')
-assert env.Using('dummy_headers') is not None
+assert env.HasDependency('dummy_headers')
+assert not env.HasDependency('missing_dependency_xyz')
 env.Build('main', 'apps/main.cpp')
 ----
 

--- a/docs/modules/ROOT/pages/integration/test-toolchain-method.adoc
+++ b/docs/modules/ROOT/pages/integration/test-toolchain-method.adoc
@@ -1,12 +1,14 @@
-= `test_toolchain_method` — `env.Toolchain`
+= `test_toolchain_method` — active toolchain and variant accessors
 :description: Cuppa integration test documentation for test_toolchain_method
 
 
 == What is tested
 
-Looking up the active toolchain by `toolchain.name()` (build/ABI identity) or by registry key returns the same toolchain object.
-For Clang with `--clang-stdlib=libc{plus}{plus}`, `name()` may be
-`clang-libc{plus}{plus}` while the registry key remains `clang`; both forms resolve.
+`env.Toolchain()` and `env.Variant()` return the active handles for the current
+toolchain×variant invoke. `env.HasToolchain(name)` accepts a registry key or
+`toolchain.name()` (build/ABI identity). For Clang with
+`--clang-stdlib=libc{plus}{plus}`, `name()` may be `clang-libc{plus}{plus}` while
+the registry key remains `clang`; both forms succeed with `HasToolchain`.
 
 == Generated files
 
@@ -24,10 +26,12 @@ cuppa.run(default_variants=['dbg'])
 [source,python]
 ----
 Import('env')
-active = env['toolchain'].name()
-looked_up = env.Toolchain(active)
-assert looked_up is not None
-assert looked_up.name() == active
+active = env.Toolchain()
+assert active is env['toolchain']
+assert env.HasToolchain(active.name())
+assert not env.HasToolchain('definitely_missing_toolchain_xyz')
+assert env.Variant() is env['variant']
+assert env.Variant().name() == 'dbg'
 env.BuildTest('hello_test', 'tests/hello_test.cpp')
 ----
 

--- a/docs/modules/ROOT/pages/methods.adoc
+++ b/docs/modules/ROOT/pages/methods.adoc
@@ -73,7 +73,7 @@ See <<progress-tracking-and-variant-scoping>> for when progress attaches.
 | {cpp} dialect, modules, Profiles
 | xref:methods/cxx-dialect-and-modules.adoc[{cpp} dialect and modules]
 
-| Dependencies and profiles (`BuildWith()`, `Using()`, …)
+| Dependencies and profiles (`BuildWith()`, `HasDependency()`, …)
 | xref:methods/dependencies-and-profiles.adoc[Dependencies and profiles]
 
 | Flags and toolchain (`ReplaceFlags()`, `AppendUnique()`, `MergeFlags()`, …)
@@ -189,7 +189,7 @@ swiss-army builder versus specialised Cuppa methods.
 
 Detailed tutorials: xref:methods/dependencies-and-profiles.adoc[Dependencies and profiles].
 
-`BuildWith()` / `Using()` / `BuildProfile()` — see also xref:dependencies.adoc[Dependencies].
+`BuildWith()` / `HasDependency()` / `BuildProfile()` — see also xref:dependencies.adoc[Dependencies].
 
 == Source discovery and filtering
 
@@ -223,7 +223,7 @@ Detailed tutorials: xref:methods/staging-files.adoc[Staging files in the build].
 
 Detailed tutorials: xref:methods/flags-and-toolchain.adoc[Flags and toolchain].
 
-`AppendUnique()`, `MergeFlags()`, `ReplaceFlags()`, `RemoveFlags()`, `Toolchain()`.
+`Toolchain()`, `Variant()`, `HasToolchain()`, `ReplaceFlags()`, `RemoveFlags()`, `AppendUnique()`, `MergeFlags()`, `Append()`.
 
 == Depends
 
@@ -285,10 +285,10 @@ Grouped names → topic page (shortcut):
 | `StdCpp()`, `CxxModules()`, `Module()`, `HeaderUnit()`, `ImportModules()`, Profiles helpers → xref:methods/cxx-dialect-and-modules.adoc[Dialect and modules]
 
 | Dependencies / profiles
-| `BuildWith()`, `Using()`, `BuildProfile()` → xref:methods/dependencies-and-profiles.adoc[Dependencies]
+| `BuildWith()`, `HasDependency()`, `BuildProfile()` → xref:methods/dependencies-and-profiles.adoc[Dependencies]
 
 | Flags / toolchain
-| `Toolchain()`, `ReplaceFlags()`, `RemoveFlags()`, `AppendUnique()`, `MergeFlags()`, `Append()` → xref:methods/flags-and-toolchain.adoc[Flags]
+| `Toolchain()`, `Variant()`, `HasToolchain()`, `ReplaceFlags()`, `RemoveFlags()`, `AppendUnique()`, `MergeFlags()`, `Append()` → xref:methods/flags-and-toolchain.adoc[Flags]
 
 | Discovery / Filter
 | `RecursiveGlob()`, `GlobFiles()`, `Glob()`, `Filter()`, `TargetFrom()` → xref:methods/discovery.adoc[Discovery]

--- a/docs/modules/ROOT/pages/methods/dependencies-and-profiles.adoc
+++ b/docs/modules/ROOT/pages/methods/dependencies-and-profiles.adoc
@@ -1,5 +1,5 @@
 = Dependencies and build-profile methods
-:description: BuildWith, Using, and BuildProfile
+:description: BuildWith, HasDependency, and BuildProfile
 
 Cuppa dependencies and build-time profiles are applied on the environment before you call
 `Build()` / `BuildTest()`. Deep tutorials for location, GitLab, and Conan packages live under
@@ -11,8 +11,8 @@ xref:dependencies.adoc[Dependencies].
 |===
 | Axis | Detail
 
-| Returns | `BuildWith()` returns the dependency instance (or a list); `Using()` returns a factory or
-  `None`; `BuildProfile()` returns nothing useful (mutates `env` only)
+| Returns | `BuildWith()` returns the dependency instance (or a list); `HasDependency(name)` returns
+  a bool; `BuildProfile()` returns nothing useful (mutates `env` only)
 | Evaluation | Configure-time
 | Output paths | N/A (dependency trees under `--dependencies-root`)
 | Progress | No (env / selection only)
@@ -94,25 +94,28 @@ Import('env')
 deps = env.BuildWith(['boost', 'widget'])
 ----
 
-== `Using()`
+== `HasDependency()`
 
-`Using(name)` looks up a dependency **factory** by name without applying it. Returns the factory,
-or `None` if that name is not registered in `cuppa.run()`.
+`HasDependency(name)` returns `True` when a dependency **factory** is registered under that exact
+registry key in `cuppa.run()`. It does **not** mean `BuildWith(name)` would succeed for every
+typed token or supply-chain case — it is a dumb registry membership check.
 
-Useful for existence checks or custom wiring before `BuildWith()`:
+Use it for existence checks before `BuildWith()`:
 
 [source,python]
 ----
 Import('env')
 
-boost_factory = env.Using('boost')
-if boost_factory is None:
+if not env.HasDependency('boost'):
     raise Exception('boost dependency is not registered in cuppa.run()')
 env.BuildWith('boost').use_libs(['filesystem'])
 ----
 
-`Using()` does not mutate include paths or link libraries — call `BuildWith()` to apply the
+`HasDependency()` does not mutate include paths or link libraries — call `BuildWith()` to apply the
 dependency to `env`.
+
+`env.Using(name)` still returns the factory (or `None`) for compatibility but is **deprecated**
+(removed in cuppa 2.0) — prefer `HasDependency(name)` for existence checks.
 
 == `BuildProfile()`
 

--- a/docs/modules/ROOT/pages/methods/docs-assets.adoc
+++ b/docs/modules/ROOT/pages/methods/docs-assets.adoc
@@ -195,7 +195,7 @@ env.RunAndRedirectToFile(out, 'tool')
 
 * xref:methods/create-version.adoc[CreateVersion] — toolchain-backed version sources (same builder pattern)
 * xref:methods/discovery.adoc[Source discovery] — find inputs before converting
-* xref:methods/flags-and-toolchain.adoc[Flags and toolchain] — `Toolchain()` lookup
+* xref:methods/flags-and-toolchain.adoc[Flags and toolchain] — `Toolchain()` / `Variant()` / `HasToolchain()`
 * xref:methods/staging-files.adoc[Staging files] — staging CSS/assets under `final/`
 * xref:integration/test-templates.adoc[Integration: Templates] ·
   xref:integration/test-docs-assets.adoc[Docs and assets] ·

--- a/docs/modules/ROOT/pages/methods/flags-and-toolchain.adoc
+++ b/docs/modules/ROOT/pages/methods/flags-and-toolchain.adoc
@@ -1,9 +1,10 @@
 = Flags and toolchain methods
-:description: Toolchain lookup and mutating compile/link flags
+:description: Active toolchain/variant accessors, registry checks, and mutating compile/link flags
 
 This page covers how you change compiler and linker flags on a Cuppa environment, and how you
-look up a registered toolchain. Cuppa's `ReplaceFlags()` / `RemoveFlags()` sit alongside everyday
-helpers such as `AppendUnique()` and `MergeFlags()` — one “how do I set flags?” story.
+read the active toolchain or check that a toolchain is registered. Cuppa's `ReplaceFlags()` /
+`RemoveFlags()` sit alongside everyday helpers such as `AppendUnique()` and `MergeFlags()` — one
+“how do I set flags?” story.
 
 Optional reference (unversioned):
 https://scons.org/doc/production/HTML/scons-user/apd.html[SCons user guide — Functions and Environment Methods].
@@ -16,7 +17,8 @@ into a real `sconscript`.
 |===
 | Axis | Detail
 
-| Returns | `Toolchain()` returns a toolchain object; flag helpers mutate `env` (typically return `None` or the env, depending on the call)
+| Returns | `Toolchain()` / `Variant()` return the active handles; `HasToolchain(name)` returns a
+  bool; flag helpers mutate `env` (typically return `None` or the env, depending on the call)
 | Evaluation | Immediate (configure-time)
 | Output paths | N/A
 | Progress | No — these calls do not create build-action nodes
@@ -49,8 +51,14 @@ into a real `sconscript`.
   modules helpers).
 
 | `Toolchain()`
-| Look up a registered toolchain by registry key (`clang`, `gcc15`, …) or by
-  `toolchain.name()` (build/ABI identity).
+| Preferred: return the **active** toolchain for this sconscript invoke (`env['toolchain']`).
+
+| `Variant()`
+| Preferred: return the **active** variant for this invoke (`env['variant']`).
+
+| `HasToolchain(name)`
+| `True` if a toolchain is registered under that registry key or `toolchain.name()` (build/ABI
+  identity). Use this for existence checks — not keyed `Toolchain(name)`.
 |===
 
 == Everyday pattern with dependencies
@@ -87,22 +95,38 @@ env.ReplaceFlags(['-std=c++23'])
 For the high-level dialect API, prefer xref:methods/cxx-dialect-and-modules.adoc[`StdCpp()`] when
 that page's tutorial is what you want; it uses `ReplaceFlags()` underneath.
 
-== Looking up a toolchain
+== Active toolchain and variant
+
+Prefer zero-arg accessors for the toolchain and variant bound on this sconscript `env`:
 
 [source,python]
 ----
 Import('env')
 
-clang = env.Toolchain('clang')
+cxx = env.Toolchain().binary()
+build_type = env.Variant().name()   # dbg, rel, cov, …
+----
+
+To check that a toolchain was registered (registry key or `name()`), use `HasToolchain`:
+
+[source,python]
+----
+Import('env')
+
+if not env.HasToolchain('clang'):
+    raise Exception('clang toolchain was not selected for this build')
 # or a build/ABI identity such as clang-libc++
 ----
+
+Keyed `env.Toolchain(name)` still resolves for compatibility but is **deprecated** (removed in
+cuppa 2.0) — prefer `Toolchain()` or `HasToolchain(name)`.
 
 Toolchain *defaults* (warnings, optimisation, modules flags) are documented under
 xref:toolchains.adoc[Toolchains] and the family pages — not duplicated here.
 
 == Related methods
 
-* xref:methods/dependencies-and-profiles.adoc[Dependencies and profiles] — `BuildWith()` / `Using()`
+* xref:methods/dependencies-and-profiles.adoc[Dependencies and profiles] — `BuildWith()` / `HasDependency()`
 * xref:methods/cxx-dialect-and-modules.adoc[{cpp} dialect and modules] — `StdCpp()`, Profiles, modules
 * xref:methods/build.adoc[Build] · xref:methods/test-run.adoc[Test and run]
 * xref:toolchains.adoc[Toolchains]

--- a/docs/modules/ROOT/pages/methods/method-index.adoc
+++ b/docs/modules/ROOT/pages/methods/method-index.adoc
@@ -195,8 +195,8 @@ For tutorials and Related-method chains, start from the xref:methods.adoc[Method
 | Apply a named dependency; returns the instance (chain `.use_libs(…)`, `local_sub_path(…)`, …)
 |
 
-| xref:methods/dependencies-and-profiles.adoc[`Using()`]
-| Look up a dependency factory by name without applying it (`None` if unregistered)
+| xref:methods/dependencies-and-profiles.adoc[`HasDependency()`]
+| `True` if a dependency factory is registered under that exact registry key
 |
 
 | xref:methods/dependencies-and-profiles.adoc[`BuildProfile()`]
@@ -212,7 +212,15 @@ For tutorials and Related-method chains, start from the xref:methods.adoc[Method
 | Method | Description | Notes
 
 | xref:methods/flags-and-toolchain.adoc[`Toolchain()`]
-| Look up a registered toolchain object by name
+| Preferred: active toolchain handle for this invoke
+|
+
+| xref:methods/flags-and-toolchain.adoc[`Variant()`]
+| Preferred: active variant handle for this invoke
+|
+
+| xref:methods/flags-and-toolchain.adoc[`HasToolchain()`]
+| `True` if registered (registry key or `toolchain.name()`)
 |
 
 | xref:methods/flags-and-toolchain.adoc[`ReplaceFlags()`]

--- a/docs/modules/ROOT/pages/packages.adoc
+++ b/docs/modules/ROOT/pages/packages.adoc
@@ -84,14 +84,22 @@ when you need `Install()` into a package layout under `final/`.
 ==== Cuppa surface → CMake flag
 
 The active toolchain and variant are bound on each sconscript `env` for the current
-toolchain×variant invoke. Today read them as construction variables; prefer
-`env['toolchain']` / `env['variant']` (not a keyed registry lookup).
+toolchain×variant invoke. Prefer the zero-arg accessors:
+
+[source,python]
+----
+cxx = env.Toolchain().binary()
+name = env.Variant().name()   # dbg, rel, cov, …
+----
+
+`env['toolchain']` / `env['variant']` remain valid. Do not use keyed `env.Toolchain(name)` for
+the active handle (that form is deprecated; use `HasToolchain(name)` for registry checks).
 
 [cols="2,2,3",options="header"]
 |===
 | Cuppa surface | Typical CMake flag / use | Notes
 
-| `env['toolchain'].binary()` or `env['CXX']`
+| `env.Toolchain().binary()` or `env['CXX']`
 | `-D CMAKE_CXX_COMPILER=…`
 | Cuppa-resolved absolute driver (including fetched toolchains)
 
@@ -99,7 +107,7 @@ toolchain×variant invoke. Today read them as construction variables; prefer
 | `-D CMAKE_C_COMPILER=…`
 | When the project also builds C
 
-| `env['variant'].name() == 'dbg'`
+| `env.Variant().name() == 'dbg'`
 | `-D CMAKE_BUILD_TYPE=Debug`
 | Mirror `--dbg`
 
@@ -167,10 +175,10 @@ build_type = {
     'dbg': 'Debug',
     'rel': 'Release',
     'cov': 'RelWithDebInfo',
-}.get( env['variant'].name(), 'Release' )
+}.get( env.Variant().name(), 'Release' )
 
 cmake_build_dir = os.path.join( '_build', publisher.package_variant() )
-cxx = env['toolchain'].binary()
+cxx = env.Toolchain().binary()
 
 configure_cmd = (
     f'cmake -B {cmake_build_dir}'
@@ -215,9 +223,9 @@ build_type = {
     'dbg': 'Debug',
     'rel': 'Release',
     'cov': 'RelWithDebInfo',
-}.get( env['variant'].name(), 'Release' )
+}.get( env.Variant().name(), 'Release' )
 
-cxx = env['toolchain'].binary()
+cxx = env.Toolchain().binary()
 cmake_out = 'cmake-out'
 
 configure_cmd = (

--- a/tests/integration/methods/test_build_with.py
+++ b/tests/integration/methods/test_build_with.py
@@ -28,7 +28,8 @@ def test_build_with_location_dependency(tmp_path):
         project,
         "Import('env')\n"
         "env.BuildWith('dummy_headers')\n"
-        "assert env.Using('dummy_headers') is not None\n"
+        "assert env.HasDependency('dummy_headers')\n"
+        "assert not env.HasDependency('missing_dependency_xyz')\n"
         "env.Build('main', 'apps/main.cpp')\n",
     )
     result = run_cuppa(project, "--dbg")

--- a/tests/integration/methods/test_toolchain_method.py
+++ b/tests/integration/methods/test_toolchain_method.py
@@ -13,10 +13,12 @@ def test_toolchain_method(tmp_path):
     write_sconscript(
         project,
         "Import('env')\n"
-        "active = env['toolchain'].name()\n"
-        "looked_up = env.Toolchain(active)\n"
-        "assert looked_up is not None\n"
-        "assert looked_up.name() == active\n"
+        "active = env.Toolchain()\n"
+        "assert active is env['toolchain']\n"
+        "assert env.HasToolchain(active.name())\n"
+        "assert not env.HasToolchain('definitely_missing_toolchain_xyz')\n"
+        "assert env.Variant() is env['variant']\n"
+        "assert env.Variant().name() == 'dbg'\n"
         "env.BuildTest('hello_test', 'tests/hello_test.cpp')\n",
     )
     result = run_cuppa(project, "--dbg", "--test")

--- a/tests/unit/test_toolchain_method_lookup.py
+++ b/tests/unit/test_toolchain_method_lookup.py
@@ -5,7 +5,9 @@
 
 import pytest
 
-from cuppa.methods.toolchain import ToolchainMethod
+from cuppa.methods.toolchain import HasToolchainMethod, ToolchainMethod, lookup_toolchain
+from cuppa.methods.using import HasDependencyMethod, UseMethod
+from cuppa.methods.variant import VariantMethod
 
 
 pytestmark = pytest.mark.unit
@@ -18,6 +20,11 @@ class _FakeToolchain(object):
 
     def name( self ):
         return self._display_name
+
+
+class _FakeVariant(object):
+    def name( self ):
+        return 'dbg'
 
 
 def test_toolchain_lookup_by_registry_key():
@@ -37,5 +44,68 @@ def test_toolchain_lookup_by_abi_name():
 def test_toolchain_lookup_missing_returns_none():
     method = ToolchainMethod( { 'gcc': _FakeToolchain( 'gcc' ) } )
     assert method( None, 'clang' ) is None
-    assert method( None, None ) is None
     assert method( None, '' ) is None
+
+
+def test_toolchain_zero_arg_returns_active():
+    active = _FakeToolchain( 'gcc' )
+    method = ToolchainMethod( { 'gcc': active } )
+    env = { 'toolchain': active }
+    assert method( env ) is active
+    assert method( env, None ) is active
+
+
+def test_toolchain_keyed_emits_deprecation( monkeypatch ):
+    warnings = []
+    monkeypatch.setattr(
+            'cuppa.methods.toolchain.logger.warn',
+            lambda message: warnings.append( message ),
+    )
+    clang = _FakeToolchain( 'clang', 'clang-libc++' )
+    method = ToolchainMethod( { 'clang': clang } )
+    assert method( {}, 'clang' ) is clang
+    assert len( warnings ) == 1
+    assert 'HasToolchain' in warnings[0]
+    assert 'removed in cuppa 2.0' in warnings[0]
+
+
+def test_has_toolchain():
+    clang = _FakeToolchain( 'clang', 'clang-libc++' )
+    method = HasToolchainMethod( { 'clang': clang } )
+    assert method( None, 'clang' ) is True
+    assert method( None, 'clang-libc++' ) is True
+    assert method( None, 'gcc' ) is False
+    assert method( None, '' ) is False
+
+
+def test_lookup_toolchain_helper():
+    clang = _FakeToolchain( 'clang', 'clang-libc++' )
+    toolchains = { 'clang': clang }
+    assert lookup_toolchain( toolchains, 'clang' ) is clang
+    assert lookup_toolchain( toolchains, 'clang-libc++' ) is clang
+    assert lookup_toolchain( toolchains, None ) is None
+
+
+def test_variant_returns_active():
+    variant = _FakeVariant()
+    assert VariantMethod()( { 'variant': variant } ) is variant
+
+
+def test_has_dependency():
+    method = HasDependencyMethod( { 'boost': object(), 'widget': object() } )
+    assert method( None, 'boost' ) is True
+    assert method( None, 'missing' ) is False
+
+
+def test_using_emits_deprecation_and_returns_factory( monkeypatch ):
+    warnings = []
+    monkeypatch.setattr(
+            'cuppa.methods.using.logger.warn',
+            lambda message: warnings.append( message ),
+    )
+    factory = object()
+    method = UseMethod( { 'boost': factory } )
+    assert method( None, 'boost' ) is factory
+    assert method( None, 'missing' ) is None
+    assert len( warnings ) == 2
+    assert 'HasDependency' in warnings[0]


### PR DESCRIPTION
## Summary

- Preferred configure-time handles: zero-arg `env.Toolchain()` / `env.Variant()` (active `env['toolchain']` / `env['variant']`).
- Registry inspection: `env.HasToolchain(name)` (key or `name()`) and `env.HasDependency(name)` (exact registry key).
- Deprecate `env.Using(name)` and keyed `env.Toolchain(name)` (warn; removed in 2.0); strip them from Antora as primary teaching.
- Plan sequence locked: accessors → Option B → C or E from friction; CMake publisher examples use the new accessors.

## Test plan

- [x] `flake8 cuppa` / `pylint -E cuppa`
- [x] `pytest -m unit`
- [x] `pytest -m integration`
- [x] CI green on the matrix
