### PR TITLE
Add CMakeConfigure/Build/Install and cuppa.buildsys.cmake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- ``cuppa.utility.cmake`` — ``cmake_configure_args`` / ``cmake_configure_command`` map the
-  active Cuppa toolchain, variant, and optional ``stdcpp`` into CMake configure flags
-  (``CMAKE_BUILD_TYPE``, ``CMAKE_CXX_COMPILER``, …) for publisher ``Command()`` graphs.
-  Antora CMake publisher patterns use the helper
+- ``cuppa.buildsys.cmake`` — public CMake argv helpers
+  (``cmake_configure_args`` / ``cmake_configure_command`` /
+  ``cmake_build_command`` / …) for publisher sconscripts; room for later
+  siblings such as ``cuppa.buildsys.b2``. Antora CMake publisher patterns use
+  this module
+  ([`cmake-drive-and-package-staging`](design/plans/cmake-drive-and-package-staging.md)).
+- ``env.CMakeConfigure`` / ``CMakeBuild`` / ``CMakeInstall`` — graph nodes for
+  external CMake publisher trees (configure stamps, ``cmake --build``, install
+  target). ``CMakeBuild`` passes ``--parallel N`` when Cuppa ``--parallel`` is set
+  (override with ``jobs=``). Methods register ``env.Clean`` on the CMake ``-B``
+  tree so ``cuppa -c`` removes out-of-tree builds under location dependencies.
+  Antora publisher patterns prefer the methods
   ([`cmake-drive-and-package-staging`](design/plans/cmake-drive-and-package-staging.md)).
 - Zero-arg ``env.Toolchain()`` / ``env.Variant()`` return the active handles for the current
   toolchain×variant invoke; ``env.HasToolchain(name)`` and ``env.HasDependency(name)`` provide
@@ -61,6 +69,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Staging / Depends docs: package ``Install`` examples use
+  ``Requires(installed_include, installed_lib)`` only (order-only under
+  ``--parallel``); explain why ``Depends`` would needlessly re-copy headers when
+  only the library changes.
 - Managing dependencies docs: short hub plus
   ``list-dependencies`` / ``list-downloads`` / ``removing`` / ``develop`` children; coloured
   ``requires`` sample uses HTML passthrough (not a collapsible text listing); removing page
@@ -90,6 +102,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Automatic ``--parallel`` job count uses the process CPU affinity set
+  (``os.sched_getaffinity`` / ``effective_cpu_count``) instead of raw
+  ``multiprocessing.cpu_count()``, so SCons ``-j`` and ``CMakeBuild``
+  ``--parallel N`` match the wrapper's "leave cores free for the OS" policy
+  (e.g. 14 on a 16-core host) rather than advertising all logical CPUs.
 - ``GitlabPackagePublisher.build_package`` refreshes staged include/lib/modules when
   the source tree is newer than the package stage (not only when the stage is missing),
   and ``sources()`` lists include and lib outside ``abs_final_dir`` so package stamps

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ Minor cycle after **1.10.0**. Prefer work that changes opt-in toolchain or packa
 | Transitive GitLab packages | [`gitlab-package-transitive.md`](design/plans/gitlab-package-transitive.md) — `cuppa-dependency.json` + `--list-dependencies` `requires` (shipped #280 / #281; #279 follow-ons deferred) |
 | Sconscript exports / sharing | [`sconscript-exports.md`](design/archive/sconscript-exports.md) — #282 / #283 shipped; remaining: dynamic `Import(name)`, MSVC `/Fd` under `--parallel` |
 | Static lib archive members | [`static-lib-archive-members.md`](design/archive/static-lib-archive-members.md) — #287 / #288 shipped (collide-only); always-flatten deferred to 2.0 |
-| GitLab CMake staging | [#209](https://github.com/ja11sop/cuppa/issues/209) — docs + min refresh + accessors shipped; **Option B (`cmake_configure_args`) in progress**; C/E later from friction: [`cmake-drive-and-package-staging.md`](design/plans/cmake-drive-and-package-staging.md) |
+| GitLab CMake staging | [#209](https://github.com/ja11sop/cuppa/issues/209) — docs + min refresh + accessors shipped; **Option B** (`cmake_configure_args`) on [#294](https://github.com/ja11sop/cuppa/pull/294); **Option C** (`CMakeConfigure` / `CMakeBuild` / `CMakeInstall`) in progress; E / archive-progress later: [`cmake-drive-and-package-staging.md`](design/plans/cmake-drive-and-package-staging.md) |
 | Artefact removal design | [#135](https://github.com/ja11sop/cuppa/issues/135) |
 | Console bundle | `--terse-output`, log hygiene, `cuppa --info` |
 | Boost package identity | [`boost-updates.md`](design/plans/boost-updates.md) (`-patched` / `-clean`) |

--- a/cuppa/buildsys/__init__.py
+++ b/cuppa/buildsys/__init__.py
@@ -1,0 +1,14 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   External build-system helpers (cmake, later b2, …)
+#-------------------------------------------------------------------------------
+
+"""Public helpers for driving external build systems from Cuppa sconscripts.
+
+Prefer ``cuppa.buildsys.cmake`` for CMake argv helpers. Graph methods live in
+``cuppa.methods.cmake`` (``env.CMakeConfigure`` / ``CMakeBuild`` / ``CMakeInstall``).
+"""

--- a/cuppa/buildsys/cmake.py
+++ b/cuppa/buildsys/cmake.py
@@ -4,15 +4,19 @@
 #          http://www.boost.org/LICENSE_1_0.txt)
 
 #-------------------------------------------------------------------------------
-#   Cuppa → CMake configure helpers (Option B)
+#   CMake configure / build argv helpers (cuppa.buildsys)
 #-------------------------------------------------------------------------------
 
-"""Build ``cmake`` configure argv from a Cuppa sconscript ``env``.
+"""Build ``cmake`` configure and ``cmake --build`` argv from a Cuppa ``env``.
 
-Pure helpers — no SCons nodes. Compose with ``cuppa.utility.command.run`` and
-``env.Command``. Prefer reading ``env['toolchain']`` / ``env['variant']`` so
-unit tests can pass plain mappings; sconscript authors still use
-``env.Toolchain()`` / ``env.Variant()`` elsewhere.
+Public API for publisher sconscripts. Option B covers configure flags;
+``env.CMakeConfigure`` / ``CMakeBuild`` / ``CMakeInstall`` compose these with
+``cuppa.utility.command.run``. Prefer reading ``env['toolchain']`` /
+``env['variant']`` / ``env['parallel']`` / ``env['job_count']`` so unit tests
+can pass plain mappings; sconscript authors still use ``env.Toolchain()`` /
+``env.Variant()`` elsewhere.
+
+Future siblings (for example ``cuppa.buildsys.b2``) belong in this package.
 """
 
 import shlex
@@ -169,4 +173,46 @@ def cmake_configure_command(
 ):
     """Return a shell command string suitable for ``cuppa.utility.command.run``."""
     tokens = [ cmake ] + list( cmake_configure_args( env, **kwargs ) )
+    return ' '.join( shlex.quote( str( token ) ) for token in tokens )
+
+
+def cmake_build_jobs( env, jobs=None ):
+    """Resolve a ``cmake --build --parallel`` job count, or ``None`` to omit.
+
+    ``jobs``:
+
+    - ``None`` (default): use ``env['job_count']`` when ``env['parallel']`` is
+      true and the count is at least 2 (Cuppa ``--parallel``)
+    - ``False`` or ``0``: omit ``--parallel`` / ``-j``
+    - positive ``int``: that many jobs (manual override)
+    """
+    if jobs is False or jobs == 0:
+        return None
+    if jobs is not None:
+        count = int( jobs )
+        if count < 1:
+            return None
+        return count
+    if env.get( 'parallel' ) and int( env.get( 'job_count' ) or 1 ) >= 2:
+        return int( env['job_count'] )
+    return None
+
+
+def cmake_build_args( build_dir, jobs=None, target=None ):
+    """Return ``cmake --build`` argv tokens (without a leading ``cmake``).
+
+    ``jobs`` must already be resolved (positive ``int`` or ``None`` to omit).
+    Uses CMake's generator-agnostic ``--parallel N`` rather than ``-- -j N``.
+    """
+    args = [ '--build', str( build_dir ) ]
+    if target is not None:
+        args.extend( [ '--target', str( target ) ] )
+    if jobs is not None:
+        args.extend( [ '--parallel', str( int( jobs ) ) ] )
+    return args
+
+
+def cmake_build_command( build_dir, jobs=None, target=None, cmake='cmake' ):
+    """Return a ``cmake --build`` shell string for ``cuppa.utility.command.run``."""
+    tokens = [ cmake ] + list( cmake_build_args( build_dir, jobs=jobs, target=target ) )
     return ' '.join( shlex.quote( str( token ) ) for token in tokens )

--- a/cuppa/construct.py
+++ b/cuppa/construct.py
@@ -12,7 +12,6 @@ import os.path
 import os
 import re
 import fnmatch
-import multiprocessing
 import six
 from urllib.parse import urlparse
 
@@ -645,7 +644,10 @@ class Construct(object):
             parallel_mode = "manually"
 
             if job_count==1 and parallel:
-                job_count = multiprocessing.cpu_count()
+                from cuppa.utility.parallelism import effective_cpu_count
+                # Honour cuppa-wrapper CPU affinity (leave cores free for the OS),
+                # not raw multiprocessing.cpu_count().
+                job_count = effective_cpu_count()
                 if job_count > 1:
                     SCons.Script.SetOption( 'num_jobs', job_count )
                     parallel_mode = "automatically"

--- a/cuppa/methods/cmake.py
+++ b/cuppa/methods/cmake.py
@@ -1,0 +1,192 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   CMakeConfigure / CMakeBuild / CMakeInstall (Option C)
+#-------------------------------------------------------------------------------
+
+"""Graph nodes for driving an external CMake project from a publisher sconscript.
+
+Compose Option B helpers (``cmake_configure_command`` / ``cmake_build_command``)
+with ``cuppa.utility.command.run`` and ``env.Command``. Callers still own
+acquire, copy/Install into a package layout, and ``PublishPackage``.
+"""
+
+import os
+
+import cuppa.progress
+
+from cuppa.utility.command import run
+from cuppa.buildsys.cmake import (
+        cmake_build_command,
+        cmake_build_jobs,
+        cmake_configure_command,
+)
+
+
+def _node_abspath( path ):
+    from SCons.Node import Node
+    if isinstance( path, Node ):
+        return path.abspath
+    return os.path.abspath( str( path ) )
+
+
+def cmake_build_tree_path( working_dir, build_dir ):
+    """Absolute path of the CMake ``-B`` tree for ``env.Clean`` registration."""
+    if build_dir is None:
+        return None
+    build_dir = str( build_dir )
+    if os.path.isabs( build_dir ):
+        return build_dir
+    if working_dir is None:
+        return None
+    return os.path.join( _node_abspath( working_dir ), build_dir )
+
+
+def _command_nodes( env, target, source, command, working_dir, clean_paths=None ):
+    nodes = env.Command( target, source, run( command, working_dir=working_dir ) )
+    if clean_paths:
+        for path in clean_paths:
+            if path:
+                env.Clean( nodes, path )
+    cuppa.progress.NotifyProgress.add( env, nodes )
+    return nodes
+
+
+class CMakeConfigureMethod(object):
+    """``env.CMakeConfigure(source, working_dir=…, build_dir=…, …)``.
+
+    Registers ``env.Clean`` on the CMake ``-B`` tree so ``cuppa -c`` removes it
+    (stamps alone are not enough when ``-B`` lives under a location dependency).
+    """
+
+    def __call__(
+            self,
+            env,
+            source,
+            working_dir,
+            target=None,
+            build_dir=None,
+            source_dir=None,
+            generator=None,
+            install_prefix=None,
+            c_compiler=False,
+            cxx_standard=True,
+            extra_defines=None,
+            include_build_type=True,
+            include_cxx_compiler=True,
+            cmake='cmake',
+    ):
+        if target is None:
+            target = 'cmake.configure.complete'
+        command = cmake_configure_command(
+                env,
+                cmake=cmake,
+                build_dir=build_dir,
+                source_dir=source_dir,
+                generator=generator,
+                install_prefix=install_prefix,
+                c_compiler=c_compiler,
+                cxx_standard=cxx_standard,
+                extra_defines=extra_defines,
+                include_build_type=include_build_type,
+                include_cxx_compiler=include_cxx_compiler,
+        )
+        return _command_nodes(
+                env,
+                target,
+                source,
+                command,
+                working_dir,
+                clean_paths=[ cmake_build_tree_path( working_dir, build_dir ) ],
+        )
+
+    @classmethod
+    def add_to_env( cls, cuppa_env ):
+        cuppa_env.add_method( 'CMakeConfigure', cls() )
+
+
+class CMakeBuildMethod(object):
+    """``env.CMakeBuild(source, build_dir=…, working_dir=…, jobs=…)``.
+
+    With ``jobs=None`` (default), passes ``--parallel N`` when Cuppa
+    ``--parallel`` set ``env['parallel']`` and ``env['job_count'] >= 2``.
+    Pass ``jobs=False`` to omit; pass a positive int to override.
+    Also ``Clean``s the CMake ``-B`` tree (same as configure).
+    """
+
+    def __call__(
+            self,
+            env,
+            source,
+            build_dir,
+            working_dir,
+            target=None,
+            jobs=None,
+            cmake='cmake',
+    ):
+        if target is None:
+            target = 'cmake.build.complete'
+        resolved_jobs = cmake_build_jobs( env, jobs=jobs )
+        command = cmake_build_command(
+                build_dir,
+                jobs=resolved_jobs,
+                cmake=cmake,
+        )
+        return _command_nodes(
+                env,
+                target,
+                source,
+                command,
+                working_dir,
+                clean_paths=[ cmake_build_tree_path( working_dir, build_dir ) ],
+        )
+
+    @classmethod
+    def add_to_env( cls, cuppa_env ):
+        cuppa_env.add_method( 'CMakeBuild', cls() )
+
+
+class CMakeInstallMethod(object):
+    """``env.CMakeInstall(source, build_dir=…, working_dir=…, target=…)``.
+
+    Runs ``cmake --build <build_dir> --target install`` (or ``cmake_target``).
+    Default ``jobs=False`` omits ``--parallel``; pass ``jobs=None`` to honour
+    Cuppa ``--parallel``, or a positive int to override.
+    Also ``Clean``s the CMake ``-B`` tree (same as configure).
+    """
+
+    def __call__(
+            self,
+            env,
+            source,
+            build_dir,
+            working_dir,
+            target=None,
+            cmake_target='install',
+            jobs=False,
+            cmake='cmake',
+    ):
+        if target is None:
+            target = 'cmake.install.complete'
+        resolved_jobs = cmake_build_jobs( env, jobs=jobs )
+        command = cmake_build_command(
+                build_dir,
+                jobs=resolved_jobs,
+                target=cmake_target,
+                cmake=cmake,
+        )
+        return _command_nodes(
+                env,
+                target,
+                source,
+                command,
+                working_dir,
+                clean_paths=[ cmake_build_tree_path( working_dir, build_dir ) ],
+        )
+
+    @classmethod
+    def add_to_env( cls, cuppa_env ):
+        cuppa_env.add_method( 'CMakeInstall', cls() )

--- a/cuppa/utility/parallelism.py
+++ b/cuppa/utility/parallelism.py
@@ -1,0 +1,38 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+#-------------------------------------------------------------------------------
+#   Parallel job count helpers
+#-------------------------------------------------------------------------------
+
+"""How many CPUs Cuppa should treat as available under ``--parallel``.
+
+The ``cuppa`` entry point may shrink process affinity (leave cores free for the
+OS). Automatic ``-j`` / ``cmake --build --parallel`` must use that restricted
+set, not raw ``cpu_count()``, or the log and tool ``-j`` disagree with affinity.
+"""
+
+import multiprocessing
+import os
+
+
+def effective_cpu_count():
+    """Return CPUs available to this process (affinity-aware), else logical count.
+
+    Prefers ``os.sched_getaffinity`` (Linux), then ``psutil`` CPU affinity, then
+    ``multiprocessing.cpu_count()``.
+    """
+    try:
+        return len( os.sched_getaffinity( 0 ) )
+    except ( AttributeError, OSError ):
+        pass
+    try:
+        import psutil
+        affinity = psutil.Process().cpu_affinity()
+        if affinity:
+            return len( affinity )
+    except Exception:
+        pass
+    return multiprocessing.cpu_count()

--- a/design/plans/cmake-drive-and-package-staging.md
+++ b/design/plans/cmake-drive-and-package-staging.md
@@ -3,7 +3,7 @@
 - **Status:** in progress
 - **Related:** [`ROADMAP.md`](../../ROADMAP.md) — 1.11.0 / [#209](https://github.com/ja11sop/cuppa/issues/209); [`cmake-to-cuppa-migration.md`](cmake-to-cuppa-migration.md) (migrate *onto* Cuppa — orthogonal); packages / custom-commands Antora; [`gitlab.py`](../../cuppa/package_managers/gitlab.py) `GitlabPackagePublisher`; preferred `Toolchain()`/`Variant()`, `Has*` inspection, deprecate `Using` / keyed `Toolchain`
 - **Updated:** 2026-09-11
-- **Impact:** staging refresh `patch` (`cmake-pkg-stage-min` done); accessors done (#293); Option B helper `minor` (#294 open); in-place packaging later (power-user / E)
+- **Impact:** staging refresh `patch` (`cmake-pkg-stage-min` done); accessors done (#293); Option B helper `minor` (#294); Option C methods `minor` (in progress); package archive progress + variant match later; in-place packaging later (power-user / E)
 
 ## Intent
 
@@ -43,9 +43,49 @@ flowchart TD
 | Pattern | Typical Cuppa wiring today | Gaps |
 |---------|---------------------------|------|
 | Small lib | `-B _build/<package_variant()>`, active toolchain `.binary()`, copy `.a` into `abs_build_dir`, `Install` into `final/.../package`, then publish | Often hardcodes `Release`; `-B` under the **dependency** checkout |
-| Large install | `CMAKE_INSTALL_PREFIX` → `final/.../installed`, publish with `source_*` = that prefix | Hardcoded compiler + standard + Release; **#209** double-copy remains (stale staging fixed by min refresh) |
+| Large install | wget/tar (or similar) → `cmake -S/-B` + `CMAKE_INSTALL_PREFIX` under `final/.../installed` → `cmake --build` + `--target install` → `PublishPackage` with `source_*` = that prefix | Hardcoded `CMAKE_BUILD_TYPE` / dialect / no toolchain `.binary()`; fixed `-B` name (dbg/rel clobber); hand-rolled `-j` via `psutil`; **#209** double-copy of large prefix |
+| Dependent package (Corosio-shaped) | Capylike `package_dependency` + Option B `extra_defines` for project-include + package dir | Variant default rel; provider script is upstream’s model, not Cuppa glue |
 
 Current staging: [`GitlabPackagePublisher.build_package`](../../cuppa/package_managers/gitlab.py) — refresh include/lib/modules when source is newer than stage (identity path skipped); then tar (or skip via `.packaged` / mtime). `publisher.sources()` lists include **and** lib when outside `abs_final_dir`.
+
+### Smoke lens — large install-prefix publisher (project C shape)
+
+Third specimen for the Option B → C thought experiment (anonymised). Contrasts with Capylike/Corosio:
+
+| Concern | What the sconscript does today | Option B covers? | Points at Option C / elsewhere? |
+|---------|--------------------------------|------------------|----------------------------------|
+| Acquire source | `wget` + `tar --strip=1` into `build_dir` (pinned version tarball) | No | Not CMake; location_dep or a download helper is a different story |
+| System deps | Assumed installed (pkg-config / apt); empty `cuppa.run` deps | No | Out of scope for cmake helpers |
+| Configure | Hardcoded `CMAKE_BUILD_TYPE=Debug`, `CMAKE_CXX_STANDARD=17`, install prefix, feature `-D`s; no `CMAKE_CXX_COMPILER` | **Yes** — `install_prefix=`, variant→build type, toolchain→compiler, `cxx_standard`, `extra_defines` | Mapping only; still `env.Command` + `run` |
+| `-B` isolation | Fixed `cmake-out` under extract tree | Caller can pass `build_dir=…/publisher.package_variant()` | Method could default that |
+| Build / install | `cmake --build` + `--target install`; `-j` from `os.cpu_count()-2` (was `psutil`) | **No** (configure-only helper) | Strongest C signal: `CMakeBuild` / `CMakeInstall` nodes + parallelism policy vs Cuppa `--parallel` |
+| Publish | `source_include/lib` = large install prefix; silent multi-minute `tar` | N/A | Option E / #209; **package-archive-progress** |
+| Env side effects | `os.environ['PREFIX']=…` | No | Leave to caller unless proven required |
+
+**Takeaway:** Option B deletes the classic Cuppa↔CMake lies (Debug under `--rel`,
+missing compiler, hand-built `-D` string). Most of the remaining bulk is **graph
+orchestration** (download → configure → build → install → publish) and **large-prefix
+staging** — exactly where a higher-level method (or E) has to justify itself, beyond
+argv sugar.
+
+**Operator friction (hours-scale builds):** this shape can take **hours** to compile
+and **many minutes** to create the GitLab package archive. Today
+`create_package_archive` runs a silent `tar -czf` (or zip walk) with no progress, so
+a healthy package step looks hung. Rebuilds must **not** redo download, CMake, install,
+staging copy, or tar when inputs are unchanged — `.packaged` / mtime skip and staging
+refresh help, but silent multi-minute tar and any unnecessary re-stage remain product
+gaps (progress-aware archive helper; Option E inplace / skip double-copy).
+
+**Deep clean:** SCons `-c` only removes graph nodes. A CMake `-B` tree under a
+location-dependency checkout is outside Cuppa `_build/` unless registered with
+`env.Clean`. Option C methods register Clean on that absolute `-B` path so
+`cuppa -c` forces a real reconfigure/rebuild rather than a no-op ninja copy.
+
+| Gap | Why it hurts here | Candidate |
+|-----|-------------------|-----------|
+| Silent package `tar`/`zip` | Minutes with no console feedback | Progress-aware `create_package_archive` (bytes / entries / heartbeat) |
+| Re-run of long steps | Hours wasted on noop rebuilds | Keep/strengthen `.packaged` + staging skip; avoid re-configure/build when stamps valid |
+| Double-copy of install prefix | Disk + time before tar | Option E `stage='inplace'` when source *is* the package tree |
 
 ## Method return patterns (align accessors with existing Cuppa)
 
@@ -185,7 +225,7 @@ Pure function / small module; argv fragments or structured object; no SCons node
 
 - **Pros:** Unit-testable; composes with `run()`; `extra_defines={}`. **Cons:** Callers still own `Command` graph; no staging fix.
 
-**Settled API (this slice):** module [`cuppa/utility/cmake.py`](../../cuppa/utility/cmake.py)
+**Settled API (this slice):** module [`cuppa/buildsys/cmake.py`](../../cuppa/buildsys/cmake.py)
 
 | Symbol | Role |
 |--------|------|
@@ -240,7 +280,7 @@ cmake_build_command = f'cmake --build {build_output}'
 **After (configure line only — graph unchanged):**
 
 ```python
-from cuppa.utility.cmake import cmake_configure_command
+from cuppa.buildsys.cmake import cmake_configure_command
 
 cmake_generator_command = cmake_configure_command(
     env,
@@ -267,9 +307,96 @@ Optional polish (not required for the helper): prefer `env.Toolchain()` in surro
 **Smoke test (consumer tree, no registry upload):** done on the Boost.Capy-shaped publisher — `--dbg` configure showed `CMAKE_BUILD_TYPE=Debug`, `--rel` showed `Release`; local `.tar.gz` / `.packaged` created without `--publish-package`. Also: single `BuildWith`, drop unused `psutil`, optional Ninja via `shutil.which`, preferred `cuppa.run` kwargs on the matching `sconstruct`.
 ### Option C — `env.CMakeConfigure` / `CMakeBuild` / `CMakeInstall`
 
-Full methods with progress wiring.
+**Informed enough to specify a lean C** from the three publisher smokes (small lib,
+dependent-package, large install-prefix). B already owns argv mapping; what remains
+repeated in every sconscript is **graph wiring**:
 
-- **Pros:** Ergonomics. **Cons:** Large surface (MSVC multi-config, generators, escape hatches). Defer until B has callers.
+```python
+env.Command( stamp, sources, run( cmake_configure_command(...), working_dir=... ) )
+env.Command( stamp, prev, run( f'cmake --build {build_dir} …' ) )
+env.Command( install_node, prev, run( f'cmake --build {build_dir} --target install' ) )
+```
+
+#### What C should absorb (shared across all three)
+
+| Concern | Lean method behaviour |
+|---------|------------------------|
+| Configure node | `env.CMakeConfigure(…)` → SCons node; internally uses Option B args + `run`; default `working_dir` / `-B` under `publisher.package_variant()` or explicit `build_dir` |
+| Build node | `env.CMakeBuild(configure_node, build_dir=…, jobs=…)` → depends on configure; **`-j` from Cuppa parallel by default** (see below) |
+| Install node | `env.CMakeInstall(build_node, build_dir=…, target='install')` → `cmake --build … --target install` (no extra `-j` unless install is a heavy custom target — default omit) |
+| Stamps | Method-owned `generation.complete` / `build.complete` (or equivalent) so authors stop inventing them |
+| Generator | Optional `generator=` / “Ninja if present” helper — same as B callers do today |
+| Progress | Wire through Cuppa command reporting so long builds are not silent blanks |
+
+#### Parallelism (`--parallel` → `cmake --build -j`)
+
+Publisher CMake builds are usually **one** long SCons action. Cuppa `--parallel` alone only raises SCons `num_jobs`; without passing `-j` into `cmake --build`, that action stays effectively serial (the large-install pain).
+
+**Default for `CMakeBuild`:** honour Cuppa’s existing parallel knobs (same idea as Boost.b2):
+
+| Condition | Behaviour |
+|-----------|-----------|
+| `env['parallel']` and `env['job_count'] >= 2` | Pass `-j {job_count}` to `cmake --build` |
+| Explicit `jobs=N` | Pass `-j N` (overrides) |
+| `jobs=False` / `jobs=0` | Omit `-j` (generator default) |
+| No `--parallel` and no `jobs=` | Omit `-j` |
+
+`--parallel` already sets `env['job_count']` from `cpu_count()` when SCons `-j` was left at 1 (`construct.py`). Methods read those env keys — authors should not re-derive affinity/`psutil` in the sconscript.
+
+**Caveat:** if a graph ever runs **several** `CMakeBuild` nodes under SCons `-j` at once, giving each full `job_count` can oversubscribe. Typical package publishers do not; document the escape hatch (`jobs=False` or a smaller `jobs=`) rather than inventing nested-job heuristics in v1 (Boost.b2’s split is for many library b2 invocations — different shape).
+
+#### What C must **not** absorb (still caller-owned)
+
+| Concern | Why leave it out |
+|---------|------------------|
+| wget / tar acquire | Not CMake; different helper if ever |
+| `extra_defines` / project-includes | Project-specific; pass through to B |
+| Copy `.a` into `abs_build_dir` + `Install` | Small-lib packaging shape; not universal |
+| `PublishPackage` / publisher construction | Packaging, not CMake |
+| System package deps | Host/CI concern |
+| Silent multi-minute package `tar` | **`package-archive-progress`** — orthogonal to C |
+| Double-copy of large install prefix | **Option E** — orthogonal to C |
+
+#### Hypothetical after lean C (large-install sketch)
+
+```python
+configured = env.CMakeConfigure(
+    extracted_release,
+    working_dir = extraction_folder,
+    build_dir = build_output,
+    install_prefix = str( install_location ),
+    generator = cmake_generator,
+    cxx_standard = False,
+    extra_defines = { … },
+)
+built = env.CMakeBuild( configured, build_dir=build_output, working_dir=extraction_folder )
+installed = env.CMakeInstall(
+    built,
+    build_dir=build_output,
+    working_dir=extraction_folder,
+    target=install_location,
+)
+published = env.PublishPackage( installed, publisher )
+```
+
+(`CMakeBuild` picks up Cuppa `--parallel` → `--parallel N`; no hand-rolled `jobs=`.)
+
+Small-lib / Corosio-shaped scripts keep the same three calls, then their own copy/`Install`
+loop. That is enough simplification to justify C; a mega-`CMakePackage` that also stages
+libs would fight the two packaging shapes.
+
+#### Still open (specify before implementing, not blockers to “enough info”)
+
+| Open | Lean default to propose |
+|------|-------------------------|
+| MSVC multi-config | Single-config generators first; document multi-config as escape hatch (`--config`) later |
+| `-j` vs Cuppa `--parallel` | **Settled:** `CMakeBuild` passes `-j env['job_count']` when `--parallel` (or explicit `jobs=`); omit otherwise — see table above |
+| Return type | **Graph nodes** (same family as `Command` / `PublishPackage`) |
+| One method vs three | Prefer three small methods (compose); reject one god-method that hides the graph |
+
+**Verdict:** enough information to design and sequence lean C. Do **not** wait for more
+publisher shapes for the configure/build/install core. Do ship **archive progress** and
+consider **E** from the large-install pain — those are not C.
 
 ### Option D — Publisher-integrated CMake mode
 
@@ -281,20 +408,22 @@ Full methods with progress wiring.
 
 `stage='copy'|'sync'|'inplace'` on the publisher.
 
-- Orthogonal to CMake teaching; addresses #209 directly.
+- Orthogonal to CMake teaching; addresses #209 / large-install double-copy directly.
 
 ### Settled lean
 
 | Topic | Decision |
 |-------|----------|
-| Sequence | Accessors → Option B → then C *or* E from friction (not both as “next”) |
+| Sequence | Accessors → Option B → then **lean C** *and/or* archive-progress / E from friction (not a single “next”) |
 | Accessors | Preferred: zero-arg `Toolchain()` / `Variant()`; inspection: `HasToolchain` / `HasDependency`; **deprecate** `Using` and keyed `Toolchain(name)` (warn + strip from docs) |
-| Helper | Option **B** preferred after accessors; not C/D yet |
-| **C** | End-state ergonomics after B has callers |
-| **E** | Opt-in power-user staging (`stage='inplace'`); side quest, not default step 3 |
+| Helper | Option **B** in ``cuppa.buildsys.cmake``; feeds C |
+| **C** | Lean `CMakeConfigure` / `CMakeBuild` / `CMakeInstall` graph nodes; **informed enough** from three smokes; do not absorb acquire / copy-Install / Publish / tar progress |
+| Package include←lib | ``Requires(installed_include, installed_lib)`` (order-only); not ``Depends`` |
+| **E** | Opt-in power-user staging (`stage='inplace'`); large install-prefix |
+| Archive progress | Separate slice; hours-scale package `tar` must not look hung |
 | `--cov` | Default map to `RelWithDebInfo`; say Cuppa coverage does not auto-instrument CMake |
 
-Refuse: pretend `--cov` covers pure CMake builds; silent `Release` under `--dbg`; private project names in Antora; accessors returning `env`; soft names for inspection (`GetToolchain`, bare `Dependency`) that compete with preferred APIs.
+Refuse: pretend `--cov` covers pure CMake builds; silent `Release` under `--dbg`; private project names in Antora; accessors returning `env`; soft names for inspection (`GetToolchain`, bare `Dependency`) that compete with preferred APIs; Option D; a C that also owns packaging.
 
 ## #209 staging — fold-in?
 
@@ -308,6 +437,73 @@ Refuse: pretend `--cov` covers pure CMake builds; silent `Release` under `--dbg`
 
 If minimal refresh grows, **split**: docs+plan first; staging as #209-only PR.
 
+## Dependent packages — variant matching + CMake wire-up
+
+Explored against a Boost.Corosio-shaped publisher that `BuildWith`s a Capylike
+`package_dependency` (registry archive) while driving Corosio via Option B.
+
+### Variant matching (dbg consumer → rel dependency)
+
+**Today:** if `package_dependency(…)` omits `variant=`, `GitlabPackageDependency.package_id`
+forces `_variant = "rel"`. A `--dbg` Corosio build therefore pulls a **rel** Capylike
+archive. That is intentional-enough for many static libs (ABI / headers dominate;
+debug symbols live in the consumer’s own objects), and it matches what the smoke
+run already did.
+
+**Product intent (default):** building a dbg (or cov) package **may** consume
+**rel** dependency packages. Exact/strict same-variant matching is opt-in, not
+the default.
+
+| Policy | Behaviour |
+|--------|-----------|
+| **Default (allow cross-variant)** | Unspecified `variant` → prefer `rel` (current), *or* later: try env variant then fall back to `rel` if the archive is missing |
+| **Strict / exact** | Match `env.Variant()` (or an explicit `variant=`); fail closed if that archive is absent |
+
+**Cuppa slice (later, `minor`):** document the default; add an explicit strict switch
+(CLI and/or `package_dependency(…, match='exact')` — exact spelling TBD). Do **not**
+break existing “omit variant → rel” publishers without a migration note.
+
+**Refuse:** silently switching the default to “always match env variant” (that would
+404 many dbg/cov consumers that only publish rel dependency archives).
+
+### Corosio Capylike wire-up (not a Cuppa workaround)
+
+Corosio’s standalone CMake expects `Boost::capy` to already exist (“provided by the
+consumer”). It does **not** `find_package(boost_capy)` for the in-tree build. The
+supported consumer integration is therefore:
+
+- `CMAKE_PROJECT_boost_corosio_INCLUDE` → a cmake script that creates `Boost::capy`
+- plus custom inputs that script understands (`COROSIO_CI_CAPY_PACKAGE_DIR` for a
+  Capylike package tree, or `COROSIO_CI_CAPY_SOURCE_DIR` for `add_subdirectory`)
+
+`provide-capy.cmake` is that script. With a Capylike **GitLab package**, Cuppa still
+needs both `-D`s: the package supplies files on disk; the include script turns
+`package_dir()` into an `IMPORTED`/`ALIAS` target. Path-only defines are not enough —
+Corosio links **targets**, not bare include/lib paths.
+
+Calling that “hacky” reflects an upstream design preference (`find_package` would be
+nicer), **not** a Cuppa gap to paper over in this workstream. Rewriting Corosio’s
+dependency model is out of scope here.
+
+**This workstream’s job:** keep driving publishers with Option B
+(`cmake_configure_command` / `extra_defines`, accessors, package deps) to see how far
+utilities go, what stays awkward in the sconscript, and whether that friction justifies
+a higher-level Option C (`env.CMake*`) — and what that method would need to absorb
+(configure argv, project-includes, dep package dirs, generators, build/install graph).
+
+`CMAKE_PREFIX_PATH` + shipping Capylike cmake package config remains a possible
+*upstream* improvement later; it is **not** the success criterion for Option B/C.
+
+### Settled lean (this section)
+
+| Topic | Decision |
+|-------|----------|
+| dbg → rel deps | **Allowed default**; strict/exact is opt-in |
+| `provide-capy.cmake` | **Legitimate Corosio integration**; keep for package and source paths |
+| Package + provider | Capylike `package_dependency` + the two `-D`s is the intended smoke path |
+| Exercise | Stress-test Option B → judge Option C value from real publisher friction |
+| Upstream rewrite | Out of scope (Corosio `find_package` / Capylike cmake Install) |
+
 ## Work slices
 
 | ID | Deliverable | Target |
@@ -316,14 +512,19 @@ If minimal refresh grows, **split**: docs+plan first; staging as #209-only PR.
 | `cmake-pkg-docs` | Antora mapping + two generic patterns | **Done** (docs PR) |
 | `cmake-pkg-stage-min` | Optional refresh-when-stale + broader `sources()` | **Done** (#292) |
 | `toolchain-variant-accessors` | Zero-arg `Toolchain()` / `Variant()`; `HasToolchain` / `HasDependency`; deprecate `Using` + keyed `Toolchain`; strip docs; warn at runtime | **Done** (#293) |
-| `cmake-pkg-args-helper` | Option B + unit tests | **In progress** (`minor`) |
-| `cmake-pkg-stage-inplace` | Opt-in no-double-copy packaging (E) | Side quest when disk friction appears |
-| (later) Option C | `env.CMake*` methods | After B has callers |
+| `cmake-pkg-args-helper` | Option B + unit tests | **Done** on branch / #294 (`minor`) |
+| `cmake-pkg-methods` | Lean Option C: `CMakeConfigure` / `CMakeBuild` / `CMakeInstall` | **In progress** (`minor`) |
+| `package-archive-progress` | Progress / heartbeat while creating large `.tar.gz` / `.zip` | Later (`patch`/`minor`) — project C pain |
+| `package-variant-match` | Document dbg→rel default; opt-in strict/exact | Later (`minor`) |
+| `cmake-pkg-dep-wire` | Antora: package dep + project-include / `extra_defines` pattern (Corosio-shaped) | Later (docs from smoke) |
+| `cmake-pkg-stage-inplace` | Opt-in no-double-copy packaging (E) — large install-prefix | Side quest when disk/time friction appears |
+| (later) Option C polish | MSVC multi-config escape hatch | After lean C |
 
 ## Acceptance
 
 1. Design index lists this plan; links resolve.
 2. Antora table is usable for CMake-novice authors; `--cov` honesty present.
 3. Accessors: zero-arg `Toolchain()` / `Variant()`, `Has*`, deprecations, Antora strip of `Using` / keyed `Toolchain` as primary; unit + integration coverage (#293).
-4. Option B: unit tests for configure argv mapping; Antora patterns use `cmake_configure_command`.
+4. Option B: unit tests for configure argv mapping; Antora patterns use `cmake_configure_command` / methods.
 5. Staging min: unit tests for refresh-when-newer and broader `sources()`; Antora NOTE matches behaviour (#292).
+6. Option C: unit tests for `cmake_build_jobs` / methods; Antora patterns use `CMakeConfigure` / `CMakeBuild` / `CMakeInstall`; `--parallel` → `--parallel N`.

--- a/docs/modules/ROOT/pages/cli/building.adoc
+++ b/docs/modules/ROOT/pages/cli/building.adoc
@@ -24,7 +24,7 @@ you can see which layer owns each decision.
 | `--scripts=LIST` | Limit graph construction to the named, comma-separated sconscripts. Product `Import` / `ImportShared` may still **widen** the set to pull required exporters from under the sconstruct (unless `--strict-sconscript-exports`)
 | `--projects=LIST` | Alias for `--scripts`
 | `--strict-sconscript-exports` | Do not widen for Export/Import; every imported name must be satisfied by the scripts already selected
-| `--parallel` | Set SCons' job count from available hardware; the wrapper may also restrict CPU affinity. Do not combine with `--cov --test` (Cuppa warns; collect serially)
+| `--parallel` | Set SCons' job count from CPUs available to the process (honours the wrapper's CPU affinity, which leaves cores free for the OS on larger machines). `CMakeBuild` uses the same count for `cmake --build --parallel`. Do not combine with `--cov --test` (Cuppa warns; collect serially)
 | `--offline` | Skip the PyPI version check and remote location updates
 | `--develop` | Prefer configured local develop paths for dependencies
 |===

--- a/docs/modules/ROOT/pages/methods/custom-commands.adoc
+++ b/docs/modules/ROOT/pages/methods/custom-commands.adoc
@@ -15,8 +15,8 @@ envs, so user `Command()` calls participate in variant progress.
 Typical jobs:
 
 * Wrap an external generate/build tool (CMake configure/build in a publisher tree —
-  prefer `cuppa.utility.cmake.cmake_configure_command` so flags track Cuppa's
-  toolchain/variant; see
+  prefer `env.CMakeConfigure` / `CMakeBuild` / `CMakeInstall`, or the lower-level
+  `cuppa.buildsys.cmake` helpers; see
   xref:packages.adoc#publishing-from-external-cmake[Publishing from an external CMake build])
 * Emit a marker file after a binary exists (`tool.done`)
 * Run a one-off code generator whose outputs feed `Build()` / `Install()`
@@ -45,6 +45,10 @@ Prefer Cuppa's specialised methods when they fit:
 
 | Arbitrary action in the graph
 | `Command()` (this page)
+
+| External CMake configure / build / install
+| `CMakeConfigure()` / `CMakeBuild()` / `CMakeInstall()` —
+  xref:packages.adoc#publishing-from-external-cmake[Publishing from an external CMake build]
 |===
 
 `Run()` versus `Command()` is also summarised on xref:methods/test-run.adoc#generic-runs-with-run[Test and run].

--- a/docs/modules/ROOT/pages/methods/depends.adoc
+++ b/docs/modules/ROOT/pages/methods/depends.adoc
@@ -46,12 +46,24 @@ in whether a change to *B* forces *A* to rebuild:
 | Use when you only need presence / ordering — for example copying a binary into a docker tree
   after `Build()` has produced it under `final/`, without re-copying every time an unrelated
   prerequisite rebuilds for another reason. Without `Requires()`, the copy can race the link
-  under parallel builds.
+  under parallel builds. Same pattern for publisher staging: `Requires(installed_include,
+  installed_lib)` so `PublishPackage(installed_include, …)` waits for the library Install
+  without re-copying headers when only the `.a` changes (see
+  xref:methods/staging-files.adoc#package-staging-with-install[Staging files]).
 |===
 
 Prefer the Cuppa kwargs (`test_depends_on`, `build_depends_on`) when you are attaching fixtures to
 `BuildTest()` / `Test()`. Use `env.Depends()` / `env.Requires()` when you are ordering nodes that are
 not covered by those kwargs (install copies, custom `Command()` chains, wait/update helpers).
+
+[NOTE]
+====
+**Package include + lib:** headers do not take the library as an *input*. If
+`PublishPackage` is sourced from the include Install only, use
+`Requires(installed_include, installed_lib)` for order under `--parallel`. Prefer that over
+`Depends(installed_include, installed_lib)`, which would rebuild the header Install whenever
+the library node changed.
+====
 
 == Ordering packaging after a binary
 

--- a/docs/modules/ROOT/pages/methods/method-index.adoc
+++ b/docs/modules/ROOT/pages/methods/method-index.adoc
@@ -459,6 +459,18 @@ xref:concepts.adoc#sconscript-discovery[Concepts: sconscript discovery and shari
 |===
 | Method | Description | Notes
 
+| xref:methods/packages.adoc[`CMakeConfigure()`]
+| Configure an external CMake tree (Cuppa toolchain/variant → CMake flags)
+| See xref:packages.adoc#publishing-from-external-cmake[Publishing from an external CMake build]
+
+| xref:methods/packages.adoc[`CMakeBuild()`]
+| `cmake --build`; ``--parallel`` when Cuppa ``--parallel`` is set
+|
+
+| xref:methods/packages.adoc[`CMakeInstall()`]
+| `cmake --build … --target install`
+|
+
 | xref:methods/packages.adoc[`PublishPackage()`]
 | Publish staged nodes through a publisher object
 |

--- a/docs/modules/ROOT/pages/methods/packages.adoc
+++ b/docs/modules/ROOT/pages/methods/packages.adoc
@@ -2,8 +2,10 @@
 :description: PublishPackage and InstallPackage
 
 Cuppa package methods stage and publish libraries for registry or Conan consumers.
-Publisher trees often combine `Command()`, `Install()`, and `Depends()` / `Requires()` — see
-xref:methods/staging-files.adoc[Staging files] and xref:methods/depends.adoc[Depends].
+Publisher trees often combine `CMakeConfigure` / `CMakeBuild` / `CMakeInstall` (or
+raw `Command()`), `Install()`, and `Depends()` / `Requires()` — see
+xref:packages.adoc#publishing-from-external-cmake[Publishing from an external CMake build],
+xref:methods/staging-files.adoc[Staging files], and xref:methods/depends.adoc[Depends].
 
 == Behaviour summary
 
@@ -14,7 +16,7 @@ xref:methods/staging-files.adoc[Staging files] and xref:methods/depends.adoc[Dep
 | Returns | Package-related nodes
 | Evaluation | Configure / build; upload typically requires `--publish-package`
 | Output paths | Package layout under cuppa package roots / registry archives
-| Progress | As wired by package publishers
+| Progress | As wired by package publishers / CMake methods
 |===
 
 == Methods
@@ -22,6 +24,15 @@ xref:methods/staging-files.adoc[Staging files] and xref:methods/depends.adoc[Dep
 [cols="2,3"]
 |===
 | Method | Role
+
+| `env.CMakeConfigure(…)`
+| Configure an external CMake project (toolchain/variant flags via `cuppa.buildsys.cmake`)
+
+| `env.CMakeBuild(…)`
+| `cmake --build`; honours Cuppa `--parallel` as `--parallel N` unless `jobs=` overrides
+
+| `env.CMakeInstall(…)`
+| `cmake --build … --target install` (default omits `--parallel`)
 
 | `env.PublishPackage(…)`
 | Build (and optionally publish) a package; GitLab generic tarball or Conan `export-pkg` via a publisher object; upload requires `--publish-package`

--- a/docs/modules/ROOT/pages/methods/staging-files.adoc
+++ b/docs/modules/ROOT/pages/methods/staging-files.adoc
@@ -131,10 +131,12 @@ env.InstallAs(
 )
 ----
 
+[#package-staging-with-install]
 == Package staging with `Install()`
 
 Publisher sconscripts typically install headers and libraries into a package directory, then hand
-the nodes to `PublishPackage()`:
+the nodes to `PublishPackage()`. `PublishPackage` is usually wired from the **include** Install
+node only, so under `--parallel` you must still ensure the library Install finishes first:
 
 [source,python]
 ----
@@ -148,14 +150,21 @@ lib_node = built_library_node      # from an earlier Command / Build step
 installed_include = env.Install(os.path.join(package_dir, 'include'), include_src)
 installed_lib = env.Install(os.path.join(package_dir, 'lib'), lib_node)
 
-env.Depends(installed_include, installed_lib)
+# Order-only: stage the library before packaging, but do *not* re-copy headers
+# when only the .a changes. Header Install already rebuilds when include_src changes.
 env.Requires(installed_include, installed_lib)
 
 published = env.PublishPackage(installed_include, publisher)
 ----
 
-`Depends()` / `Requires()` keep include and library staging ordered with the built library — see
-xref:methods/depends.adoc[Depends] and xref:methods/packages.adoc[Packages].
+Prefer ``Requires(installed_include, installed_lib)`` here — not ``Depends``. Headers do not
+*depend on* the library as an input; they only need the library Install to have run so
+``PublishPackage`` (which follows the include node) sees a complete ``package_dir``.
+``Depends(include, lib)`` would also work for ordering, but would re-run the header Install
+whenever the library node changed, which is unnecessary.
+
+See xref:methods/depends.adoc[Depends] (``Depends`` vs ``Requires``) and
+xref:methods/packages.adoc[Packages].
 
 == Assets under `final/`
 

--- a/docs/modules/ROOT/pages/packages.adoc
+++ b/docs/modules/ROOT/pages/packages.adoc
@@ -77,12 +77,17 @@ then `PublishPackage()`. Map Cuppa's active toolchain and variant into CMake fla
 `--dbg` / `--rel` / `--cov` and `--toolchains=` produce matching external builds instead of
 always forcing `Release` and a hard-coded compiler path.
 
-Use xref:methods/custom-commands.adoc[Custom commands] (`cuppa.utility.command.run` +
-`env.Command`) for the CMake invocations. Prefer
-`cuppa.utility.cmake.cmake_configure_command` (or `cmake_configure_args`) so
-`CMAKE_BUILD_TYPE` and `CMAKE_CXX_COMPILER` track the active variant and toolchain
-instead of hand-rolled dictionaries. Pair with xref:methods/staging-files.adoc[Staging files]
+Use xref:methods/custom-commands.adoc[Custom commands] when you need a raw
+`Command()`, but prefer **`env.CMakeConfigure` / `CMakeBuild` / `CMakeInstall`**
+for the usual configure → build → install graph. Those methods wrap
+`cuppa.buildsys.cmake` (Option B argv helpers) and `cuppa.utility.command.run` so
+`CMAKE_BUILD_TYPE` / `CMAKE_CXX_COMPILER` track the active variant and toolchain,
+and `CMakeBuild` passes ``cmake --build --parallel N`` when you pass Cuppa
+``--parallel``. Pair with xref:methods/staging-files.adoc[Staging files]
 when you need `Install()` into a package layout under `final/`.
+
+Lower-level: `cmake_configure_command` / `cmake_build_command` remain available if
+you must hand-wire `env.Command` yourself.
 
 ==== Cuppa surface → CMake flag
 
@@ -141,13 +146,24 @@ the active handle (that form is deprecated; use `HasToolchain(name)` for registr
 | `CMAKE_INSTALL_PREFIX` and/or `Install()` destinations
 | Large third-party trees often install once under `final/`, then publish from that prefix
 
-| `--parallel` / SCons `-j`
-| `cmake --build … --parallel` / `-j N`
-| Separate from Cuppa's job server; choose `N` deliberately (for example from process affinity)
+| `--parallel` / `env['job_count']`
+| `cmake --build … --parallel N` via `env.CMakeBuild`
+| When Cuppa `--parallel` is set, `CMakeBuild` passes `--parallel` with
+  `env['job_count']` (affinity-aware — same count as SCons `-j`, after the
+  wrapper leaves cores free for the OS). Override with `jobs=N` or omit with
+  `jobs=False`. Nested oversubscribe is possible if several CMake builds run
+  under SCons `-j` at once; use `jobs=` then.
 
 | Generator (`-G Ninja`, …)
-| Author choice
+| Author choice (`generator=` on `CMakeConfigure`)
 | Common on Linux; not required by Cuppa
+
+| `cuppa -c` / SCons clean
+| Removes configure/build/install stamps **and** the CMake `-B` tree
+| `CMakeConfigure` / `CMakeBuild` / `CMakeInstall` register `env.Clean` on the
+  absolute `-B` path (including trees under location-dependency checkouts).
+  Without that, clean only removes Cuppa copies/stamps and the next build
+  looks like a no-op ninja rebuild.
 |===
 
 ==== Pattern A — small library: configure, build, install, publish
@@ -159,8 +175,6 @@ tree under `final/`, then `PublishPackage`.
 ----
 Import( 'env' )
 import os
-from cuppa.utility.command import run
-from cuppa.utility.cmake import cmake_configure_command
 from cuppa.package_managers.gitlab import GitlabPackagePublisher
 
 # Source tree already available (location dependency, extract step, …)
@@ -177,28 +191,27 @@ publisher = GitlabPackagePublisher(
 )
 
 cmake_build_dir = os.path.join( '_build', publisher.package_variant() )
-configure_cmd = cmake_configure_command(
-    env,
+configure = env.CMakeConfigure(
+    widget_src,
+    working_dir = widget_src,
     build_dir = cmake_build_dir,
     generator = 'Ninja',
-    extra_defines = { 'WIDGET_BUILD_TESTS': 'OFF' },
+    extra_defines = { 'WIDGET_BUILD_TESTS': False },
 )
-build_cmd = f'cmake --build {cmake_build_dir}'
-
-configure = env.Command(
-    'cmake.configure.complete',
-    widget_src,
-    run( configure_cmd, working_dir=widget_src ),
-)
-built = env.Command(
-    'cmake.build.complete',
+built = env.CMakeBuild(
     configure,
-    run( build_cmd, working_dir=widget_src ),
+    build_dir = cmake_build_dir,
+    working_dir = widget_src,
 )
 
 # Install or copy headers/libs into package_dir, then:
 # env.PublishPackage( installed_nodes, publisher )
 ----
+
+When `PublishPackage` is sourced from the include `Install` only, order the library
+Install with `Requires(installed_include, installed_lib)` under `--parallel` — do not
+use `Depends` for that edge (headers should not re-copy when only the `.a` changes).
+See xref:methods/staging-files.adoc#package-staging-with-install[Staging files].
 
 ==== Pattern B — install prefix: CMake install, then publish
 
@@ -209,26 +222,10 @@ Sketch: CMake installs into a prefix under `final/`; `GitlabPackagePublisher` po
 ----
 Import( 'env' )
 import os
-from cuppa.utility.command import run
-from cuppa.utility.cmake import cmake_configure_command
 from cuppa.package_managers.gitlab import GitlabPackagePublisher
 
 # extraction_folder = … Dir under env['build_dir'] after download/extract …
 install_prefix = env.Dir( os.path.join( env['final_dir'], 'installed' ) )
-
-cmake_out = 'cmake-out'
-configure_cmd = cmake_configure_command(
-    env,
-    source_dir = '.',
-    build_dir = cmake_out,
-    install_prefix = install_prefix,
-    extra_defines = { 'BUILD_TESTING': False },
-)
-build_cmd = f'cmake --build {cmake_out}'
-install_cmd = f'cmake --build {cmake_out} --target install'
-
-# Wire Command() nodes: configure → build → install into install_prefix …
-
 publisher = GitlabPackagePublisher(
     env,
     source_include_dir = os.path.join( str( install_prefix ), 'include' ),
@@ -237,7 +234,28 @@ publisher = GitlabPackagePublisher(
     package            = 'widget',
     version            = '2.28.0',
 )
-# env.PublishPackage( install_node, publisher )
+
+cmake_out = os.path.join( '_build', publisher.package_variant() )
+configure = env.CMakeConfigure(
+    extraction_folder,
+    working_dir = extraction_folder,
+    source_dir = '.',
+    build_dir = cmake_out,
+    install_prefix = install_prefix,
+    extra_defines = { 'BUILD_TESTING': False },
+)
+built = env.CMakeBuild(
+    configure,
+    build_dir = cmake_out,
+    working_dir = extraction_folder,
+)
+installed = env.CMakeInstall(
+    built,
+    build_dir = cmake_out,
+    working_dir = extraction_folder,
+    target = install_prefix,
+)
+# env.PublishPackage( installed, publisher )
 ----
 
 [NOTE]

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         'cuppa.test_report',
         'cuppa.toolchains',
         'cuppa.variants',
+        'cuppa.buildsys',
         'cuppa.utility',
     ],
     package_data = {

--- a/tests/unit/test_cmake_configure_args.py
+++ b/tests/unit/test_cmake_configure_args.py
@@ -7,7 +7,7 @@ import shlex
 
 import pytest
 
-from cuppa.utility import cmake
+from cuppa.buildsys import cmake
 
 
 pytestmark = pytest.mark.unit

--- a/tests/unit/test_cmake_methods.py
+++ b/tests/unit/test_cmake_methods.py
@@ -1,0 +1,174 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+import shlex
+
+import pytest
+
+import cuppa.progress
+from cuppa.buildsys import cmake
+from cuppa.methods.cmake import (
+        CMakeBuildMethod,
+        CMakeConfigureMethod,
+        CMakeInstallMethod,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def silence_progress( monkeypatch ):
+    monkeypatch.setattr(
+            cuppa.progress.NotifyProgress,
+            'add',
+            classmethod( lambda cls, env, target: None ),
+    )
+
+
+class _FakeToolchain(object):
+    def binary( self ):
+        return '/opt/gcc/bin/g++'
+
+
+class _FakeVariant(object):
+    def __init__( self, name ):
+        self._name = name
+
+    def name( self ):
+        return self._name
+
+
+def _env( variant='dbg', parallel=False, job_count=1, stdcpp=None ):
+    return {
+            'toolchain': _FakeToolchain(),
+            'variant': _FakeVariant( variant ),
+            'stdcpp': stdcpp,
+            'parallel': parallel,
+            'job_count': job_count,
+            'CC': '/opt/gcc/bin/gcc',
+    }
+
+
+class _RecordingEnv(dict):
+    """Minimal env that records ``Command`` / ``Clean`` and accepts NotifyProgress.add."""
+
+    def __init__( self, *args, **kwargs ):
+        dict.__init__( self, *args, **kwargs )
+        self.commands = []
+        self.cleans = []
+
+    def Command( self, target, source, action ):
+        self.commands.append( {
+                'target': target,
+                'source': source,
+                'action': action,
+        } )
+        return [ 'node:{}'.format( target ) ]
+
+    def Clean( self, target, files ):
+        self.cleans.append( ( target, files ) )
+
+
+def test_cmake_build_jobs_default_omits_without_parallel():
+    assert cmake.cmake_build_jobs( _env() ) is None
+    assert cmake.cmake_build_jobs( _env( parallel=True, job_count=1 ) ) is None
+
+
+def test_cmake_build_jobs_honours_parallel():
+    assert cmake.cmake_build_jobs( _env( parallel=True, job_count=8 ) ) == 8
+
+
+def test_cmake_build_jobs_explicit_and_omit():
+    env = _env( parallel=True, job_count=8 )
+    assert cmake.cmake_build_jobs( env, jobs=4 ) == 4
+    assert cmake.cmake_build_jobs( env, jobs=False ) is None
+    assert cmake.cmake_build_jobs( env, jobs=0 ) is None
+
+
+def test_cmake_build_args_and_command():
+    assert cmake.cmake_build_args( '_build/rel', jobs=4 ) == [
+            '--build', '_build/rel',
+            '--parallel', '4',
+    ]
+    assert cmake.cmake_build_args( '_build/rel', target='install' ) == [
+            '--build', '_build/rel',
+            '--target', 'install',
+    ]
+    command = cmake.cmake_build_command( 'out', jobs=2, target='install' )
+    assert shlex.split( command ) == [
+            'cmake', '--build', 'out', '--target', 'install', '--parallel', '2',
+    ]
+
+
+def test_cmake_configure_method_wires_command( silence_progress ):
+    env = _RecordingEnv( _env( 'rel' ) )
+    nodes = CMakeConfigureMethod()(
+            env,
+            'src',
+            working_dir='/tmp/src',
+            build_dir='_build/gcc_rel',
+            generator='Ninja',
+            extra_defines={ 'WIDGET_BUILD_TESTS': False },
+    )
+    assert nodes == [ 'node:cmake.configure.complete' ]
+    assert len( env.commands ) == 1
+    recorded = env.commands[0]
+    assert recorded['target'] == 'cmake.configure.complete'
+    assert recorded['source'] == 'src'
+    action = recorded['action']
+    assert action._working_dir == '/tmp/src'
+    tokens = shlex.split( action._command )
+    assert tokens[0] == 'cmake'
+    assert '-B' in tokens and '_build/gcc_rel' in tokens
+    assert '-G' in tokens and 'Ninja' in tokens
+    assert '-DCMAKE_BUILD_TYPE=Release' in tokens
+    assert '-DWIDGET_BUILD_TESTS=OFF' in tokens
+    assert env.cleans == [
+            ( [ 'node:cmake.configure.complete' ], '/tmp/src/_build/gcc_rel' ),
+    ]
+
+
+def test_cmake_build_method_honours_parallel_jobs( silence_progress ):
+    env = _RecordingEnv( _env( parallel=True, job_count=6 ) )
+    CMakeBuildMethod()(
+            env,
+            'configure',
+            build_dir='_build/x',
+            working_dir='/tmp/src',
+    )
+    action = env.commands[0]['action']
+    assert shlex.split( action._command ) == [
+            'cmake', '--build', '_build/x', '--parallel', '6',
+    ]
+
+
+def test_cmake_build_method_jobs_false_omits_parallel( silence_progress ):
+    env = _RecordingEnv( _env( parallel=True, job_count=6 ) )
+    CMakeBuildMethod()(
+            env,
+            'configure',
+            build_dir='_build/x',
+            working_dir='/tmp/src',
+            jobs=False,
+    )
+    assert shlex.split( env.commands[0]['action']._command ) == [
+            'cmake', '--build', '_build/x',
+    ]
+
+
+def test_cmake_install_method_default_omits_parallel( silence_progress ):
+    env = _RecordingEnv( _env( parallel=True, job_count=6 ) )
+    nodes = CMakeInstallMethod()(
+            env,
+            'built',
+            build_dir='_build/x',
+            working_dir='/tmp/src',
+            target='/tmp/final/installed',
+    )
+    assert nodes == [ 'node:/tmp/final/installed' ]
+    assert shlex.split( env.commands[0]['action']._command ) == [
+            'cmake', '--build', '_build/x', '--target', 'install',
+    ]

--- a/tests/unit/test_parallelism.py
+++ b/tests/unit/test_parallelism.py
@@ -1,0 +1,39 @@
+#          Copyright Jamie Allsop 2026-2026
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+import pytest
+
+from cuppa.utility.parallelism import effective_cpu_count
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_effective_cpu_count_prefers_sched_getaffinity( monkeypatch ):
+    monkeypatch.setattr(
+            'cuppa.utility.parallelism.os.sched_getaffinity',
+            lambda pid: set( range( 14 ) ),
+            raising=False,
+    )
+    assert effective_cpu_count() == 14
+
+
+def test_effective_cpu_count_falls_back_to_multiprocessing( monkeypatch ):
+    def _raise( pid ):
+        raise AttributeError( 'no affinity' )
+
+    monkeypatch.setattr(
+            'cuppa.utility.parallelism.os.sched_getaffinity',
+            _raise,
+            raising=False,
+    )
+    monkeypatch.setattr(
+            'cuppa.utility.parallelism.multiprocessing.cpu_count',
+            lambda: 8,
+    )
+    # Force psutil path to fail so we hit multiprocessing.
+    import sys
+    monkeypatch.setitem( sys.modules, 'psutil', None )
+    assert effective_cpu_count() == 8


### PR DESCRIPTION
## Summary

- Add `env.CMakeConfigure` / `CMakeBuild` / `CMakeInstall` for publisher CMake graphs (Option C), including `Clean` of the CMake `-B` tree and `--parallel` → `cmake --build --parallel N`.
- Move public CMake argv helpers to `cuppa.buildsys.cmake` (room for later `b2`); fix automatic `--parallel` job count to honour process CPU affinity.
- Antora: prefer the methods; teach `Requires(installed_include, installed_lib)` for package staging (not `Depends`).

Stacked on #294 (`feature/cmake-configure-args`).

## Test plan

- [x] `flake8 cuppa` / `pylint -E cuppa`
- [x] `pytest -m unit`
- [x] `pytest -m integration`
- [ ] CI green on the matrix
- [x] Capylike / Corosio smoke: clean removes `-B` tree; rebuild recompiles; jobs=14 under `--parallel`
